### PR TITLE
log schema after its init in FiloRelation

### DIFF
--- a/spark/src/main/scala/filodb.spark/FiloRelation.scala
+++ b/spark/src/main/scala/filodb.spark/FiloRelation.scala
@@ -117,9 +117,9 @@ case class FiloRelation(dataset: String,
 
   val datasetObj = getDatasetObj(dataset)
   val filoSchema = getSchema(dataset, version)
-  logger.info(s"Read schema for dataset $dataset = $schema")
 
   val schema = StructType(columnsToSqlFields(filoSchema.values.toSeq))
+  logger.info(s"Read schema for dataset $dataset = $schema")
 
   def buildScan(): RDD[Row] = buildScan(filoSchema.keys.toArray)
 


### PR DESCRIPTION
A minor fix. 
If we log the `schema` before its init, it's always `null` in logging.