### PR TITLE
Changes made in getScanSplits function

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -170,8 +170,8 @@ extends CachedMergingColumnStore with StrictLogging {
     tokensComplete.map { tokenRange =>
       val replicas = metadata.getReplicas(clusterConnector.keySpace.name, tokenRange).asScala
       Map("token_start" -> tokenRange.getStart.toString,
-        "token_end" -> tokenRange.getEnd.toString,
-        "replicas" -> replicas.map(_.toString).mkString(","))
+          "token_end"   -> tokenRange.getEnd.toString,
+          "replicas"    -> replicas.map(_.toString).mkString(","))
     }
   }
 

--- a/cassandra/src/test/scala/filodb.cassandra/metastore/ColumnTableSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/metastore/ColumnTableSpec.scala
@@ -20,7 +20,7 @@ class ColumnTableSpec extends CassandraFlatSpec with BeforeAndAfter {
   val config = ConfigFactory.load("application_test.conf").getConfig("cassandra")
   val columnTable = new ColumnTable(config)
   implicit val keySpace = KeySpace(config.getString("keyspace"))
-  val timeout = Timeout(50 seconds)
+  val timeout = Timeout(30 seconds)
   // First create the columns table
   override def beforeAll() {
     super.beforeAll()

--- a/cassandra/src/test/scala/filodb.cassandra/metastore/ColumnTableSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/metastore/ColumnTableSpec.scala
@@ -20,7 +20,7 @@ class ColumnTableSpec extends CassandraFlatSpec with BeforeAndAfter {
   val config = ConfigFactory.load("application_test.conf").getConfig("cassandra")
   val columnTable = new ColumnTable(config)
   implicit val keySpace = KeySpace(config.getString("keyspace"))
-  val timeout = Timeout(50 seconds)
+  val timeout = Timeout(10 seconds)
   // First create the columns table
   override def beforeAll() {
     super.beforeAll()

--- a/cassandra/src/test/scala/filodb.cassandra/metastore/ColumnTableSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/metastore/ColumnTableSpec.scala
@@ -20,7 +20,7 @@ class ColumnTableSpec extends CassandraFlatSpec with BeforeAndAfter {
   val config = ConfigFactory.load("application_test.conf").getConfig("cassandra")
   val columnTable = new ColumnTable(config)
   implicit val keySpace = KeySpace(config.getString("keyspace"))
-  val timeout = Timeout(10 seconds)
+  val timeout = Timeout(50 seconds)
   // First create the columns table
   override def beforeAll() {
     super.beforeAll()

--- a/cassandra/src/test/scala/filodb.cassandra/metastore/ColumnTableSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/metastore/ColumnTableSpec.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.ConfigFactory
 import com.websudos.phantom.dsl._
 import com.websudos.phantom.testkit._
 import org.scalatest.BeforeAndAfter
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -19,30 +20,30 @@ class ColumnTableSpec extends CassandraFlatSpec with BeforeAndAfter {
   val config = ConfigFactory.load("application_test.conf").getConfig("cassandra")
   val columnTable = new ColumnTable(config)
   implicit val keySpace = KeySpace(config.getString("keyspace"))
-
+  val timeout = Timeout(50 seconds)
   // First create the columns table
   override def beforeAll() {
     super.beforeAll()
     // Note: This is a CREATE TABLE IF NOT EXISTS
-    columnTable.initialize().futureValue
+    columnTable.initialize().futureValue(timeout)
   }
 
   before {
-    columnTable.clearAll().futureValue
+    columnTable.clearAll().futureValue(timeout)
   }
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
   "ColumnTable" should "return empty schema if a dataset does not exist in columns table" in {
-    columnTable.getSchema("foo", 1).futureValue should equal (Map())
+    columnTable.getSchema("foo", 1).futureValue(timeout) should equal (Map())
   }
 
   it should "add the first column and read it back as a schema" in {
     columnTable.insertColumn(firstColumn).futureValue should equal (Success)
-    columnTable.getSchema("foo", 2).futureValue should equal (Map("first" -> firstColumn))
+    columnTable.getSchema("foo", 2).futureValue(timeout) should equal (Map("first" -> firstColumn))
 
     // Check that limiting the getSchema query to version 0 does not return the version 1 column
-    columnTable.getSchema("foo", 0).futureValue should equal (Map())
+    columnTable.getSchema("foo", 0).futureValue(timeout) should equal (Map())
   }
 
   it should "return MetadataException if illegal column type encoded in Cassandra" in {
@@ -53,6 +54,6 @@ class ColumnTableSpec extends CassandraFlatSpec with BeforeAndAfter {
                               .future()
     f.futureValue
 
-    columnTable.getSchema("bar", 7).failed.futureValue shouldBe a [MetadataException]
+    columnTable.getSchema("bar", 7).failed.futureValue(timeout) shouldBe a [MetadataException]
   }
 }

--- a/cassandra/src/test/scala/filodb.cassandra/metastore/DatasetTableSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/metastore/DatasetTableSpec.scala
@@ -21,17 +21,15 @@ class DatasetTableSpec extends CassandraFlatSpec with BeforeAndAfter {
   override def beforeAll() {
     super.beforeAll()
     // Note: This is a CREATE TABLE IF NOT EXISTS
-    val timeout = Timeout(5000 seconds)
     datasetTable.initialize().futureValue(timeout)
   }
 
   before {
-    val timeout = Timeout(5000 seconds)
     datasetTable.clearAll().futureValue(timeout)
   }
 
   val fooDataset = Dataset("foo", "someSortCol")
-  val timeout = Timeout(5000 seconds)
+  val timeout = Timeout(50 seconds)
   import scala.concurrent.ExecutionContext.Implicits.global
 
   "DatasetTable" should "create a dataset successfully, then return AlreadyExists" in {

--- a/cassandra/src/test/scala/filodb.cassandra/metastore/DatasetTableSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/metastore/DatasetTableSpec.scala
@@ -29,7 +29,7 @@ class DatasetTableSpec extends CassandraFlatSpec with BeforeAndAfter {
   }
 
   val fooDataset = Dataset("foo", "someSortCol")
-  val timeout = Timeout(50 seconds)
+  val timeout = Timeout(10 seconds)
   import scala.concurrent.ExecutionContext.Implicits.global
 
   "DatasetTable" should "create a dataset successfully, then return AlreadyExists" in {

--- a/cassandra/src/test/scala/filodb.cassandra/metastore/DatasetTableSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/metastore/DatasetTableSpec.scala
@@ -29,7 +29,7 @@ class DatasetTableSpec extends CassandraFlatSpec with BeforeAndAfter {
   }
 
   val fooDataset = Dataset("foo", "someSortCol")
-  val timeout = Timeout(10 seconds)
+  val timeout = Timeout(50 seconds)
   import scala.concurrent.ExecutionContext.Implicits.global
 
   "DatasetTable" should "create a dataset successfully, then return AlreadyExists" in {

--- a/cassandra/src/test/scala/filodb.cassandra/metastore/DatasetTableSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/metastore/DatasetTableSpec.scala
@@ -29,7 +29,7 @@ class DatasetTableSpec extends CassandraFlatSpec with BeforeAndAfter {
   }
 
   val fooDataset = Dataset("foo", "someSortCol")
-  val timeout = Timeout(50 seconds)
+  val timeout = Timeout(30 seconds)
   import scala.concurrent.ExecutionContext.Implicits.global
 
   "DatasetTable" should "create a dataset successfully, then return AlreadyExists" in {

--- a/cassandra/src/test/scala/filodb.cassandra/metastore/DatasetTableSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/metastore/DatasetTableSpec.scala
@@ -31,16 +31,16 @@ class DatasetTableSpec extends CassandraFlatSpec with BeforeAndAfter {
   }
 
   val fooDataset = Dataset("foo", "someSortCol")
-
+  val timeout = Timeout(5000 seconds)
   import scala.concurrent.ExecutionContext.Implicits.global
 
   "DatasetTable" should "create a dataset successfully, then return AlreadyExists" in {
-    whenReady(datasetTable.createNewDataset(fooDataset)) { response =>
+    whenReady(datasetTable.createNewDataset(fooDataset),timeout) { response =>
       response should equal (Success)
     }
 
     // Second time around, dataset already exists
-    whenReady(datasetTable.createNewDataset(fooDataset)) { response =>
+    whenReady(datasetTable.createNewDataset(fooDataset),timeout) { response =>
       response should equal (AlreadyExists)
     }
   }
@@ -48,29 +48,29 @@ class DatasetTableSpec extends CassandraFlatSpec with BeforeAndAfter {
   // Apparently, deleting a nonexisting dataset also returns success.  :/
 
   it should "delete a dataset" in {
-    whenReady(datasetTable.createNewDataset(fooDataset)) { response =>
+    whenReady(datasetTable.createNewDataset(fooDataset),timeout) { response =>
       response should equal (Success)
     }
-    whenReady(datasetTable.deleteDataset("foo")) { response =>
+    whenReady(datasetTable.deleteDataset("foo"),timeout) { response =>
       response should equal (Success)
     }
 
-    whenReady(datasetTable.getDataset("foo").failed) { err =>
+    whenReady(datasetTable.getDataset("foo").failed,timeout) { err =>
       err shouldBe a [NotFoundError]
     }
   }
 
   it should "return NotFoundError when trying to get nonexisting dataset" in {
-    whenReady(datasetTable.getDataset("foo").failed) { err =>
+    whenReady(datasetTable.getDataset("foo").failed,timeout) { err =>
       err shouldBe a [NotFoundError]
     }
   }
 
   it should "return the Dataset if it exists" in {
     val barDataset = Dataset("bar", "sortCol")
-    datasetTable.createNewDataset(barDataset).futureValue should equal (Success)
+    datasetTable.createNewDataset(barDataset).futureValue(timeout) should equal (Success)
 
-    whenReady(datasetTable.getDataset("bar")) { dataset =>
+    whenReady(datasetTable.getDataset("bar"),timeout) { dataset =>
       dataset should equal (barDataset)
     }
   }

--- a/cassandra/src/test/scala/filodb.cassandra/metastore/DatasetTableSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/metastore/DatasetTableSpec.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.ConfigFactory
 import com.websudos.phantom.dsl._
 import com.websudos.phantom.testkit._
 import org.scalatest.BeforeAndAfter
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -20,11 +21,13 @@ class DatasetTableSpec extends CassandraFlatSpec with BeforeAndAfter {
   override def beforeAll() {
     super.beforeAll()
     // Note: This is a CREATE TABLE IF NOT EXISTS
-    datasetTable.initialize().futureValue
+    val timeout = Timeout(5000 seconds)
+    datasetTable.initialize().futureValue(timeout)
   }
 
   before {
-    datasetTable.clearAll().futureValue
+    val timeout = Timeout(5000 seconds)
+    datasetTable.clearAll().futureValue(timeout)
   }
 
   val fooDataset = Dataset("foo", "someSortCol")


### PR DESCRIPTION
The getScanSplits function in filodb.cassandra.columnstore.CassandraColumnStore.scala has been changed to ensure that the splits of token ranges per node conforms to the splits_per_node parameter specified. Timeout set in the tests in ColumnTableSpec and DatasetTableSpec.