### PR TITLE
fixed regex to grab everything in version.sbt quotes

### DIFF
--- a/filo-cli
+++ b/filo-cli
@@ -2,7 +2,7 @@
 
 # set -x
 SCALA_VERSION="2.10"
-FILO_VERSION=$(cat version.sbt | sed -e 's/.*\([0-9]\.[^"]*\).*/\1/g')
+FILO_VERSION=$(cat version.sbt | sed -e 's/.*"\(.*\)"/\1/g')
 CLI_FILE=`pwd`"/cli/target/scala-$SCALA_VERSION/filo-cli-$FILO_VERSION"
 
 function isJava8(){


### PR DESCRIPTION
The previous expression was dropping the initial '0.', resulting in 2.1-SNAPSHOT instead of 0.2.1-SNAPSHOT