### PR TITLE
fix(query) Double counting of metrics in cases of shard migration

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -275,13 +275,10 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
   def scanPartitions(lookup: PartLookupResult,
                      colIds: Seq[Types.ColumnId],
                      querySession: QuerySession): Observable[ReadablePartition] = {
-
     // Step 1: Choose the downsample level depending on the range requested
     val (resolutionMs, downsampledDataset) = chooseDownsampleResolution(lookup.chunkMethod)
     logger.debug(s"Chose resolution $downsampledDataset for chunk method ${lookup.chunkMethod}")
-
     capDataScannedPerShardCheck(lookup, resolutionMs)
-
     // Step 2: Query Cassandra table for that downsample level using downsampleColStore
     // Create a ReadablePartition objects that contain the time series data. This can be either a
     // PagedReadablePartitionOnHeap or PagedReadablePartitionOffHeap. This will be garbage collected/freed


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

The Raw partition reads need to honor the start time in the index. Suppose, the shards for the time series is migrated, the time series will show up in two shards but not in both at any given point in  time. However if the start and end date range cover the point in time when the shard migration occurred, and if both shards query for the same user provided time range, we will have the same data returned twice. Current implementation follows this behavior and returns the same data from multiple shards. 


**New behavior :**
If the shards return the data for time duration they owned the data we will not have duplicates. The changes fixes this issue to a great extent. There still are cases in ``DownsampledTimeSeriesShard`` where we will get overlaps (mentioned in code comments) and also in cases when we do ODP in raw data.


