### PR TITLE
Ability to scan multiple partitions using IN operator

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/ChunkRowMapTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/ChunkRowMapTable.scala
@@ -41,7 +41,7 @@ extends CassandraTable[ChunkRowMapTable, ChunkRowMapRecord] {
   object nextChunkId extends IntColumn(this)
   // Keeping below to remember how to define a set column, but move it elsewhere.
   // object columnsWritten extends SetColumn[ChunkRowMapTable, ChunkRowMapRecord, String](this)
-  //scalastyle:on
+  // scalastyle:on
 
   override def fromRow(row: Row): ChunkRowMapRecord =
     ChunkRowMapRecord(ByteVector(partition(row)),
@@ -67,7 +67,8 @@ extends CassandraTable[ChunkRowMapTable, ChunkRowMapRecord] {
   /**
    * Retrieves a whole series of chunk maps, in the range [startSegmentId, untilSegmentId)
    * End is exclusive or not depending on keyRange.endExclusive flag
-   * @return ChunkMaps(...), if nothing found will return ChunkMaps(Nil).
+    *
+    * @return ChunkMaps(...), if nothing found will return ChunkMaps(Nil).
    */
   def getChunkMaps(keyRange: BinaryKeyRange,
                    version: Int): Future[Iterator[ChunkRowMapRecord]] =
@@ -109,7 +110,8 @@ extends CassandraTable[ChunkRowMapTable, ChunkRowMapRecord] {
 
   /**
    * Writes a new chunk map to the chunkRowTable.
-   * @return Success, or an exception as a Future.failure
+    *
+    * @return Success, or an exception as a Future.failure
    */
   def writeChunkMap(partition: Types.BinaryPartition,
                     version: Int,

--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/ChunkRowMapTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/ChunkRowMapTable.scala
@@ -41,7 +41,7 @@ extends CassandraTable[ChunkRowMapTable, ChunkRowMapRecord] {
   object nextChunkId extends IntColumn(this)
   // Keeping below to remember how to define a set column, but move it elsewhere.
   // object columnsWritten extends SetColumn[ChunkRowMapTable, ChunkRowMapRecord, String](this)
-  // scalastyle:on
+  //scalastyle:on
 
   override def fromRow(row: Row): ChunkRowMapRecord =
     ChunkRowMapRecord(ByteVector(partition(row)),
@@ -67,8 +67,7 @@ extends CassandraTable[ChunkRowMapTable, ChunkRowMapRecord] {
   /**
    * Retrieves a whole series of chunk maps, in the range [startSegmentId, untilSegmentId)
    * End is exclusive or not depending on keyRange.endExclusive flag
-    *
-    * @return ChunkMaps(...), if nothing found will return ChunkMaps(Nil).
+   * @return ChunkMaps(...), if nothing found will return ChunkMaps(Nil).
    */
   def getChunkMaps(keyRange: BinaryKeyRange,
                    version: Int): Future[Iterator[ChunkRowMapRecord]] =
@@ -110,8 +109,7 @@ extends CassandraTable[ChunkRowMapTable, ChunkRowMapRecord] {
 
   /**
    * Writes a new chunk map to the chunkRowTable.
-    *
-    * @return Success, or an exception as a Future.failure
+   * @return Success, or an exception as a Future.failure
    */
   def writeChunkMap(partition: Types.BinaryPartition,
                     version: Int,

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -35,6 +35,9 @@
 
       # Maximum number of chunks to flush at one time using one Unlogged Batch.
       chunk-batch-size = 16
+
+      # Maximum number of partitions can be fetched at once using IN query
+      inquery-partitions-limit = 12
     }
 
     memtable {

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -36,7 +36,9 @@
       # Maximum number of chunks to flush at one time using one Unlogged Batch.
       chunk-batch-size = 16
 
-      # Maximum number of partitions can be fetched at once using IN query
+      # Maximum number of partitions that can be fetched at once that will still fit in
+      # one Spark partition/thread when using IN clause in query.
+      # If number of partitions are more than this limit then full table scan is performed.
       inquery-partitions-limit = 12
     }
 

--- a/core/src/main/scala/filodb.core/store/ColumnStore.scala
+++ b/core/src/main/scala/filodb.core/store/ColumnStore.scala
@@ -20,6 +20,8 @@ case class FilteredPartitionScan(split: ScanSplit,
 case class FilteredPartitionRangeScan(split: ScanSplit,
                                       segmentRange: SegmentRange[_],
                                       filter: Any => Boolean = (a: Any) => true) extends ScanMethod
+case class MultiPartitionScan(partitions: Seq[Any]) extends ScanMethod
+// case class MultiPartitionRangeScanMethod(partitions: Seq[Any]) extends ScanMethod
 
 trait ScanSplit {
   // Should return a set of hostnames or IP addresses describing the preferred hosts for that scan split

--- a/core/src/main/scala/filodb.core/store/ColumnStore.scala
+++ b/core/src/main/scala/filodb.core/store/ColumnStore.scala
@@ -21,7 +21,7 @@ case class FilteredPartitionRangeScan(split: ScanSplit,
                                       segmentRange: SegmentRange[_],
                                       filter: Any => Boolean = (a: Any) => true) extends ScanMethod
 case class MultiPartitionScan(partitions: Seq[Any]) extends ScanMethod
-// case class MultiPartitionRangeScanMethod(partitions: Seq[Any]) extends ScanMethod
+case class MultiPartitionRangeScan(keyRanges: Seq[KeyRange[_, _]]) extends ScanMethod
 
 trait ScanSplit {
   // Should return a set of hostnames or IP addresses describing the preferred hosts for that scan split

--- a/core/src/main/scala/filodb.core/store/InMemoryColumnStore.scala
+++ b/core/src/main/scala/filodb.core/store/InMemoryColumnStore.scala
@@ -167,21 +167,21 @@ trait InMemoryColumnStoreScanner extends ColumnStoreScanner {
 
   def multiPartScan(projection: RichProjection, version: Int, partitions: Seq[Any]):
     Iterator[(BinaryPartition, RowMapTreeLike)] = {
-    partitions.map { partition => {
+    partitions.toIterator.collect { case (partition)  => {
       val binPart = projection.partitionType.toBytes(partition.asInstanceOf[projection.PK])
        (binPart, rowMaps.getOrElse((projection.datasetRef, binPart, version), EmptyRowMapTree))
-    }}.toIterator
+    }}
   }
 
   def multiPartRangeScan(projection: RichProjection, version: Int, keyRanges: Seq[KeyRange[_, _]]):
     Iterator[(BinaryPartition, RowMapTreeLike)] = {
-    keyRanges.map { range => {
+    keyRanges.toIterator.collect { case (range) => {
       val binKR = projection.toBinaryKeyRange(range)
       val rowMapTree = rowMaps.getOrElse((projection.datasetRef, binKR.partition, version),
                                         EmptyRowMapTree)
       val subMap = rowMapTree.subMap(binKR.start, true, binKR.end, !binKR.endExclusive)
       (binKR.partition, subMap)
-    }}.toIterator
+    }}
   }
 
   def singlePartRangeScan(projection: RichProjection, version: Int, k: KeyRange[_, _]):

--- a/core/src/main/scala/filodb.core/store/InMemoryColumnStore.scala
+++ b/core/src/main/scala/filodb.core/store/InMemoryColumnStore.scala
@@ -166,20 +166,19 @@ trait InMemoryColumnStoreScanner extends ColumnStoreScanner {
   }
 
   def multiPartScan(projection: RichProjection, version: Int, partitions: Seq[Any]):
-  Iterator[(BinaryPartition, RowMapTreeLike)] = {
-    partitions.map{partition => {
-      logger.info(s"partition :${partition}")
+    Iterator[(BinaryPartition, RowMapTreeLike)] = {
+    partitions.map { partition => {
       val binPart = projection.partitionType.toBytes(partition.asInstanceOf[projection.PK])
        (binPart, rowMaps.getOrElse((projection.datasetRef, binPart, version), EmptyRowMapTree))
     }}.toIterator
   }
 
   def multiPartRangeScan(projection: RichProjection, version: Int, keyRanges: Seq[KeyRange[_, _]]):
-  Iterator[(BinaryPartition, RowMapTreeLike)] = {
-    keyRanges.map{range => {
+    Iterator[(BinaryPartition, RowMapTreeLike)] = {
+    keyRanges.map { range => {
       val binKR = projection.toBinaryKeyRange(range)
       val rowMapTree = rowMaps.getOrElse((projection.datasetRef, binKR.partition, version),
-        EmptyRowMapTree)
+                                        EmptyRowMapTree)
       val subMap = rowMapTree.subMap(binKR.start, true, binKR.end, !binKR.endExclusive)
       (binKR.partition, subMap)
     }}.toIterator

--- a/core/src/main/scala/filodb.core/store/InMemoryColumnStore.scala
+++ b/core/src/main/scala/filodb.core/store/InMemoryColumnStore.scala
@@ -193,6 +193,8 @@ trait InMemoryColumnStoreScanner extends ColumnStoreScanner {
       case SinglePartitionScan(partition) => singlePartScan(projection, version, partition)
       case SinglePartitionRangeScan(k)    => singlePartRangeScan(projection, version, k)
 
+      case MultiPartitionScan(partitions) => singlePartScan(projection, version, partitions)
+
       case FilteredPartitionScan(split, filterFunc) =>
         filteredPartScan(projection, version, split, filterFunc)
 

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -17,7 +17,9 @@
       # Maximum number of chunks to flush at one time using one Unlogged Batch.
       chunk-batch-size = 16
 
-      # Maximum number of partitions can be fetched at once using IN query
+      # Maximum number of partitions that can be fetched at once that will still fit in
+      # one Spark partition/thread when using IN clause in query.
+      # If number of partitions are more than this limit then full table scan is performed.
       inquery-partitions-limit = 12
     }
 

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -16,6 +16,9 @@
 
       # Maximum number of chunks to flush at one time using one Unlogged Batch.
       chunk-batch-size = 16
+
+      # Maximum number of partitions can be fetched at once using IN query
+      inquery-partitions-limit = 12
     }
 
     memtable {

--- a/spark/src/main/scala/filodb.spark/FiloRelation.scala
+++ b/spark/src/main/scala/filodb.spark/FiloRelation.scala
@@ -100,9 +100,6 @@ object FiloRelation extends StrictLogging {
     * For example filters provided in the query are actor2Code IN ('JPN', 'KHM') and year = 1979
     * then this method returns all combinations like ('JPN',1979) , ('KHM',1979) which represents
     * full partition key value.
-    * @param xs
-    * @tparam A
-    * @return
     */
   def combine[A](xs: Traversable[Traversable[A]]): Seq[Seq[A]] =
     xs.filter(_.nonEmpty).foldLeft(Seq(Seq.empty[A])) {

--- a/spark/src/test/scala/filodb.spark/SaveAsFiloTest.scala
+++ b/spark/src/test/scala/filodb.spark/SaveAsFiloTest.scala
@@ -370,8 +370,8 @@ class SaveAsFiloTest extends SparkTestBase {
     df.agg(sum("numArticles")).collect().head(0) should equal (492)
 
     df.registerTempTable("gdelt")
-    sql.sql("select sum(numArticles) from gdelt where  actor2Code in ('JPN', 'KHM') " +
-      "and year=1979 and eventId >= 21 AND eventId <= 24").collect().
+    sql.sql("select sum(numArticles) from gdelt where year=1979 " +
+      "and  actor2Code in ('JPN', 'KHM')  and eventId >= 21 AND eventId <= 24").collect().
       head(0) should equal (21)
   }
 

--- a/spark/src/test/scala/filodb.spark/SaveAsFiloTest.scala
+++ b/spark/src/test/scala/filodb.spark/SaveAsFiloTest.scala
@@ -321,7 +321,7 @@ class SaveAsFiloTest extends SparkTestBase {
       head(0) should equal (10)
   }
 
-  it("should be able to parse and use single partition query") {
+  it("should be able to parse and use single partition query ") {
     import sql.implicits._
 
     val gdeltDF = sc.parallelize(GdeltTestData.records.toSeq).toDF()


### PR DESCRIPTION
This feature avoids full table scan when multiple partition keys are provided via IN clause in select query. Issue #109.