### PR TITLE
bug(query): fix metadataquery shardkeyregex queries

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
@@ -56,12 +56,22 @@ class ShardKeyRegexPlanner(val dataset: Dataset,
   override def materialize(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
     val nonMetricShardKeyFilters =
       LogicalPlan.getNonMetricShardKeyFilters(logicalPlan, dataset.options.nonMetricShardColumns)
-    if (LogicalPlan.hasShardKeyEqualsOnly(logicalPlan, dataset.options.nonMetricShardColumns)) {
+    if (isMetadataQuery(logicalPlan)
+      || LogicalPlan.hasShardKeyEqualsOnly(logicalPlan, dataset.options.nonMetricShardColumns)) {
       queryPlanner.materialize(logicalPlan, qContext)
     } else if (hasSingleShardKeyMatch(nonMetricShardKeyFilters)) {
       // For queries like topk(2, test{_ws_ = "demo", _ns_ =~ "App-1"}) which have just one matching value
       generateExecWithoutRegex(logicalPlan, nonMetricShardKeyFilters.head, qContext).head
     } else walkLogicalPlanTree(logicalPlan, qContext).plans.head
+  }
+
+  def isMetadataQuery(logicalPlan: LogicalPlan): Boolean = {
+    logicalPlan match {
+      case _: LabelValues |
+           _: LabelNames |
+           _: SeriesKeysByFilters => true
+      case _ => false
+    }
   }
 
   def walkLogicalPlanTree(logicalPlan: LogicalPlan,
@@ -77,9 +87,6 @@ class ShardKeyRegexPlanner(val dataset: Dataset,
       case lp: VectorPlan                  => materializeVectorPlan(qContext, lp)
       case lp: Aggregate                   => materializeAggregate(lp, qContext)
       case lp: BinaryJoin                  => materializeBinaryJoin(lp, qContext)
-      case lp: LabelValues                 => PlanResult(Seq(queryPlanner.materialize(lp, qContext)))
-      case lp: LabelNames                  => PlanResult(Seq(queryPlanner.materialize(lp, qContext)))
-      case lp: SeriesKeysByFilters         => PlanResult(Seq(queryPlanner.materialize(lp, qContext)))
       case _                               => materializeOthers(logicalPlan, qContext)
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

Following query fails since we try to convertLogicalPlanToQuery which is not required for metadata queries.

```
/api/v2/label/values?start=1634596636&end=1634607436&labels=_ns_,__name__,instance&filter=_ns_="App-2",_ws_=~"filodb.*"'
```

**New behavior :**

Metadata queries with regex on shardkey should work without any issues.