### PR TITLE
perf(core): Reduce heap utilized by each TimeSeriesPartition object

### DIFF
--- a/cassandra/src/test/scala/filodb.cassandra/columnstore/OdpSpec.scala
+++ b/cassandra/src/test/scala/filodb.cassandra/columnstore/OdpSpec.scala
@@ -1,12 +1,16 @@
 package filodb.cassandra.columnstore
 
 import scala.concurrent.Future
+
 import com.typesafe.config.ConfigFactory
 import monix.execution.Scheduler
 import monix.reactive.Observable
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
+
 import filodb.cassandra.DefaultFiloSessionProvider
 import filodb.core.{MachineMetricsData, TestData}
 import filodb.core.binaryrecord2.{BinaryRecordRowReader, RecordBuilder}
@@ -14,14 +18,12 @@ import filodb.core.downsample.OffHeapMemory
 import filodb.core.memstore._
 import filodb.core.memstore.FiloSchedulers.QuerySchedName
 import filodb.core.metadata.{Dataset, Schemas}
-import filodb.core.query.{ColumnFilter, EmptyQueryConfig, PlannerParams, QueryConfig, QueryContext, QuerySession}
+import filodb.core.query._
 import filodb.core.query.Filter.Equals
 import filodb.core.store.{InMemoryMetaStore, PartKeyRecord, StoreConfig, TimeRangeChunkScan}
 import filodb.memory.format.ZeroCopyUTF8String._
 import filodb.query.{QueryResponse, QueryResult}
 import filodb.query.exec.{InProcessPlanDispatcher, MultiSchemaPartitionsExec}
-import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.matchers.should.Matchers
 
 class OdpSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
 
@@ -69,9 +71,8 @@ class OdpSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll with Scala
     val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
     val partKey = partBuilder.partKeyFromObjects(Schemas.gauge, gaugeName, seriesTags)
 
-    val part = new TimeSeriesPartition(0, Schemas.gauge, partKey,
-      0, offheapMem.bufferPools(Schemas.gauge.schemaHash), shardStats,
-      offheapMem.nativeMemoryManager, 1)
+    val shardInfo = TimeSeriesShardInfo(0, shardStats, offheapMem.bufferPools, offheapMem.nativeMemoryManager)
+    val part = new TimeSeriesPartition(0, Schemas.gauge, partKey, shardInfo, 1)
 
     gaugePartKeyBytes = part.partKeyBytes
 

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesPartitionSpec.scala
@@ -31,15 +31,17 @@ object TimeSeriesPartitionSpec {
   def makePart(partNo: Int, dataset: Dataset,
                partKey: NativePointer = defaultPartKey,
                bufferPool: WriteBufferPool = myBufferPool): TimeSeriesPartition = {
-    new TimeSeriesPartition(partNo, dataset.schema, partKey, 0, bufferPool,
-          new TimeSeriesShardStats(dataset.ref, 0), memFactory, 40)
+    val bufferPools = debox.Map(dataset.schema.schemaHash -> bufferPool)
+    val shardInfo = TimeSeriesShardInfo(0, new TimeSeriesShardStats(dataset.ref, 0), bufferPools, memFactory)
+    new TimeSeriesPartition(partNo, dataset.schema, partKey, shardInfo, 40)
   }
 
   def tracingPart(partNo: Int, dataset: Dataset,
                partKey: NativePointer = defaultPartKey,
                bufferPool: WriteBufferPool = myBufferPool): TimeSeriesPartition = {
-    new TracingTimeSeriesPartition(partNo, dataset.ref, dataset.schema, partKey, 0, bufferPool,
-          new TimeSeriesShardStats(dataset.ref, 0), memFactory, 40)
+    val bufferPools = debox.Map(dataset.schema.schemaHash -> bufferPool)
+    val shardInfo = TimeSeriesShardInfo(0, new TimeSeriesShardStats(dataset.ref, 0), bufferPools, memFactory)
+    new TracingTimeSeriesPartition(partNo, dataset.ref, dataset.schema, partKey, shardInfo, 40)
   }
 }
 

