### PR TITLE
Catch UnknownDataset error in truncateDataset op and correclty propag…

### DIFF
--- a/spark/src/main/scala/filodb.spark/package.scala
+++ b/spark/src/main/scala/filodb.spark/package.scala
@@ -144,6 +144,7 @@ package object spark extends StrictLogging {
       actorAsk(FiloSetup.coordinatorActor,
                TruncateProjection(dataset.projections.head, version), 1.minute) {
         case ProjectionTruncated => logger.info(s"Truncation of ${dataset.name} finished")
+        case UnknownDataset => throw NotFoundError(s"(${dataset.name}, ${version}})")
       }
     }
 


### PR DESCRIPTION
When trying to ingest data with the new changes I've got a scala match error over `UnknownDataset`. 
In fact `withDsCood` method sends back a `UnknownDataset` message if the correct dataset and version is not found. Here I catch the message and propagate an `NotFoundError` so that `saveAsFiloDataset` will call `createNewDataset` correctly.