### PR TITLE
fix(core): Adding a check to prevent segv while accessing non-existent columns

### DIFF
--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -175,17 +175,17 @@ trait ChunkSource extends RawChunkSource with StrictLogging {
       lookupRes.firstSchemaId match {
         case Some(reqSchemaId) =>
           scanPartitions(ref, lookupRes, columnIDs, querySession).filter { p =>
-            // short term fix to prevent segv which occurs when we access non-existent columns
-            // while querying histograms that have max and min columns
-            require(columnIDs.forall(id => id < p.schema.data.columns.size), "Internal error - " +
-              "seeking non-existent columns; For now, add filter such as _type_=\"otel-delta-histogram\"" +
-              " to the query while this issue is being fixed")
             if (!Utils.doesSchemaMatchOrBackCompatibleHistograms(
                   p.schema.name, p.schema.schemaHash, // current partition
                   Schemas.global.schemaName(reqSchemaId), reqSchemaId) // requested schema
             ) {
               throw SchemaMismatch(Schemas.global.schemaName(reqSchemaId), p.schema.name, getClass.getSimpleName)
             }
+            // short term fix to prevent segv which occurs when we access non-existent columns
+            // while querying histograms that have max and min columns
+            require(columnIDs.forall(id => id < p.schema.data.columns.size), "Internal error - " +
+              "seeking non-existent columns; For now, add filter such as _type_=\"otel-delta-histogram\"" +
+              " to the query while this issue is being fixed")
             p.hasChunks(lookupRes.chunkMethod)
           }
         case None =>


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Adding a check to prevent segv while accessing non-existent columns
This happens when customers migrate from prom-histogram to otel histograms which have max and min columns