### PR TITLE
feat(query): Do not optimize latest instant queries since agg data would not be ready

### DIFF
--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/AggLpOptimizationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/AggLpOptimizationSpec.scala
@@ -299,6 +299,15 @@ class AggLpOptimizationSpec extends AnyFunSpec with Matchers {
     }
   }
 
+  it("should not optimize instant queries within latest minute") {
+    val query = """sum(rate(foo{_ws_="demo",_ns_="localNs"}[300s]))"""
+    val now = System.currentTimeMillis() / 1000
+    val lp = Parser.queryToLogicalPlan(query, now, step, Antlr)
+    val arp = newProvider(excludeRules1)
+    val optimized = lp.useHigherLevelAggregatedMetric(arp)
+    LogicalPlanParser.convertToQuery(optimized) shouldEqual query
+  }
+
   it("should not optimize when no_optimize function is set") {
     val testCases = Seq(
       // same
@@ -362,4 +371,5 @@ class AggLpOptimizationSpec extends AnyFunSpec with Matchers {
     val optimized = lp.useHigherLevelAggregatedMetric(arp)
     LogicalPlanParser.convertToQuery(optimized) shouldEqual query
   }
+
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Do not optimize latest instant queries with aggregated data since agg data would not be ready and it lags by a minute or so