### PR TITLE
bug(query): Remote query not returning custom response for HAPlanner

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -79,7 +79,7 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
           val promQlParams = PromQlQueryParams(queryParams.promQl,
             (timeRange.startMs + offsetMs.max) / 1000, queryParams.stepSecs, (timeRange.endMs + offsetMs.min) / 1000)
           val newQueryContext = qContext.copy(origQueryParams = promQlParams, plannerParams = qContext.plannerParams.
-            copy(processFailure = false) )
+            copy(processFailure = false, processMultiPartition = false) )
           logger.debug("PromQlExec params:" + promQlParams)
           val httpEndpoint = remoteHttpEndpoint + queryParams.remoteQueryPath.getOrElse("")
           rootLogicalPlan match {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
While creating RemoteExec in HAPlanner, `processMultiPartition` is not set to false. Hence the query response from remote servers are not having custom response string for label/values queries and few aggregate queries, resulting in DecodeFailures in RemoteExec.

**New behavior :**
HAPlanner sets `processMultiPartition` to true to let remote servers to respond with custom response.