--- a/memory/src/main/scala/filodb.memory/data/ChunkMap.scala
+++ b/memory/src/main/scala/filodb.memory/data/ChunkMap.scala
@@ -157,10 +157,15 @@ object ChunkMap extends StrictLogging {
 }
 
 /**
- * @param memFactory a THREAD-SAFE factory for allocating offheap space
  * @param capacity initial capacity of the map; must be more than 0
  */
-class ChunkMap(val memFactory: NativeMemoryManager, var capacity: Int) {
+abstract class ChunkMap(var capacity: Int) {
+
+  /**
+   * A THREAD-SAFE factory for allocating offheap space
+   */
+  def memFactory: NativeMemoryManager
+
   require(capacity > 0)
 
   private var lockState: Int = 0

--- a/memory/src/test/scala/filodb.memory/data/ChunkMapTest.scala
+++ b/memory/src/test/scala/filodb.memory/data/ChunkMapTest.scala
@@ -13,6 +13,9 @@ import filodb.memory.format.UnsafeUtils
 import filodb.memory.format.vectors.NativeVectorTest
 
 class ChunkMapTest extends NativeVectorTest with ScalaFutures {
+
+  val nmm = memFactory
+
   def makeElementWithID(id: Long): NativePointer = {
     val newElem = memFactory.allocateOffheap(16)
     UnsafeUtils.setLong(newElem, id)
@@ -27,7 +30,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
   }
 
   it("should be empty when first starting") {
-    val map = new ChunkMap(memFactory, 8)
+    val map = new ChunkMap(8) {
+      def memFactory = nmm
+    }
     map.chunkmapSize shouldEqual 0
     map.chunkmapContains(5L) shouldEqual false
     intercept[IndexOutOfBoundsException] { map.chunkmapDoGetFirst }
@@ -39,7 +44,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
   }
 
   it("should insert and read back properly in various places") {
-    val map = new ChunkMap(memFactory, 8)
+    val map = new ChunkMap(8) {
+      def memFactory = nmm
+    }
     val elems = makeElems((0 to 11).map(_.toLong))
 
     // when empty
@@ -100,7 +107,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
 
   it("should replace existing elements in various places") {
     // pre-populate with elements 2 to 10
-    val map = new ChunkMap(memFactory, 8)
+    val map = new ChunkMap(8) {
+      def memFactory = nmm
+    }
     val elems = makeElems((2 to 10).map(_.toLong))
     elems.foreach { elem =>
       map.chunkmapDoPut(elem)
@@ -132,7 +141,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
 
   it("should putIfAbsent only if item doesn't already exist") {
     // pre-populate with elements 2 to 10
-    val map = new ChunkMap(memFactory, 8)
+    val map = new ChunkMap(8) {
+      def memFactory = nmm
+    }
     val elems = makeElems((2 to 10).map(_.toLong))
     map.chunkmapSize shouldEqual 0
 
@@ -163,7 +174,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
   }
 
   it("should not be able to put NULL elements") {
-    val map = new ChunkMap(memFactory, 8)
+    val map = new ChunkMap(8) {
+      def memFactory = nmm
+    }
     intercept[IllegalArgumentException] {
       map.chunkmapDoPut(0)
     }
@@ -172,7 +185,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
 
   it("should insert, delete, and reinsert") {
     // insert 1 item, then delete it, test map is truly empty
-    val map = new ChunkMap(memFactory, 8)
+    val map = new ChunkMap(8) {
+      def memFactory = nmm
+    }
     map.chunkmapDoPut(makeElementWithID(1))
     map.chunkmapSize shouldEqual 1
     map.chunkmapDoRemove(1L)
@@ -210,7 +225,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
   }
 
   it("should remove floor") {
-    val map = new ChunkMap(memFactory, 12)
+    val map = new ChunkMap(12) {
+      def memFactory = nmm
+    }
     val elems = makeElems((0 to 30 by 3).map(_.toLong))
     elems.foreach { elem =>
       map.chunkmapDoPut(elem)
@@ -247,7 +264,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
 
   it("should handle concurrent inserts in various places") {
     // Let's have 1 thread inserting at head, and another one inserting in middle
-    val map = new ChunkMap(memFactory, 32)
+    val map = new ChunkMap(32) {
+      def memFactory = nmm
+    }
     val headElems = makeElems((100 to 199).map(_.toLong))
     val midElems = makeElems((0 to 99).map(_.toLong))
 
@@ -274,7 +293,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
   it("should handle concurrent inserts and ensure slice/iterations return sane data") {
     // 1 thread inserts random elem.  Another allocates random strings in the buffer, just to
     // increase chances of reading random crap
-    val map = new ChunkMap(memFactory, 32)
+    val map = new ChunkMap(32) {
+      def memFactory = nmm
+    }
     val elems = makeElems((0 to 99).map(_.toLong)).toSeq
 
     val insertThread = Future {
@@ -310,7 +331,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
 
   it("should handle concurrent inserts and deletes in various places") {
     // First insert 0 to 99 single threaded
-    val map = new ChunkMap(memFactory, 32)
+    val map = new ChunkMap(32) {
+      def memFactory = nmm
+    }
     val elems = makeElems((0 to 99).map(_.toLong))
     elems.foreach { elem =>
       map.chunkmapWithExclusive(map.chunkmapDoPut(elem))
@@ -346,7 +369,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
   }
 
   it("should slice correctly") {
-    val map = new ChunkMap(memFactory, 32)
+    val map = new ChunkMap(32) {
+      def memFactory = nmm
+    }
     val elems = makeElems((0 to 30 by 3).map(_.toLong))
     elems.foreach { elem =>
       map.chunkmapDoPut(elem)
@@ -374,7 +399,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
   }
 
   it("should sliceToEnd correctly") {
-    val map = new ChunkMap(memFactory, 32)
+    val map = new ChunkMap(32) {
+      def memFactory = nmm
+    }
     val elems = makeElems((0 to 30 by 3).map(_.toLong))
     elems.foreach { elem =>
       map.chunkmapDoPut(elem)
@@ -392,7 +419,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
   }
 
   it("should behave gracefully once map is freed") {
-    val map = new ChunkMap(memFactory, 32)
+    val map = new ChunkMap(32) {
+      def memFactory = nmm
+    }
     val elems = makeElems((0 to 30 by 3).map(_.toLong))
     elems.foreach { elem =>
       map.chunkmapDoPut(elem)
@@ -420,7 +449,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
     // elements, which do end up getting tested with these parameters.
 
     val rnd = new java.util.Random(8675309)
-    val map = new ChunkMap(memFactory, 4)
+    val map = new ChunkMap(4) {
+      def memFactory = nmm
+    }
     val set = new HashSet[Long]()
 
     var size = 0
@@ -451,7 +482,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
   }
 
   it("should support uncontended locking behavior") {
-    val map = new ChunkMap(memFactory, 32)
+    val map = new ChunkMap(32) {
+      def memFactory = nmm
+    }
 
     map.chunkmapAcquireExclusive()
     map.chunkmapReleaseExclusive()
@@ -477,7 +510,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
   }
 
   it("should support exclusive lock") {
-    val map = new ChunkMap(memFactory, 32)
+    val map = new ChunkMap(32) {
+      def memFactory = nmm
+    }
 
     map.chunkmapAcquireExclusive()
 
@@ -513,7 +548,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
   }
 
   it("should block exclusive lock when shared lock is held") {
-    val map = new ChunkMap(memFactory, 32)
+    val map = new ChunkMap(32) {
+      def memFactory = nmm
+    }
 
     map.chunkmapAcquireShared()
     map.chunkmapAcquireShared()
@@ -559,7 +596,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
   }
 
   it("should block shared lock when exclusive lock is held") {
-    val map = new ChunkMap(memFactory, 32)
+    val map = new ChunkMap(32) {
+      def memFactory = nmm
+    }
 
     map.chunkmapAcquireExclusive()
 
@@ -605,7 +644,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
   }
 
   it("should delay shared lock when exclusive lock is waiting") {
-    val map = new ChunkMap(memFactory, 32)
+    val map = new ChunkMap(32) {
+      def memFactory = nmm
+    }
 
     map.chunkmapAcquireShared()
 
@@ -660,7 +701,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
   }
 
   it("should release all shared locks held by the current thread") {
-    val map = new ChunkMap(memFactory, 32)
+    val map = new ChunkMap(32) {
+      def memFactory = nmm
+    }
 
     map.chunkmapAcquireShared()
     map.chunkmapAcquireShared()
@@ -697,7 +740,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
   }
 
   it("should release all shared locks held for only the current thread") {
-    val map = new ChunkMap(memFactory, 32)
+    val map = new ChunkMap(32) {
+      def memFactory = nmm
+    }
 
     map.chunkmapAcquireShared()
     map.chunkmapAcquireShared()
@@ -752,7 +797,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
   }
 
   it("should support reentrant shared lock when exclusive lock is requested") {
-    val map = new ChunkMap(memFactory, 32)
+    val map = new ChunkMap(32) {
+      def memFactory = nmm
+    }
 
     map.chunkmapAcquireShared()
 
@@ -795,7 +842,9 @@ class ChunkMapTest extends NativeVectorTest with ScalaFutures {
     val mm = new NativeMemoryManager(200)
 
     // Tiny initial capacity.
-    val map = new ChunkMap(mm, 1)
+    val map = new ChunkMap(1) {
+      def memFactory = mm
+    }
 
     val elems = makeElems((0 to 19).map(_.toLong))
     elems.foreach { elem =>

--- a/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/DownsamplerMainSpec.scala
@@ -22,7 +22,7 @@ import filodb.core.GlobalScheduler._
 import filodb.core.MachineMetricsData
 import filodb.core.binaryrecord2.{BinaryRecordRowReader, RecordBuilder, RecordSchema}
 import filodb.core.downsample.{DownsampledTimeSeriesStore, OffHeapMemory}
-import filodb.core.memstore.{PagedReadablePartition, TimeSeriesPartition}
+import filodb.core.memstore.{PagedReadablePartition, TimeSeriesPartition, TimeSeriesShardInfo}
 import filodb.core.memstore.FiloSchedulers.QuerySchedName
 import filodb.core.metadata.{Dataset, Schemas}
 import filodb.core.query._
@@ -65,6 +65,8 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
 
   val offheapMem = new OffHeapMemory(Seq(Schemas.gauge, Schemas.promCounter, Schemas.promHistogram, Schemas.untyped),
                                      Map.empty, 100, rawDataStoreConfig)
+  val shardInfo = TimeSeriesShardInfo(0, batchDownsampler.shardStats,
+    offheapMem.bufferPools, offheapMem.nativeMemoryManager)
 
   val untypedName = "my_untyped"
   var untypedPartKeyBytes: Array[Byte] = _
@@ -112,9 +114,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
     val partKey = partBuilder.partKeyFromObjects(Schemas.untyped, untypedName, seriesTags)
 
-    val part = new TimeSeriesPartition(0, Schemas.untyped, partKey,
-      0, offheapMem.bufferPools(Schemas.untyped.schemaHash), batchDownsampler.shardStats,
-      offheapMem.nativeMemoryManager, 1)
+    val part = new TimeSeriesPartition(0, Schemas.untyped, partKey, shardInfo, 1)
 
     untypedPartKeyBytes = part.partKeyBytes
 
@@ -155,9 +155,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
     val partKey = partBuilder.partKeyFromObjects(Schemas.gauge, gaugeName, seriesTags)
 
-    val part = new TimeSeriesPartition(0, Schemas.gauge, partKey,
-      0, offheapMem.bufferPools(Schemas.gauge.schemaHash), batchDownsampler.shardStats,
-      offheapMem.nativeMemoryManager, 1)
+    val part = new TimeSeriesPartition(0, Schemas.gauge, partKey, shardInfo,1)
 
     gaugePartKeyBytes = part.partKeyBytes
 
@@ -198,9 +196,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
     val partKey = partBuilder.partKeyFromObjects(Schemas.gauge, gaugeLowFreqName, seriesTags)
 
-    val part = new TimeSeriesPartition(0, Schemas.gauge, partKey,
-      0, offheapMem.bufferPools(Schemas.gauge.schemaHash), batchDownsampler.shardStats,
-      offheapMem.nativeMemoryManager, 1)
+    val part = new TimeSeriesPartition(0, Schemas.gauge, partKey, shardInfo, 1)
 
     gaugeLowFreqPartKeyBytes = part.partKeyBytes
 
@@ -239,9 +235,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
     val partKey = partBuilder.partKeyFromObjects(Schemas.promCounter, counterName, seriesTags)
 
-    val part = new TimeSeriesPartition(0, Schemas.promCounter, partKey,
-      0, offheapMem.bufferPools(Schemas.promCounter.schemaHash), batchDownsampler.shardStats,
-      offheapMem.nativeMemoryManager, 1)
+    val part = new TimeSeriesPartition(0, Schemas.promCounter, partKey, shardInfo, 1)
 
     counterPartKeyBytes = part.partKeyBytes
 
@@ -286,9 +280,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
     val partKey = partBuilder.partKeyFromObjects(Schemas.promHistogram, histName, seriesTags)
 
-    val part = new TimeSeriesPartition(0, Schemas.promHistogram, partKey,
-      0, offheapMem.bufferPools(Schemas.promHistogram.schemaHash), batchDownsampler.shardStats,
-      offheapMem.nativeMemoryManager, 1)
+    val part = new TimeSeriesPartition(0, Schemas.promHistogram, partKey, shardInfo, 1)
 
     histPartKeyBytes = part.partKeyBytes
 
@@ -334,9 +326,7 @@ class DownsamplerMainSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
     val partKey = partBuilder.partKeyFromObjects(Schemas.promHistogram, histNameNaN, seriesTagsNaN)
 
-    val part = new TimeSeriesPartition(0, Schemas.promHistogram, partKey,
-      0, offheapMem.bufferPools(Schemas.promHistogram.schemaHash), batchDownsampler.shardStats,
-      offheapMem.nativeMemoryManager, 1)
+    val part = new TimeSeriesPartition(0, Schemas.promHistogram, partKey, shardInfo, 1)
 
     histNaNPartKeyBytes = part.partKeyBytes
 

--- a/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/repair/PartitionKeysCopierSpec.scala
@@ -3,6 +3,7 @@ package filodb.repair
 import java.io.File
 import java.time.Instant
 import java.time.format.DateTimeFormatter
+
 import com.typesafe.config.{ConfigFactory, ConfigRenderOptions}
 import monix.reactive.Observable
 import org.apache.spark.SparkConf
@@ -11,15 +12,15 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
-
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
+
 import filodb.cassandra.DefaultFiloSessionProvider
 import filodb.cassandra.columnstore.CassandraColumnStore
 import filodb.core.GlobalConfig
 import filodb.core.binaryrecord2.RecordBuilder
 import filodb.core.downsample.OffHeapMemory
-import filodb.core.memstore.{TimeSeriesPartition, TimeSeriesShardStats}
+import filodb.core.memstore.{TimeSeriesPartition, TimeSeriesShardInfo, TimeSeriesShardStats}
 import filodb.core.metadata.{Dataset, Schema, Schemas}
 import filodb.core.store.{PartKeyRecord, StoreConfig}
 import filodb.memory.format.ZeroCopyUTF8String._
@@ -148,9 +149,8 @@ class PartitionKeysCopierSpec extends AnyFunSpec with Matchers with BeforeAndAft
                     seriesTags: Map[ZeroCopyUTF8String, ZeroCopyUTF8String]): TimeSeriesPartition = {
       val partBuilder = new RecordBuilder(offheapMem.nativeMemoryManager)
       val partKey = partBuilder.partKeyFromObjects(schema, gaugeName, seriesTags)
-      val part = new TimeSeriesPartition(0, schema, partKey,
-        0, offheapMem.bufferPools(schema.schemaHash), shardStats,
-        offheapMem.nativeMemoryManager, 1)
+      val shardInfo = TimeSeriesShardInfo(0, shardStats, offheapMem.bufferPools, offheapMem.nativeMemoryManager)
+      val part = new TimeSeriesPartition(0, schema, partKey, shardInfo, 1)
       part
     }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Reduce number of stored fields in TSP object by 20 bytes. If there are 16mil TSP
objects on the heap, this gives a savings of 320 MB

Existing unit tests updated.