### PR TITLE
fix(query): make QueryStatistics `samplesScanned` optional

### DIFF
--- a/query/src/main/scala/filodb/query/PromCirceSupport.scala
+++ b/query/src/main/scala/filodb/query/PromCirceSupport.scala
@@ -138,7 +138,8 @@ object PromCirceSupport {
         resultBytes       <- c.downField("resultBytes").as[Long]
         cpuNanos          <- c.downField("cpuNanos").as[Option[Long]] // option to be backward compatible
       } yield {
-        QueryStatistics(group, timeSeriesScanned, dataBytesScanned, samplesScanned, resultBytes, cpuNanos.getOrElse(0))
+        QueryStatistics(group, timeSeriesScanned, dataBytesScanned, samplesScanned.getOrElse(0), resultBytes,
+          cpuNanos.getOrElse(0))
       }
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**
Treat samplesScanned as Option[Long] in JSON decoding, mirroring cpuNanos.
Default to 0L when the field is absent to preserve compatibility with older payloads.