### PR TITLE
InMemoryColumn/MetaStore + perf improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,13 @@ The options to use with the data-source api are:
 | default_partition_key | default value to use for the partition key if the partition_column has a null value.  If not specified, an error is thrown. Note that this only has an effect if the dataset is created for the first time.| write | Yes |
 | version          | numeric version of data to write, defaults to 0  | write | Yes |
 
+### Configuring FiloDB
+
+Some options must be configured before starting the Spark Shell or Spark application.  There are two methods:
+
+1. Modify the `application.conf` and rebuild, or repackage a new configuration.
+2. Override the built in defaults by setting SparkConf configuration values, preceding the filo settings with `spark.filodb`.  For example, to change the keyspace, pass `--conf spark.filodb.cassandra.keyspace=mykeyspace` to Spark Shell/Submit.  To use the fast in-memory column store instead of Cassandra, pass `--conf spark.filodb.store=in-memory`.
+
 ### Spark data-source Example (spark-shell)
 
 You can follow along using the [Spark Notebook](http://github.com/andypetrella/spark-notebook) in doc/FiloDB.snb....  launch the notebook using `EXTRA_CLASSPATH=$FILO_JAR ADD_JARS=$FILO_JAR ./bin/spark-notebook &` where `FILO_JAR` is the path to `filodb-spark-assembly` jar.

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -8,7 +8,7 @@ import spray.caching._
 
 import filodb.cassandra.FiloCassandraConnector
 import filodb.core._
-import filodb.core.columnstore.CachedMergingColumnStore
+import filodb.core.store.CachedMergingColumnStore
 import filodb.core.metadata.{Column, Projection}
 
 /**
@@ -37,7 +37,7 @@ import filodb.core.metadata.{Column, Projection}
 class CassandraColumnStore(config: Config)
                           (implicit val ec: ExecutionContext)
 extends CachedMergingColumnStore with StrictLogging {
-  import filodb.core.columnstore._
+  import filodb.core.store._
   import Types._
   import collection.JavaConverters._
 

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/ChunkTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/ChunkTable.scala
@@ -10,7 +10,7 @@ import scodec.bits._
 
 import filodb.cassandra.FiloCassandraConnector
 import filodb.core._
-import filodb.core.columnstore.ChunkedData
+import filodb.core.store.ChunkedData
 
 /**
  * Represents the table which holds the actual columnar chunks for segments

--- a/cassandra/src/main/scala/filodb.cassandra/metastore/CassandraMetaStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/metastore/CassandraMetaStore.scala
@@ -4,7 +4,8 @@ import com.typesafe.config.Config
 import scala.concurrent.{ExecutionContext, Future}
 
 import filodb.core._
-import filodb.core.metadata.{Column, Dataset, MetaStore}
+import filodb.core.metadata.{Column, Dataset}
+import filodb.core.store.MetaStore
 
 /**
  * A class for Cassandra implementation of the MetaStore.

--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
@@ -1,59 +1,26 @@
 package filodb.cassandra.columnstore
 
-import com.typesafe.config.ConfigFactory
 import com.websudos.phantom.testkit._
-import java.nio.ByteBuffer
-import org.scalatest.BeforeAndAfter
-import org.scalatest.time.{Millis, Seconds, Span}
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
 
 import filodb.core._
 import filodb.core.metadata.{Column, Projection, RichProjection}
+import filodb.core.store.ColumnStoreSpec
 import filodb.core.Types
 
-class CassandraColumnStoreSpec extends CassandraFlatSpec with BeforeAndAfter {
+class CassandraColumnStoreSpec extends CassandraFlatSpec with ColumnStoreSpec {
   import scala.concurrent.ExecutionContext.Implicits.global
   import com.websudos.phantom.dsl._
   import filodb.core.store._
   import SegmentSpec._
 
-  implicit val defaultPatience =
-    PatienceConfig(timeout = Span(10, Seconds), interval = Span(50, Millis))
-
-  val config = ConfigFactory.load("application_test.conf")
   val colStore = new CassandraColumnStore(config)
   implicit val keySpace = KeySpace(config.getString("cassandra.keyspace"))
-  val dataset = "foo"
-  val fooProj = Projection(0, dataset, "someCol")
 
-
-  val (chunkTable, rowMapTable) = Await.result(colStore.getSegmentTables(dataset), 3 seconds)
-
-  // First create the tables in C*
-  override def beforeAll() {
-    super.beforeAll()
-    colStore.initializeProjection(fooProj).futureValue
-  }
-
-  before {
-    colStore.clearProjectionData(fooProj).futureValue
-    colStore.clearSegmentCache()
-  }
-
-  val keyRange = KeyRange(dataset, "partition", 0L, 10000L)
-
-  val bytes1 = ByteBuffer.wrap("apple".getBytes("UTF-8"))
-  val bytes2 = ByteBuffer.wrap("orange".getBytes("UTF-8"))
-
-  val rowIndex = new UpdatableChunkRowMap[Long]
-
-  val baseSegment = new GenericSegment(keyRange, rowIndex)
-  baseSegment.addChunks(0, Map("columnA" -> bytes1, "columnB" -> bytes2))
-  baseSegment.addChunks(1, Map("columnA" -> bytes1, "columnB" -> bytes2))
-  rowIndex.index = rowIndex.index ++
-                     Map(500L -> (0 -> 0), 1000L -> (1 -> 0), 600L -> (0 -> 1), 700L -> (0 -> 2))
+  val (chunkTable, rowMapTable) =
+    Await.result(colStore.asInstanceOf[CassandraColumnStore].getSegmentTables(dataset), 3 seconds)
 
   private def getChunkRowMap[K](segment: Segment[K]): Future[BinaryChunkRowMap] =
     rowMapTable.getChunkMaps(segment.partition, 0, segment.segmentId, segment.keyRange.binaryEnd).
@@ -80,123 +47,6 @@ class CassandraColumnStoreSpec extends CassandraFlatSpec with BeforeAndAfter {
     whenReady(getChunkRowMap(baseSegment)) { binRowMap =>
       binRowMap.chunkIdIterator.toSeq should equal (Seq(0, 0, 0, 1))
       binRowMap.rowNumIterator.toSeq should equal (Seq(0, 1, 2, 0))
-    }
-  }
-
-  it should "NOOP if the segment is empty" in {
-    val segment = getRowWriter(keyRange)
-    whenReady(colStore.appendSegment(projection, segment, 0)) { response =>
-      response should equal (NotApplied)
-    }
-  }
-
-  it should "append new rows to a cached segment successfully" in {
-    val segment = getRowWriter(keyRange)
-    segment.addRowsAsChunk(mapper(names take 3), getSortKey _)
-    whenReady(colStore.appendSegment(projection, segment, 0)) { response =>
-      response should equal (Success)
-    }
-
-    // Writing segment2, last 3 rows, should get appended to first 3 in same segment
-    val segment2 = getRowWriter(keyRange)
-    segment2.addRowsAsChunk(mapper(names drop 3), getSortKey _)
-    whenReady(colStore.appendSegment(projection, segment2, 0)) { response =>
-      response should equal (Success)
-    }
-
-    whenReady(colStore.readSegments(schema, keyRange, 0)) { segIter =>
-      val segments = segIter.toSeq
-      segments should have length (1)
-      val readSeg = segments.head.asInstanceOf[RowReaderSegment[Long]]
-      readSeg.keyRange.start should equal (segment.keyRange.start)
-      readSeg.rowIterator().map(_.getLong(2)).toSeq should equal (Seq(24L, 25L, 28L, 29L, 39L, 40L))
-      readSeg.rowIterator().map(_.getString(0)).toSeq should equal (firstNames)
-    }
-  }
-
-  it should "replace rows to an uncached segment successfully" in {
-    val segment = getRowWriter(keyRange)
-    segment.addRowsAsChunk(mapper(names drop 1), getSortKey _)
-    whenReady(colStore.appendSegment(projection, segment, 0)) { response =>
-      response should equal (Success)
-    }
-
-    colStore.clearSegmentCache()
-
-    // Writing segment2, repeat 1 row and add another row.  Should read orig segment from disk.
-    val segment2 = getRowWriter(keyRange)
-    segment2.addRowsAsChunk(mapper(names take 2), getSortKey _)
-    whenReady(colStore.appendSegment(projection, segment2, 0)) { response =>
-      response should equal (Success)
-    }
-
-    whenReady(colStore.readSegments(schema, keyRange, 0)) { segIter =>
-      val segments = segIter.toSeq
-      segments should have length (1)
-      val readSeg = segments.head.asInstanceOf[RowReaderSegment[Long]]
-      readSeg.keyRange.start should equal (segment.keyRange.start)
-      readSeg.rowIterator().map(_.getLong(2)).toSeq should equal (Seq(24L, 25L, 28L, 29L, 39L, 40L))
-      readSeg.rowIterator().map(_.getString(0)).toSeq should equal (firstNames)
-    }
-  }
-
-  "readSegments" should "read segments back that were written" in {
-    val segment = getRowWriter(keyRange)
-    segment.addRowsAsChunk(mapper(names), getSortKey _)
-    whenReady(colStore.appendSegment(projection, segment, 0)) { response =>
-      response should equal (Success)
-    }
-
-    whenReady(colStore.readSegments(schema, keyRange, 0)) { segIter =>
-      val segments = segIter.toSeq
-      segments should have length (1)
-      val readSeg = segments.head.asInstanceOf[RowReaderSegment[Long]]
-      readSeg.keyRange.start should equal (segment.keyRange.start)
-      readSeg.getChunks.toSet should equal (segment.getChunks.toSet)
-      readSeg.index.rowNumIterator.toSeq should equal (segment.index.rowNumIterator.toSeq)
-      readSeg.rowIterator().map(_.getLong(2)).toSeq should equal (Seq(24L, 25L, 28L, 29L, 39L, 40L))
-    }
-  }
-
-  it should "return empty iterator if cannot find segment" in {
-    whenReady(colStore.readSegments(schema, keyRange, 0)) { segIter =>
-      segIter.toSeq should have length (0)
-    }
-  }
-
-  it should "return empty iterator if cannot find partition or version" in (pending)
-
-  it should "return segment with empty chunks if cannot find columns" in {
-    whenReady(colStore.appendSegment(projection, baseSegment, 0)) { response =>
-      response should equal (Success)
-    }
-
-    val fakeCol = Column("notACol", dataset, 0, Column.ColumnType.StringColumn)
-    whenReady(colStore.readSegments(Seq(fakeCol), keyRange, 0)) { segIter =>
-      val segments = segIter.toSeq
-      segments should have length (1)
-      segments.head.getChunks.toSet should equal (Set(("notACol", 0, null), ("notACol", 1, null)))
-    }
-  }
-
-  "scanSegments" should "read segments back that were written" in {
-    val segment = getRowWriter(keyRange)
-    segment.addRowsAsChunk(mapper(names), getSortKey _)
-    whenReady(colStore.appendSegment(projection, segment, 0)) { response =>
-      response should equal (Success)
-    }
-
-    val paramSet = colStore.getScanSplits(dataset)
-    paramSet should have length (1)
-
-    whenReady(colStore.scanSegments[Long](schema, dataset, 0, params = paramSet.head)) { segIter =>
-      val segments = segIter.toSeq
-      segments should have length (1)
-      val readSeg = segments.head.asInstanceOf[RowReaderSegment[Long]]
-      readSeg.keyRange.start should equal (segment.keyRange.start)
-      readSeg.getChunks.toSet should equal (segment.getChunks.toSet)
-      readSeg.index.rowNumIterator.toSeq should equal (segment.index.rowNumIterator.toSeq)
-      readSeg.rowIterator().map(_.getLong(2)).toSeq should equal (Seq(24L, 25L, 28L, 29L, 39L, 40L))
     }
   }
 

--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
@@ -16,7 +16,7 @@ import filodb.core.Types
 class CassandraColumnStoreSpec extends CassandraFlatSpec with BeforeAndAfter {
   import scala.concurrent.ExecutionContext.Implicits.global
   import com.websudos.phantom.dsl._
-  import filodb.core.columnstore._
+  import filodb.core.store._
   import SegmentSpec._
 
   implicit val defaultPatience =

--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/CassandraColumnStoreSpec.scala
@@ -20,7 +20,7 @@ class CassandraColumnStoreSpec extends CassandraFlatSpec with ColumnStoreSpec {
   implicit val keySpace = KeySpace(config.getString("cassandra.keyspace"))
 
   val (chunkTable, rowMapTable) =
-    Await.result(colStore.asInstanceOf[CassandraColumnStore].getSegmentTables(dataset), 3 seconds)
+    Await.result(colStore.asInstanceOf[CassandraColumnStore].getSegmentTables(dataset.name), 3 seconds)
 
   private def getChunkRowMap[K](segment: Segment[K]): Future[BinaryChunkRowMap] =
     rowMapTable.getChunkMaps(segment.partition, 0, segment.segmentId, segment.keyRange.binaryEnd).
@@ -52,13 +52,13 @@ class CassandraColumnStoreSpec extends CassandraFlatSpec with ColumnStoreSpec {
 
   "getScanSplits" should "return splits from Cassandra" in {
     // Single split, token_start should equal token_end
-    val singleSplit = colStore.getScanSplits(dataset)
+    val singleSplit = colStore.getScanSplits(dataset.name)
     singleSplit should have length (1)
     singleSplit.head("token_start") should equal (singleSplit.head("token_end"))
     singleSplit.head("replicas").split(",").size should equal (1)
 
     // Multiple splits.  Each split token start/end should not equal each other.
-    val multiSplit = colStore.getScanSplits(dataset, Map("splits_per_node" -> "2"))
+    val multiSplit = colStore.getScanSplits(dataset.name, Map("splits_per_node" -> "2"))
     multiSplit should have length (2)
     multiSplit.foreach { split =>
       split("token_start") should not equal (split("token_end"))

--- a/cassandra/src/test/scala/filodb.cassandra/metastore/CassandraMetaStoreSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/metastore/CassandraMetaStoreSpec.scala
@@ -5,7 +5,8 @@ import java.nio.ByteBuffer
 import scala.concurrent.Future
 
 import filodb.core._
-import filodb.core.metadata.{Column, Dataset, MetaStore}
+import filodb.core.metadata.{Column, Dataset}
+import filodb.core.store.MetaStore
 import filodb.cassandra.AllTablesTest
 
 import org.scalatest.{FunSpec, BeforeAndAfter}

--- a/cassandra/src/test/scala/filodb.cassandra/metastore/CassandraMetaStoreSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/metastore/CassandraMetaStoreSpec.scala
@@ -1,43 +1,12 @@
 package filodb.cassandra.metastore
 
-import com.typesafe.config.ConfigFactory
-import java.nio.ByteBuffer
 import scala.concurrent.Future
 
 import filodb.core._
 import filodb.core.metadata.{Column, Dataset}
-import filodb.core.store.MetaStore
+import filodb.core.store.MetaStoreSpec
 import filodb.cassandra.AllTablesTest
 
 import org.scalatest.{FunSpec, BeforeAndAfter}
 
-class CassandraMetaStoreSpec extends FunSpec with BeforeAndAfter with AllTablesTest {
-  import MetaStore._
-
-  override def beforeAll() {
-    super.beforeAll()
-    metaStore.initialize().futureValue
-  }
-
-  before { metaStore.clearAllData().futureValue }
-
-  describe("column API") {
-    it("should return IllegalColumnChange if an invalid column addition submitted") {
-      val firstColumn = Column("first", "foo", 1, Column.ColumnType.StringColumn)
-      whenReady(metaStore.newColumn(firstColumn)) { response =>
-        response should equal (Success)
-      }
-
-      whenReady(metaStore.newColumn(firstColumn.copy(version = 0)).failed) { err =>
-        err shouldBe an [IllegalColumnChange]
-      }
-    }
-
-    val monthYearCol = Column("monthYear", "gdelt", 1, Column.ColumnType.LongColumn)
-    it("should be able to create a Column and get the Schema") {
-      metaStore.newColumn(monthYearCol).futureValue should equal (Success)
-      metaStore.getSchema("gdelt", 10).futureValue should equal (Map("monthYear" -> monthYearCol))
-    }
-  }
-
-}
+class CassandraMetaStoreSpec extends MetaStoreSpec with AllTablesTest

--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -8,7 +8,7 @@ import com.opencsv.CSVWriter
 import com.quantifind.sumac.{ArgMain, FieldArgs}
 import com.typesafe.config.ConfigFactory
 import filodb.core.SortKeyHelper
-import filodb.core.columnstore.RowReaderSegment
+import filodb.core.store.RowReaderSegment
 import filodb.core.metadata.Column.{ColumnType, Schema}
 import org.velvia.filo.{RowReader, FastFiloRowReader}
 import scala.concurrent.Await
@@ -18,7 +18,7 @@ import scala.language.postfixOps
 import filodb.cassandra.columnstore.CassandraColumnStore
 import filodb.cassandra.metastore.CassandraMetaStore
 import filodb.coordinator.{NodeCoordinatorActor, DefaultCoordinatorSetup}
-import filodb.core.columnstore.{Analyzer, CachedMergingColumnStore}
+import filodb.core.store.{Analyzer, CachedMergingColumnStore}
 import filodb.core.metadata.{Column, Dataset, RichProjection}
 
 //scalastyle:off

--- a/cli/src/main/scala/filodb.cli/CliMain.scala
+++ b/cli/src/main/scala/filodb.cli/CliMain.scala
@@ -17,7 +17,7 @@ import scala.language.postfixOps
 
 import filodb.cassandra.columnstore.CassandraColumnStore
 import filodb.cassandra.metastore.CassandraMetaStore
-import filodb.coordinator.{NodeCoordinatorActor, DefaultCoordinatorSetup}
+import filodb.coordinator.{NodeCoordinatorActor, CoordinatorSetup}
 import filodb.core.store.{Analyzer, CachedMergingColumnStore}
 import filodb.core.metadata.{Column, Dataset, RichProjection}
 
@@ -53,7 +53,7 @@ class Arguments extends FieldArgs {
 
 case class UnsupportedSortKeyException(columnType: ColumnType) extends Exception(s"Sort on $columnType is not Supported.")
 
-object CliMain extends ArgMain[Arguments] with CsvImportExport with DefaultCoordinatorSetup {
+object CliMain extends ArgMain[Arguments] with CsvImportExport with CoordinatorSetup {
 
   val system = ActorSystem("filo-cli")
   val config = ConfigFactory.load

--- a/cli/src/main/scala/filodb.cli/CsvImportExport.scala
+++ b/cli/src/main/scala/filodb.cli/CsvImportExport.scala
@@ -10,7 +10,7 @@ import scala.concurrent.{Await, Future, ExecutionContext}
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-import filodb.core.metadata.MetaStore
+import filodb.core.store.MetaStore
 import filodb.coordinator.{NodeCoordinatorActor, DatasetCoordinatorActor, RowSource}
 import filodb.coordinator.sources.CsvSourceActor
 import filodb.core._

--- a/coordinator/src/main/scala/filodb.coordinator/CoordinatorSetup.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/CoordinatorSetup.scala
@@ -36,8 +36,3 @@ trait CoordinatorSetup {
     metaStore.shutdown()
   }
 }
-
-/**
- * A CoordinatorSetup with default memtable initialized from config
- */
-trait DefaultCoordinatorSetup extends CoordinatorSetup

--- a/coordinator/src/main/scala/filodb.coordinator/CoordinatorSetup.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/CoordinatorSetup.scala
@@ -3,7 +3,7 @@ package filodb.coordinator
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 
-import filodb.core.columnstore.ColumnStore
+import filodb.core.store.ColumnStore
 import filodb.core.FutureUtils
 import filodb.core.metadata.MetaStore
 import filodb.core.reprojector._

--- a/coordinator/src/main/scala/filodb.coordinator/CoordinatorSetup.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/CoordinatorSetup.scala
@@ -3,9 +3,8 @@ package filodb.coordinator
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 
-import filodb.core.store.ColumnStore
+import filodb.core.store.{ColumnStore, MetaStore}
 import filodb.core.FutureUtils
-import filodb.core.metadata.MetaStore
 import filodb.core.reprojector._
 
 /**

--- a/coordinator/src/main/scala/filodb.coordinator/DatasetCoordinatorActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/DatasetCoordinatorActor.scala
@@ -7,7 +7,7 @@ import org.velvia.filo.RowReader
 import scala.concurrent.Future
 
 import filodb.core.metadata.{Column, Dataset, Projection, RichProjection}
-import filodb.core.columnstore.ColumnStore
+import filodb.core.store.ColumnStore
 import filodb.core.reprojector.{MemTable, FiloMemTable, Reprojector}
 
 object DatasetCoordinatorActor {

--- a/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 import filodb.core._
 import filodb.core.Types._
 import filodb.core.metadata.{Column, Dataset, MetaStore, Projection, RichProjection}
-import filodb.core.columnstore.ColumnStore
+import filodb.core.store.ColumnStore
 import filodb.core.reprojector.Reprojector
 
 /**

--- a/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/NodeCoordinatorActor.scala
@@ -9,8 +9,8 @@ import scala.concurrent.duration._
 
 import filodb.core._
 import filodb.core.Types._
-import filodb.core.metadata.{Column, Dataset, MetaStore, Projection, RichProjection}
-import filodb.core.store.ColumnStore
+import filodb.core.metadata.{Column, Dataset, Projection, RichProjection}
+import filodb.core.store.{ColumnStore, MetaStore}
 import filodb.core.reprojector.Reprojector
 
 /**

--- a/coordinator/src/test/scala/filodb.coordinator/DatasetCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/DatasetCoordinatorActorSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 
 import filodb.core._
 import filodb.core.metadata.{Column, Dataset, RichProjection}
-import filodb.core.columnstore.{InMemoryColumnStore, SegmentSpec}
+import filodb.core.store.{InMemoryColumnStore, SegmentSpec}
 import filodb.core.reprojector.{DefaultReprojector, MemTable, Reprojector}
 
 import org.scalatest.concurrent.ScalaFutures
@@ -75,7 +75,7 @@ with ScalaFutures {
   }
 
   val testReprojector = new Reprojector {
-    import filodb.core.columnstore.Segment
+    import filodb.core.store.Segment
 
     def reproject[K](memTable: MemTable[K], version: Int): Future[Seq[String]] = {
       reprojections = reprojections :+ (memTable.projection.dataset.name -> version)

--- a/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/NodeCoordinatorActorSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import filodb.core._
-import filodb.core.columnstore.{RowReaderSegment, SegmentSpec}
+import filodb.core.store.{RowReaderSegment, SegmentSpec}
 import filodb.core.metadata.{Column, Dataset}
 import filodb.cassandra.AllTablesTest
 

--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -5,6 +5,11 @@
     keyspace = "filodb"
   }
 
+  # Which column and metaStore to use, ie where to persist columnar chunks.
+  # Valid values are "cassandra", "in-memory"
+  # Only the filodb-spark library pays attention to this, not the CLI.
+  store = "cassandra"
+
   columnstore {
     # Number of cache entries for the table cache
     tablecache-size = 50

--- a/core/src/main/scala/filodb.core/Types.scala
+++ b/core/src/main/scala/filodb.core/Types.scala
@@ -6,7 +6,7 @@ import scodec.bits.ByteVector
 
 /**
  * Temporary home for new FiloDB API definitions, including column store and memtable etc.
- * Perhaps they should be moved into filodb.core.columnstore and filodb.core.reprojector
+ * Perhaps they should be moved into filodb.core.store and filodb.core.reprojector
  *
  * NOT included: the MetadataStore, which contains column, partition, version definitions
  */

--- a/core/src/main/scala/filodb.core/reprojector/FiloMemTable.scala
+++ b/core/src/main/scala/filodb.core/reprojector/FiloMemTable.scala
@@ -13,7 +13,7 @@ import scalaxy.loops._
 
 import filodb.core.{KeyRange, SortKeyHelper}
 import filodb.core.Types._
-import filodb.core.columnstore.{RowWriterSegment, Segment}
+import filodb.core.store.{RowWriterSegment, Segment}
 import filodb.core.metadata.{Column, Dataset, RichProjection}
 
 /**

--- a/core/src/main/scala/filodb.core/reprojector/Reprojector.scala
+++ b/core/src/main/scala/filodb.core/reprojector/Reprojector.scala
@@ -5,7 +5,7 @@ import org.velvia.filo.RowReader
 import scala.concurrent.{ExecutionContext, Future}
 
 import filodb.core._
-import filodb.core.columnstore.{ColumnStore, RowWriterSegment, Segment}
+import filodb.core.store.{ColumnStore, RowWriterSegment, Segment}
 import filodb.core.metadata.{Dataset, Column, RichProjection}
 
 /**

--- a/core/src/main/scala/filodb.core/store/Analyzer.scala
+++ b/core/src/main/scala/filodb.core/store/Analyzer.scala
@@ -1,4 +1,4 @@
-package filodb.core.columnstore
+package filodb.core.store
 
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._

--- a/core/src/main/scala/filodb.core/store/ChunkMergingStrategy.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkMergingStrategy.scala
@@ -1,4 +1,4 @@
-package filodb.core.columnstore
+package filodb.core.store
 
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import java.nio.ByteBuffer

--- a/core/src/main/scala/filodb.core/store/ChunkRowMap.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkRowMap.scala
@@ -1,4 +1,4 @@
-package filodb.core.columnstore
+package filodb.core.store
 
 import org.velvia.filo.{FiloVector, VectorBuilder, VectorReader}
 import java.nio.ByteBuffer

--- a/core/src/main/scala/filodb.core/store/ColumnStore.scala
+++ b/core/src/main/scala/filodb.core/store/ColumnStore.scala
@@ -1,4 +1,4 @@
-package filodb.core.columnstore
+package filodb.core.store
 
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import java.nio.ByteBuffer

--- a/core/src/main/scala/filodb.core/store/InMemoryColumnStore.scala
+++ b/core/src/main/scala/filodb.core/store/InMemoryColumnStore.scala
@@ -14,6 +14,10 @@ import filodb.core.metadata.{Column, Projection}
 /**
  * A ColumnStore implementation which is entirely in memory for speed.
  * Good for testing or performance.
+ *
+ * NOTE: This implementation effectively only works on a single node.
+ * We would need, for example, a Spark-specific implementation which can
+ * know how to distribute data, or at least keep track of different nodes,
  * TODO: use thread-safe structures
  */
 class InMemoryColumnStore(implicit val ec: ExecutionContext)

--- a/core/src/main/scala/filodb.core/store/InMemoryColumnStore.scala
+++ b/core/src/main/scala/filodb.core/store/InMemoryColumnStore.scala
@@ -111,9 +111,9 @@ extends CachedMergingColumnStore with StrictLogging {
                        version: Int,
                        partitionFilter: (PartitionKey => Boolean),
                        params: Map[String, String]): Future[Iterator[ChunkMapInfo]] = Future {
-    val parts = rowMaps.keys.filter { case (ds, partition, ver) =>
+    val parts = rowMaps.keysIterator.filter { case (ds, partition, ver) =>
       ds == dataset && ver == version && partitionFilter(partition) }
-    val maps = parts.toIterator.flatMap { case key @ (_, partition, _) =>
+    val maps = parts.flatMap { case key @ (_, partition, _) =>
                  rowMaps(key).entrySet.iterator.map { entry =>
                    val segId = entry.getKey
                    val (chunkIds, rowNums, nextChunkId) = entry.getValue

--- a/core/src/main/scala/filodb.core/store/InMemoryColumnStore.scala
+++ b/core/src/main/scala/filodb.core/store/InMemoryColumnStore.scala
@@ -1,4 +1,4 @@
-package filodb.core.columnstore
+package filodb.core.store
 
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import java.nio.ByteBuffer

--- a/core/src/main/scala/filodb.core/store/InMemoryColumnStore.scala
+++ b/core/src/main/scala/filodb.core/store/InMemoryColumnStore.scala
@@ -25,6 +25,8 @@ extends CachedMergingColumnStore with StrictLogging {
   import Types._
   import collection.JavaConversions._
 
+  logger.info("Starting InMemoryColumnStore...")
+
   val segmentCache = LruCache[Segment[_]](100)
 
   val mergingStrategy = new AppendingChunkMergingStrategy(this)

--- a/core/src/main/scala/filodb.core/store/InMemoryMetaStore.scala
+++ b/core/src/main/scala/filodb.core/store/InMemoryMetaStore.scala
@@ -1,0 +1,83 @@
+package filodb.core.store
+
+import com.typesafe.scalalogging.slf4j.StrictLogging
+import java.util.TreeMap
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.{ExecutionContext, Future}
+
+import filodb.core._
+import filodb.core.metadata.{Column, Dataset}
+
+/**
+ * An in-memory MetaStore.  Does not aim to keep data distributed, but is just a
+ * single-node implementation, which works for example in the Spark driver since
+ * the MetaStore is only called by the driver code and not by workers.
+ */
+class InMemoryMetaStore(implicit val ec: ExecutionContext) extends MetaStore with StrictLogging {
+  import collection.JavaConverters._
+
+  val datasets = new TrieMap[String, Dataset]
+  type ColumnMap = TreeMap[(Int, Types.ColumnId), Column]
+  val colMapOrdering = math.Ordering[(Int, Types.ColumnId)]
+  val columns = new TrieMap[String, ColumnMap]
+
+  def initialize(): Future[Response] = Future.successful(Success)
+
+  def clearAllData(): Future[Response] = Future {
+    datasets.clear()
+    columns.clear()
+    Success
+  }
+
+  /**
+   * ** Dataset API ***
+   */
+
+  def newDataset(dataset: Dataset): Future[Response] = {
+    if (dataset.projections.isEmpty) {
+      Future.failed(MetadataException(new IllegalArgumentException(s"Dataset $dataset has no projections")))
+    } else {
+      datasets.putIfAbsent(dataset.name, dataset) match {
+        case None    => Future.successful(Success)
+        case Some(x) =>
+          logger.info(s"Ignoring newDataset($dataset); entry already exists")
+          Future.successful(AlreadyExists)
+      }
+    }
+  }
+
+  def getDataset(name: String): Future[Dataset] =
+    datasets.get(name).map(Future.successful)
+            .getOrElse(Future.failed(NotFoundError(name)))
+
+  def deleteDataset(name: String): Future[Response] = Future {
+    datasets.remove(name)
+    columns.remove(name)
+    Success
+  }
+
+  /**
+   * ** Column API ***
+   */
+
+  def insertColumn(column: Column): Future[Response] = {
+    val columnMap = columns.getOrElseUpdate(column.dataset, new ColumnMap(colMapOrdering))
+    if (columnMap.containsKey((column.version, column.name))) {
+      Future.successful(NotApplied)
+    } else {
+      columnMap.put((column.version, column.name), column)
+      Future.successful(Success)
+    }
+  }
+
+  def getSchema(dataset: String, version: Int): Future[Column.Schema] = Future {
+    columns.get(dataset).map { columnMap =>
+      columnMap.entrySet.asScala
+               .takeWhile(_.getKey()._1 <= version)
+               .map(_.getValue)
+               .foldLeft(Column.EmptySchema)(Column.schemaFold)
+    }.getOrElse(Column.EmptySchema)
+  }
+
+  def shutdown(): Unit = {}
+}

--- a/core/src/main/scala/filodb.core/store/InMemoryMetaStore.scala
+++ b/core/src/main/scala/filodb.core/store/InMemoryMetaStore.scala
@@ -16,6 +16,8 @@ import filodb.core.metadata.{Column, Dataset}
 class InMemoryMetaStore(implicit val ec: ExecutionContext) extends MetaStore with StrictLogging {
   import collection.JavaConverters._
 
+  logger.info("Starting InMemoryMetaStore...")
+
   val datasets = new TrieMap[String, Dataset]
   type ColumnMap = TreeMap[(Int, Types.ColumnId), Column]
   val colMapOrdering = math.Ordering[(Int, Types.ColumnId)]
@@ -24,6 +26,7 @@ class InMemoryMetaStore(implicit val ec: ExecutionContext) extends MetaStore wit
   def initialize(): Future[Response] = Future.successful(Success)
 
   def clearAllData(): Future[Response] = Future {
+    logger.warn("Clearing all data!")
     datasets.clear()
     columns.clear()
     Success

--- a/core/src/main/scala/filodb.core/store/MetaStore.scala
+++ b/core/src/main/scala/filodb.core/store/MetaStore.scala
@@ -1,8 +1,9 @@
-package filodb.core.metadata
+package filodb.core.store
 
 import scala.concurrent.{ExecutionContext, Future}
 
 import filodb.core._
+import filodb.core.metadata.{Column, Dataset}
 
 object MetaStore {
   case class IllegalColumnChange(reasons: Seq[String]) extends Exception {

--- a/core/src/main/scala/filodb.core/store/Segment.scala
+++ b/core/src/main/scala/filodb.core/store/Segment.scala
@@ -169,13 +169,13 @@ class RowReaderSegment[K](val keyRange: KeyRange[K],
       new Iterator[RowReader] {
         var curChunk = 0
         var curReader = readers(curChunk)
-        val len = index.chunkIds.length
-        var i = 0
+        private final val len = index.chunkIds.length
+        private var i = 0
 
         // NOTE: manually iterate over the chunkIds / rowNums FiloVectors, instead of using the
         // iterator methods, which are extremely slow and boxes everything
-        def hasNext: Boolean = i < len
-        def next: RowReader = {
+        final def hasNext: Boolean = i < len
+        final def next: RowReader = {
           val nextChunk = index.chunkIds(i)
           if (nextChunk != curChunk) {
             curChunk = nextChunk

--- a/core/src/main/scala/filodb.core/store/Segment.scala
+++ b/core/src/main/scala/filodb.core/store/Segment.scala
@@ -214,7 +214,7 @@ class RowReaderSegment[K](val keyRange: KeyRange[K],
 object RowReaderSegment {
   type RowReaderFactory = (Array[ByteBuffer], Array[Class[_]]) => FiloRowReader
 
-  private val DefaultReaderFactory: RowReaderFactory =
+  val DefaultReaderFactory: RowReaderFactory =
     (bytes, clazzes) => new FastFiloRowReader(bytes, clazzes)
 
   def apply[K](genSeg: GenericSegment[K], schema: Seq[Column]): RowReaderSegment[K] = {

--- a/core/src/main/scala/filodb.core/store/Segment.scala
+++ b/core/src/main/scala/filodb.core/store/Segment.scala
@@ -1,4 +1,4 @@
-package filodb.core.columnstore
+package filodb.core.store
 
 import com.typesafe.scalalogging.slf4j.StrictLogging
 import java.nio.ByteBuffer

--- a/core/src/test/scala/filodb.core/metadata/DatasetSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/DatasetSpec.scala
@@ -2,7 +2,7 @@ package filodb.core.metadata
 
 import org.velvia.filo.TupleRowReader
 
-import filodb.core.columnstore.SegmentSpec
+import filodb.core.store.SegmentSpec
 
 import org.scalatest.{FunSpec, Matchers, BeforeAndAfter}
 

--- a/core/src/test/scala/filodb.core/metadata/ProjectionSpec.scala
+++ b/core/src/test/scala/filodb.core/metadata/ProjectionSpec.scala
@@ -2,7 +2,7 @@ package filodb.core.metadata
 
 import org.velvia.filo.TupleRowReader
 
-import filodb.core.columnstore.SegmentSpec
+import filodb.core.store.SegmentSpec
 import org.scalatest.{FunSpec, Matchers, BeforeAndAfter}
 
 class ProjectionSpec extends FunSpec with Matchers {

--- a/core/src/test/scala/filodb.core/reprojector/FiloMemTableSpec.scala
+++ b/core/src/test/scala/filodb.core/reprojector/FiloMemTableSpec.scala
@@ -5,7 +5,7 @@ import org.velvia.filo.TupleRowReader
 
 import filodb.core.KeyRange
 import filodb.core.metadata.{Column, Dataset, RichProjection}
-import filodb.core.columnstore.SegmentSpec
+import filodb.core.store.SegmentSpec
 
 import org.scalatest.{FunSpec, Matchers, BeforeAndAfter}
 

--- a/core/src/test/scala/filodb.core/reprojector/MapDBMemTableSpec.scala
+++ b/core/src/test/scala/filodb.core/reprojector/MapDBMemTableSpec.scala
@@ -5,7 +5,7 @@ import org.velvia.filo.TupleRowReader
 
 import filodb.core.KeyRange
 import filodb.core.metadata.{Column, Dataset, RichProjection}
-import filodb.core.columnstore.SegmentSpec
+import filodb.core.store.SegmentSpec
 import scala.concurrent.Future
 
 import org.scalatest.{FunSpec, Matchers, BeforeAndAfter}

--- a/core/src/test/scala/filodb.core/reprojector/MemTableMemoryTest.scala
+++ b/core/src/test/scala/filodb.core/reprojector/MemTableMemoryTest.scala
@@ -5,7 +5,7 @@ import org.velvia.filo.TupleRowReader
 
 import filodb.core.KeyRange
 import filodb.core.metadata.{Column, Dataset}
-import filodb.core.columnstore.SegmentSpec
+import filodb.core.store.SegmentSpec
 
 import org.scalatest.{FunSpec, Matchers, BeforeAndAfter}
 

--- a/core/src/test/scala/filodb.core/store/ChunkMergingStrategySpec.scala
+++ b/core/src/test/scala/filodb.core/store/ChunkMergingStrategySpec.scala
@@ -1,4 +1,4 @@
-package filodb.core.columnstore
+package filodb.core.store
 
 import com.typesafe.config.ConfigFactory
 import filodb.core._

--- a/core/src/test/scala/filodb.core/store/ChunkRowMapSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ChunkRowMapSpec.scala
@@ -1,4 +1,4 @@
-package filodb.core.columnstore
+package filodb.core.store
 
 import filodb.core._
 import java.nio.ByteBuffer

--- a/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/store/ColumnStoreSpec.scala
@@ -1,0 +1,173 @@
+package filodb.core.store
+
+import com.typesafe.config.ConfigFactory
+import java.nio.ByteBuffer
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+import scala.language.postfixOps
+
+import filodb.core._
+import filodb.core.metadata.{Column, Projection, RichProjection}
+import filodb.core.Types
+
+import org.scalatest.{FlatSpec, Matchers, BeforeAndAfter, BeforeAndAfterAll}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
+
+trait ColumnStoreSpec extends FlatSpec with Matchers
+with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
+  import scala.concurrent.ExecutionContext.Implicits.global
+  import SegmentSpec._
+
+  implicit val defaultPatience =
+    PatienceConfig(timeout = Span(10, Seconds), interval = Span(50, Millis))
+
+  val config = ConfigFactory.load("application_test.conf")
+  def colStore: CachedMergingColumnStore
+
+  val dataset = "foo"
+  val fooProj = Projection(0, dataset, "someCol")
+
+  // First create the tables in C*
+  override def beforeAll() {
+    super.beforeAll()
+    colStore.initializeProjection(fooProj).futureValue
+  }
+
+  before {
+    colStore.clearProjectionData(fooProj).futureValue
+    colStore.clearSegmentCache()
+  }
+
+  val keyRange = KeyRange(dataset, "partition", 0L, 10000L)
+
+  val bytes1 = ByteBuffer.wrap("apple".getBytes("UTF-8"))
+  val bytes2 = ByteBuffer.wrap("orange".getBytes("UTF-8"))
+
+  val rowIndex = new UpdatableChunkRowMap[Long]
+
+  val baseSegment = new GenericSegment(keyRange, rowIndex)
+  baseSegment.addChunks(0, Map("columnA" -> bytes1, "columnB" -> bytes2))
+  baseSegment.addChunks(1, Map("columnA" -> bytes1, "columnB" -> bytes2))
+  rowIndex.index = rowIndex.index ++
+                     Map(500L -> (0 -> 0), 1000L -> (1 -> 0), 600L -> (0 -> 1), 700L -> (0 -> 2))
+
+  // NOTE: The test below purposefully does not use any of the read APIs so that if only the read code
+  // breaks, this test can independently test for write failures
+  "appendSegment" should "NOOP if the segment is empty" in {
+    val segment = getRowWriter(keyRange)
+    whenReady(colStore.appendSegment(projection, segment, 0)) { response =>
+      response should equal (NotApplied)
+    }
+  }
+
+  it should "append new rows to a cached segment successfully" in {
+    val segment = getRowWriter(keyRange)
+    segment.addRowsAsChunk(mapper(names take 3), getSortKey _)
+    whenReady(colStore.appendSegment(projection, segment, 0)) { response =>
+      response should equal (Success)
+    }
+
+    // Writing segment2, last 3 rows, should get appended to first 3 in same segment
+    val segment2 = getRowWriter(keyRange)
+    segment2.addRowsAsChunk(mapper(names drop 3), getSortKey _)
+    whenReady(colStore.appendSegment(projection, segment2, 0)) { response =>
+      response should equal (Success)
+    }
+
+    whenReady(colStore.readSegments(schema, keyRange, 0)) { segIter =>
+      val segments = segIter.toSeq
+      segments should have length (1)
+      val readSeg = segments.head.asInstanceOf[RowReaderSegment[Long]]
+      readSeg.keyRange.start should equal (segment.keyRange.start)
+      readSeg.rowIterator().map(_.getLong(2)).toSeq should equal (Seq(24L, 25L, 28L, 29L, 39L, 40L))
+      readSeg.rowIterator().map(_.getString(0)).toSeq should equal (firstNames)
+    }
+  }
+
+  it should "replace rows to an uncached segment successfully" in {
+    val segment = getRowWriter(keyRange)
+    segment.addRowsAsChunk(mapper(names drop 1), getSortKey _)
+    whenReady(colStore.appendSegment(projection, segment, 0)) { response =>
+      response should equal (Success)
+    }
+
+    colStore.clearSegmentCache()
+
+    // Writing segment2, repeat 1 row and add another row.  Should read orig segment from disk.
+    val segment2 = getRowWriter(keyRange)
+    segment2.addRowsAsChunk(mapper(names take 2), getSortKey _)
+    whenReady(colStore.appendSegment(projection, segment2, 0)) { response =>
+      response should equal (Success)
+    }
+
+    whenReady(colStore.readSegments(schema, keyRange, 0)) { segIter =>
+      val segments = segIter.toSeq
+      segments should have length (1)
+      val readSeg = segments.head.asInstanceOf[RowReaderSegment[Long]]
+      readSeg.keyRange.start should equal (segment.keyRange.start)
+      readSeg.rowIterator().map(_.getLong(2)).toSeq should equal (Seq(24L, 25L, 28L, 29L, 39L, 40L))
+      readSeg.rowIterator().map(_.getString(0)).toSeq should equal (firstNames)
+    }
+  }
+
+  "readSegments" should "read segments back that were written" in {
+    val segment = getRowWriter(keyRange)
+    segment.addRowsAsChunk(mapper(names), getSortKey _)
+    whenReady(colStore.appendSegment(projection, segment, 0)) { response =>
+      response should equal (Success)
+    }
+
+    whenReady(colStore.readSegments(schema, keyRange, 0)) { segIter =>
+      val segments = segIter.toSeq
+      segments should have length (1)
+      val readSeg = segments.head.asInstanceOf[RowReaderSegment[Long]]
+      readSeg.keyRange.start should equal (segment.keyRange.start)
+      readSeg.getChunks.toSet should equal (segment.getChunks.toSet)
+      readSeg.index.rowNumIterator.toSeq should equal (segment.index.rowNumIterator.toSeq)
+      readSeg.rowIterator().map(_.getLong(2)).toSeq should equal (Seq(24L, 25L, 28L, 29L, 39L, 40L))
+    }
+  }
+
+  it should "return empty iterator if cannot find segment" in {
+    whenReady(colStore.readSegments(schema, keyRange, 0)) { segIter =>
+      segIter.toSeq should have length (0)
+    }
+  }
+
+  it should "return empty iterator if cannot find partition or version" in (pending)
+
+  it should "return segment with empty chunks if cannot find columns" in {
+    whenReady(colStore.appendSegment(projection, baseSegment, 0)) { response =>
+      response should equal (Success)
+    }
+
+    val fakeCol = Column("notACol", dataset, 0, Column.ColumnType.StringColumn)
+    whenReady(colStore.readSegments(Seq(fakeCol), keyRange, 0)) { segIter =>
+      val segments = segIter.toSeq
+      segments should have length (1)
+      segments.head.getChunks.toSet should equal (Set(("notACol", 0, null), ("notACol", 1, null)))
+    }
+  }
+
+  "scanSegments" should "read segments back that were written" in {
+    val segment = getRowWriter(keyRange)
+    segment.addRowsAsChunk(mapper(names), getSortKey _)
+    whenReady(colStore.appendSegment(projection, segment, 0)) { response =>
+      response should equal (Success)
+    }
+
+    val paramSet = colStore.getScanSplits(dataset)
+    paramSet should have length (1)
+
+    whenReady(colStore.scanSegments[Long](schema, dataset, 0, params = paramSet.head)) { segIter =>
+      val segments = segIter.toSeq
+      segments should have length (1)
+      val readSeg = segments.head.asInstanceOf[RowReaderSegment[Long]]
+      readSeg.keyRange.start should equal (segment.keyRange.start)
+      readSeg.getChunks.toSet should equal (segment.getChunks.toSet)
+      readSeg.index.rowNumIterator.toSeq should equal (segment.index.rowNumIterator.toSeq)
+      readSeg.rowIterator().map(_.getLong(2)).toSeq should equal (Seq(24L, 25L, 28L, 29L, 39L, 40L))
+    }
+  }
+}

--- a/core/src/test/scala/filodb.core/store/InMemoryColumnStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/store/InMemoryColumnStoreSpec.scala
@@ -1,0 +1,6 @@
+package filodb.core.store
+
+class InMemoryColumnStoreSpec extends ColumnStoreSpec {
+  import scala.concurrent.ExecutionContext.Implicits.global
+  val colStore = new InMemoryColumnStore
+}

--- a/core/src/test/scala/filodb.core/store/InMemoryMetaStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/store/InMemoryMetaStoreSpec.scala
@@ -1,0 +1,11 @@
+package filodb.core.store
+
+import org.scalatest.time.{Millis, Span, Seconds}
+
+class InMemoryMetaStoreSpec extends MetaStoreSpec {
+  implicit val defaultPatience =
+    PatienceConfig(timeout = Span(10, Seconds), interval = Span(50, Millis))
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+  lazy val metaStore = new InMemoryMetaStore
+}

--- a/core/src/test/scala/filodb.core/store/MetaStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/store/MetaStoreSpec.scala
@@ -1,0 +1,63 @@
+package filodb.core.store
+
+import java.nio.ByteBuffer
+import scala.concurrent.Future
+
+import filodb.core._
+import filodb.core.metadata.{Column, Dataset}
+
+import org.scalatest.{FunSpec, Matchers, BeforeAndAfter, BeforeAndAfterAll}
+import org.scalatest.concurrent.ScalaFutures
+
+trait MetaStoreSpec extends FunSpec with Matchers
+with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
+  import MetaStore._
+
+  def metaStore: MetaStore
+
+  override def beforeAll() {
+    super.beforeAll()
+    metaStore.initialize().futureValue
+  }
+
+  before { metaStore.clearAllData().futureValue }
+
+  describe("dataset API") {
+    it("should create a new Dataset if one not there") {
+      val dataset = Dataset("foo", "autoid")
+      metaStore.newDataset(dataset).futureValue should equal (Success)
+
+      metaStore.getDataset("foo").futureValue should equal (dataset)
+    }
+
+    it("should return AlreadyExists if dataset already exists") {
+      val dataset = Dataset("foo", "autoid")
+      metaStore.newDataset(dataset).futureValue should equal (Success)
+      metaStore.newDataset(dataset).futureValue should equal (AlreadyExists)
+    }
+
+    it("should return NotFound if getDataset on nonexisting dataset") {
+      metaStore.getDataset("notThere").failed.futureValue shouldBe a [NotFoundError]
+    }
+  }
+
+  describe("column API") {
+    it("should return IllegalColumnChange if an invalid column addition submitted") {
+      val firstColumn = Column("first", "foo", 1, Column.ColumnType.StringColumn)
+      whenReady(metaStore.newColumn(firstColumn)) { response =>
+        response should equal (Success)
+      }
+
+      whenReady(metaStore.newColumn(firstColumn.copy(version = 0)).failed) { err =>
+        err shouldBe an [IllegalColumnChange]
+      }
+    }
+
+    val monthYearCol = Column("monthYear", "gdelt", 1, Column.ColumnType.LongColumn)
+    it("should be able to create a Column and get the Schema") {
+      metaStore.newColumn(monthYearCol).futureValue should equal (Success)
+      metaStore.getSchema("gdelt", 10).futureValue should equal (Map("monthYear" -> monthYearCol))
+    }
+  }
+
+}

--- a/core/src/test/scala/filodb.core/store/SegmentSpec.scala
+++ b/core/src/test/scala/filodb.core/store/SegmentSpec.scala
@@ -1,4 +1,4 @@
-package filodb.core.columnstore
+package filodb.core.store
 
 import filodb.core._
 import filodb.core.metadata.{Column, Dataset, RichProjection}

--- a/jmh/src/main/scala/filodb.jmh/IntSumReadBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/IntSumReadBenchmark.scala
@@ -9,7 +9,7 @@ import scala.language.postfixOps
 
 import filodb.core._
 import filodb.core.metadata.{Column, Dataset, RichProjection}
-import filodb.core.columnstore.{RowReaderSegment, RowWriterSegment}
+import filodb.core.store.{RowReaderSegment, RowWriterSegment}
 import org.velvia.filo.{FiloVector, FastFiloRowReader, RowReader, TupleRowReader}
 
 import java.util.concurrent.TimeUnit

--- a/jmh/src/main/scala/filodb.jmh/IntSumReadBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/IntSumReadBenchmark.scala
@@ -68,6 +68,22 @@ class IntSumReadBenchmark {
   }
 
   /**
+   * Row-wise scanning with null/isAvailable check
+   */
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def rowWiseSegmentScanNullCheck(): Int = {
+    val it = readSeg.rowIterator()
+    var sum = 0
+    while(it.hasNext) {
+      val row = it.next
+      if (row.notNull(0)) sum += row.getInt(0)
+    }
+    sum
+  }
+
+  /**
    * Simulation of boxed row-wise scanning speed (Spark 1.4.x aggregations)
    */
   @Benchmark

--- a/jmh/src/main/scala/filodb.jmh/SparkCassBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/SparkCassBenchmark.scala
@@ -1,0 +1,54 @@
+package filodb.jmh
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+import scalaxy.loops._
+import scala.language.postfixOps
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import filodb.core._
+import filodb.core.metadata.{Column, Dataset, RichProjection}
+import filodb.core.store.{InMemoryColumnStore, RowReaderSegment, RowWriterSegment}
+import filodb.spark.{SparkRowReader, FiloSetup, TypeConverters}
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions.sum
+import org.apache.spark.{SparkContext, SparkException, SparkConf}
+import org.velvia.filo.{RowReader, TupleRowReader}
+
+// Spark CassandraColumnStore benchmark
+// NOTE: before running this test, MUST do sbt jmh/run on CreateCassTestData to populate
+// the randomInts FiloDB table in Cassandra.
+@State(Scope.Benchmark)
+class SparkCassBenchmark {
+  // Now create an RDD[Row] out of it, and a Schema, -> DataFrame
+  val conf = (new SparkConf).setMaster("local[4]")
+                            .setAppName("test")
+                            // .set("spark.sql.tungsten.enabled", "false")
+                            .set("spark.filodb.cassandra.keyspace", "filodb")
+  val sc = new SparkContext(conf)
+  val sql = new SQLContext(sc)
+  // Below is to make sure that Filo actor system stuff is run before test code
+  // so test code is not hit with unnecessary slowdown
+  val filoConfig = FiloSetup.configFromSpark(sc)
+  FiloSetup.init(filoConfig)
+
+  @TearDown
+  def shutdownFiloActors(): Unit = {
+    FiloSetup.shutdown()
+    sc.stop()
+  }
+
+  val cassDF = sql.read.format("filodb.spark").option("dataset", "randomInts").load()
+
+  // NOTE: before running this test, MUST do sbt jmh/run on CreateCassTestData to populate
+  // the randomInts FiloDB table in Cassandra.
+  @Benchmark
+  @BenchmarkMode(Array(Mode.SingleShotTime))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def sparkCassSum(): Any = {
+    cassDF.agg(sum(cassDF("data"))).collect().head
+  }
+}

--- a/jmh/src/main/scala/filodb.jmh/SparkReadBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/SparkReadBenchmark.scala
@@ -4,62 +4,46 @@ import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 import scalaxy.loops._
 import scala.language.postfixOps
-import scala.concurrent.Await
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
 import filodb.core._
 import filodb.core.metadata.{Column, Dataset, RichProjection}
-import filodb.core.store.{InMemoryColumnStore, RowReaderSegment, RowWriterSegment}
-import filodb.spark.{SparkRowReader, FiloSetup, TypeConverters}
-import org.apache.spark.sql.{DataFrame, Row, SQLContext}
-import org.apache.spark.sql.types._
+import filodb.core.store.RowWriterSegment
+import filodb.spark.{FiloSetup, FiloRelation}
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.functions.sum
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.apache.spark.{SparkContext, SparkException, SparkConf}
 import org.velvia.filo.{RowReader, TupleRowReader}
 
-object SparkReadBenchmark {
-  import scala.concurrent.ExecutionContext.Implicits.global
-  implicit val keyHelper = IntKeyHelper(10000)
-
-  val colStore = new InMemoryColumnStore
-
-  // Pretty much lifted from FiloRelation.getRows()
-  def readInner(schema: Seq[Column]): Iterator[Row] = {
-    Await.result(colStore.scanSegments[Int](schema, "dataset", 0), 10.seconds).flatMap { seg =>
-      val readerSeg = seg.asInstanceOf[RowReaderSegment[Int]]
-      readerSeg.rowIterator((bytes, clazzes) => new SparkRowReader(bytes, clazzes))
-         .asInstanceOf[Iterator[Row]]
-    }
-
-  }
-}
-
 /**
- * A benchmark to compare performance of filodb.spark connector against different scenarios,
+ * A benchmark to compare performance of FiloRelation against different scenarios,
  * for an analytical query summing 5 million random integers from a single column of a
  * FiloDB dataset.  Description:
  * - sparkSum(): Sum 5 million integers stored using InMemoryColumnStore.
- *   NOTE: we use code lifted from FiloRelation, but not the actual FiloRelation, because
- *   of the lack of an InMemoryMetaStore, and to avoid having to ingest through MemTable etc.
  * - sparkBaseline(): Get the first 2 records.  Just to see what the baseline latency is of a
  *   DataFrame query.
+ * - inMemoryColStoreOnly(): No Spark, just reading rows from the InMemoryColumnStore
  * - sparkCassSum(): Sum 5 million integers using CassandraColumnStore.  Must have run CreateCassTestData
  *   first to populate into Cassandra.
+ *   NOTE: This has been moved to SparkCassBenchmark.scala
  *
  * To get the scan speed, one needs to subtract the baseline from the total time of sparkSum/sparkCassSum.
  * For example, on my laptop, here is the JMH output:
  * {{{
  *  Benchmark                         Mode  Cnt  Score   Error  Units
- *  SparkReadBenchmark.sparkBaseline    ss    9  0.026 ± 0.002   s/op
- *  SparkReadBenchmark.sparkCassSum     ss    9  0.845 ± 0.114   s/op
- *  SparkReadBenchmark.sparkSum         ss    9  0.049 ± 0.006   s/op
+ *  SparkReadBenchmark.sparkBaseline    ss   15  0.023 ± 0.002   s/op
+ *  SparkReadBenchmark.sparkSum         ss   15  0.415 ± 0.034   s/op
+ *  SparkCassBenchmark.sparkCassSum     ss   15  0.622 ± 0.031   s/op
  * }}}
  *
  * (The above run against Cassandra 2.1.6, 5GB heap, with jmh:run -i 3 -wi 3 -f3 filodb.jmh.SparkReadBenchmark)
  *
  * Thus:
- * - Cassandra scan speed = 5000000 / (0.845 - 0.026) = 6,105,006 ops/sec
- * - InMemory scan speed  = 5000000 / (0.049 - 0.026) = 217,391,304 ops/sec
+ * - Cassandra scan speed = 5000000 / (0.622 - 0.023) =  8,347,245 ops/sec
+ * - InMemory scan speed  = 5000000 / (0.415 - 0.023) = 12,755,102 ops/sec
  */
 @State(Scope.Benchmark)
 class SparkReadBenchmark {
@@ -67,11 +51,28 @@ class SparkReadBenchmark {
   // Source of rows
   implicit val keyHelper = IntKeyHelper(10000)
 
+  val conf = (new SparkConf).setMaster("local[4]")
+                            .setAppName("test")
+                            // .set("spark.sql.tungsten.enabled", "false")
+                            .set("spark.filodb.store", "in-memory")
+  val sc = new SparkContext(conf)
+  val sql = new SQLContext(sc)
+  // Below is to make sure that Filo actor system stuff is run before test code
+  // so test code is not hit with unnecessary slowdown
+  val filoConfig = FiloSetup.configFromSpark(sc)
+  FiloSetup.init(filoConfig)
+
   val schema = Seq(Column("int", "dataset", 0, Column.ColumnType.IntColumn),
                    Column("rownum", "dataset", 0, Column.ColumnType.IntColumn))
 
   val dataset = Dataset("dataset", "rownum")
   val projection = RichProjection[Int](dataset, schema)
+
+  // Initialize metastore
+  import scala.concurrent.ExecutionContext.Implicits.global
+  Await.result(FiloSetup.metaStore.newDataset(dataset), 3.seconds)
+  val createColumns = schema.map { col => FiloSetup.metaStore.newColumn(col) }
+  Await.result(Future.sequence(createColumns), 3.seconds)
 
   val rowStream = Iterator.from(0).map { row => (Some(util.Random.nextInt), Some(row)) }
 
@@ -83,29 +84,8 @@ class SparkReadBenchmark {
     val writerSeg = new RowWriterSegment(keyRange, schema)
     writerSeg.addRowsAsChunk(rows.toIterator.map(TupleRowReader),
                              (r: RowReader) => r.getInt(1) )
-    Await.result(SparkReadBenchmark.colStore.appendSegment(projection, writerSeg, 0), 10.seconds)
+    Await.result(FiloSetup.columnStore.appendSegment(projection, writerSeg, 0), 10.seconds)
   }
-
-  private def makeTestRDD() = {
-    val _schema = schema
-    sc.parallelize(Seq(1), 1).mapPartitions { x =>
-      SparkReadBenchmark.readInner(_schema)
-    }
-  }
-
-  // Now create an RDD[Row] out of it, and a Schema, -> DataFrame
-  val conf = (new SparkConf).setMaster("local[4]")
-                            .setAppName("test")
-                            // .set("spark.sql.tungsten.enabled", "false")
-                            .set("filodb.cassandra.keyspace", "filodb")
-                            .set("filodb.memtable.min-free-mb", "10")
-  val sc = new SparkContext(conf)
-  val sql = new SQLContext(sc)
-  // Below is to make sure that Filo actor system stuff is run before test code
-  // so test code is not hit with unnecessary slowdown
-  val filoConfig = FiloSetup.configFromSpark(sc)
-  FiloSetup.init(filoConfig)
-  val sqlSchema = StructType(TypeConverters.columnsToSqlFields(schema))
 
   @TearDown
   def shutdownFiloActors(): Unit = {
@@ -113,13 +93,13 @@ class SparkReadBenchmark {
     sc.stop()
   }
 
+  val df = sql.read.format("filodb.spark").option("dataset", dataset.name).load
+
   // How long does it take to iterate through all the rows
   @Benchmark
   @BenchmarkMode(Array(Mode.SingleShotTime))
   @OutputTimeUnit(TimeUnit.SECONDS)
   def sparkSum(): Any = {
-    val testRdd = makeTestRDD()
-    val df = sql.createDataFrame(testRdd, sqlSchema)
     df.agg(sum(df("int"))).collect().head
   }
 
@@ -129,7 +109,8 @@ class SparkReadBenchmark {
   @BenchmarkMode(Array(Mode.SingleShotTime))
   @OutputTimeUnit(TimeUnit.SECONDS)
   def inMemoryColStoreOnly(): Any = {
-    val it = SparkReadBenchmark.readInner(schema)
+    val it = FiloRelation.getRows(dataset.options, dataset.name, 0, schema, schema.last,
+                                  (x => true), Map.empty).asInstanceOf[Iterator[InternalRow]]
     var sum = 0
     while (it.hasNext) {
       val row = it.next
@@ -143,19 +124,6 @@ class SparkReadBenchmark {
   @BenchmarkMode(Array(Mode.SingleShotTime))
   @OutputTimeUnit(TimeUnit.SECONDS)
   def sparkBaseline(): Any = {
-    val testRdd = makeTestRDD()
-    val df = sql.createDataFrame(testRdd, sqlSchema)
     df.select("int").limit(2).collect()
-  }
-
-  val cassDF = sql.read.format("filodb.spark").option("dataset", "randomInts").load()
-
-  // NOTE: before running this test, MUST do sbt jmh/run on CreateCassTestData to populate
-  // the randomInts FiloDB table in Cassandra.
-  @Benchmark
-  @BenchmarkMode(Array(Mode.SingleShotTime))
-  @OutputTimeUnit(TimeUnit.SECONDS)
-  def sparkCassSum(): Any = {
-    cassDF.agg(sum(cassDF("data"))).collect().head
   }
 }

--- a/jmh/src/main/scala/filodb.jmh/SparkReadBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/SparkReadBenchmark.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 
 import filodb.core._
 import filodb.core.metadata.{Column, Dataset, RichProjection}
-import filodb.core.columnstore.{InMemoryColumnStore, RowReaderSegment, RowWriterSegment}
+import filodb.core.store.{InMemoryColumnStore, RowReaderSegment, RowWriterSegment}
 import filodb.spark.{SparkRowReader, FiloSetup, TypeConverters}
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.apache.spark.sql.types._

--- a/spark/src/main/scala/filodb.spark/FiloRelation.scala
+++ b/spark/src/main/scala/filodb.spark/FiloRelation.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 
 import filodb.core._
 import filodb.core.metadata.{Column, Dataset, DatasetOptions}
-import filodb.core.columnstore.RowReaderSegment
+import filodb.core.store.RowReaderSegment
 
 object FiloRelation {
   import TypeConverters._

--- a/spark/src/main/scala/filodb.spark/FiloRelation.scala
+++ b/spark/src/main/scala/filodb.spark/FiloRelation.scala
@@ -149,9 +149,11 @@ case class FiloRelation(dataset: String,
   // For now just implement really simple filtering
   private def getFilterFuncs(filters: Seq[Filter]): Seq[Types.PartitionKey => Boolean] = {
     import org.apache.spark.sql.sources._
+    logger.info(s"Filters = $filters")
     filters.flatMap {
       case EqualTo(datasetObj.partitionColumn, equalVal) =>
         val compareVal = equalVal.toString   // must convert to same type as partitionKey
+        logger.info(s"Adding filter predicate === $compareVal")
         Some((p: Types.PartitionKey) => p == compareVal)
       case other: Filter =>
         None

--- a/spark/src/test/scala/filodb.spark/SaveAsFiloTest.scala
+++ b/spark/src/test/scala/filodb.spark/SaveAsFiloTest.scala
@@ -129,6 +129,7 @@ with Matchers with ScalaFutures {
                  save()
     val df = sql.read.format("filodb.spark").option("dataset", "test1").load()
     df.agg(sum("year")).collect().head(0) should equal (4030)
+    df.select("id", "year").limit(2).collect()   // Just to make sure row copy works
   }
 
   val jsonRows2 = Seq(

--- a/spark/src/test/scala/filodb.spark/SaveAsFiloTest.scala
+++ b/spark/src/test/scala/filodb.spark/SaveAsFiloTest.scala
@@ -30,8 +30,8 @@ with Matchers with ScalaFutures {
   // Setup SQLContext and a sample DataFrame
   val conf = (new SparkConf).setMaster("local[4]")
                             .setAppName("test")
-                            .set("filodb.cassandra.keyspace", "unittest")
-                            .set("filodb.memtable.min-free-mb", "10")
+                            .set("spark.filodb.cassandra.keyspace", "unittest")
+                            .set("spark.filodb.memtable.min-free-mb", "10")
   val sc = new SparkContext(conf)
   val sql = new SQLContext(sc)
 

--- a/spark/src/test/scala/filodb.spark/StreamingTest.scala
+++ b/spark/src/test/scala/filodb.spark/StreamingTest.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 
 import filodb.core._
 import filodb.core.metadata.{Column, Dataset}
-import filodb.core.columnstore.SegmentSpec
+import filodb.core.store.SegmentSpec
 
 import org.scalatest.{FunSpec, BeforeAndAfter, BeforeAndAfterAll, Matchers}
 import org.scalatest.concurrent.ScalaFutures

--- a/spark/src/test/scala/filodb.spark/StreamingTest.scala
+++ b/spark/src/test/scala/filodb.spark/StreamingTest.scala
@@ -29,8 +29,8 @@ with Matchers with ScalaFutures {
   // Setup SQLContext and a sample DataFrame
   val conf = (new SparkConf).setMaster("local[4]")
                             .setAppName("test")
-                            .set("filodb.cassandra.keyspace", "unittest")
-                            .set("filodb.memtable.min-free-mb", "10")
+                            .set("spark.filodb.cassandra.keyspace", "unittest")
+                            .set("spark.filodb.memtable.min-free-mb", "10")
   val ssc = new StreamingContext(conf, Milliseconds(700))
   val sql = new SQLContext(ssc.sparkContext)
 


### PR DESCRIPTION
Summary of changes:

- Added an InMemoryMetaStore, so that FiloDB could be tried and used completely as an in-memory DB
- Fixed passing of config parameters in Spark datasource.  Now precede params with `filodb.spark`.
- The choice of store could be configured via `filodb.spark.store`
- Big performance improvements in Spark Datasource (roughly doubling scan speeds for Cassandra column store; tripling for InMemoryColumnStore), due to Iterator loop optimization and switch to RDD[InternalRow]
- Improved README