### PR TITLE
Added support for Cassandra Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Join the chat at https://gitter.im/velvia/FiloDB](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/velvia/FiloDB?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 Distributed.  Columnar.  Versioned.  Streaming.  SQL.
 
+## NOTE: The repo has been relocated to [TupleJump](http://github.com/tuplejump/FiloDB).
+
 ```
     _______ __      ____  ____ 
    / ____(_) /___  / __ \/ __ )

--- a/cassandra/src/main/scala/filodb.cassandra/FiloCassandraConnector.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/FiloCassandraConnector.scala
@@ -1,16 +1,28 @@
 package filodb.cassandra
 
-import com.datastax.driver.core.{Session, VersionNumber}
+import com.datastax.driver.core.{AuthProvider, PlainTextAuthProvider, Session, VersionNumber}
 import com.typesafe.config.Config
 import com.websudos.phantom.connectors.{ContactPoints, KeySpace}
 import net.ceedubs.ficus.Ficus._
 
 trait FiloCassandraConnector {
   private[this] lazy val connector =
-    ContactPoints(config.as[Seq[String]]("hosts"), config.getInt("port")).keySpace(keySpace.name)
+    ContactPoints(config.as[Seq[String]]("hosts"), config.getInt("port"))
+      .withClusterBuilder(_.withAuthProvider(authProvider))
+      .keySpace(keySpace.name)
 
-  // Cassandra config with following keys:  keyspace, hosts, port
+  // Cassandra config with following keys:  keyspace, hosts, port, username, password
   def config: Config
+
+  private[this] lazy val authEnabled = config.hasPath("username") && config.hasPath("password")
+
+  private[this] lazy val authProvider =
+    if (authEnabled) {
+      new PlainTextAuthProvider(config.getString("username"), config.getString("password"))
+    }
+    else {
+      AuthProvider.NONE
+    }
 
   implicit lazy val keySpace = KeySpace(config.getString("keyspace"))
 


### PR DESCRIPTION
This PR adds config keys for username and password to application.conf, as follows:

    cassandra {
        hosts = ["localhost"]
        port = 9042
        keyspace = "filodb"
        username = "cassandra"
        password = "cassandra"
    }

There are two tests that appear to be failing to pick up the auth settings.  After stepping through with the debugger I am unable to determine the root cause of this, as the session in scope always contains the settings.  My real-world tests don't exhibit this behavior, so I'm at a bit of a loss as to where the issue is.