### PR TITLE
feat(core): TimeSeriesShard billable cardinalities

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/TenantIngestionMetering.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/TenantIngestionMetering.scala
@@ -42,6 +42,7 @@ case class TenantIngestionMetering(settings: FilodbSettings,
   private val FILODB_PARTITION = settings.config.getString("partition")
 
   private val METRIC_ACTIVE = "tsdb_metering_active_timeseries"
+  private val METRIC_BILLABLE = "tsdb_metering_billable_timeseries"
   private val METRIC_TOTAL = "tsdb_metering_total_timeseries"
   private val METRIC_LONGTERM = "tsdb_metering_longterm_timeseries"
 
@@ -96,6 +97,7 @@ case class TenantIngestionMetering(settings: FilodbSettings,
             }
             else {
               FilodbMetrics.gauge(METRIC_ACTIVE, tags).update(data.counts.active.toDouble)
+              FilodbMetrics.gauge(METRIC_BILLABLE, tags).update(data.counts.billable.toDouble)
               FilodbMetrics.gauge(METRIC_TOTAL, tags).update(data.counts.shortTerm.toDouble)
             }
           })

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -1410,7 +1410,7 @@ kamon {
   }
 
   cardinality {
-    schema-name-to-virtual-cardinality-per-series {
+    schema-name-to-virtual-active-cardinality-per-series {
       # All non-exponential histograms.
       prom-histogram              = 25
       delta-histogram             = 25

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -1408,4 +1408,22 @@ kamon {
     # Set to true to publish label stats to Kafka.
     publish-to-kafka = false
   }
+
+  cardinality {
+    schema-name-to-virtual-cardinality-per-series {
+      # All non-exponential histograms.
+      prom-histogram              = 25
+      delta-histogram             = 25
+      otel-cumulative-histogram   = 25
+      otel-delta-histogram        = 25
+      delta-histogram-v2          = 25
+      preagg-delta-histogram      = 25
+      preagg-otel-delta-histogram = 25
+      preagg-delta-histogram-v2   = 25
+
+      # All exponential histograms.
+      otel-exp-delta-histogram        = 50
+      preagg-otel-exp-delta-histogram = 50
+    }
+  }
 }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -1410,20 +1410,20 @@ kamon {
   }
 
   cardinality {
-    schema-name-to-virtual-active-cardinality-per-series {
+    schema-name-to-billable-cardinality-per-active-series {
       # All non-exponential histograms.
-      prom-histogram              = 25
-      delta-histogram             = 25
-      otel-cumulative-histogram   = 25
-      otel-delta-histogram        = 25
-      delta-histogram-v2          = 25
-      preagg-delta-histogram      = 25
-      preagg-otel-delta-histogram = 25
-      preagg-delta-histogram-v2   = 25
+      prom-histogram              = 15
+      delta-histogram             = 15
+      otel-cumulative-histogram   = 15
+      otel-delta-histogram        = 15
+      delta-histogram-v2          = 15
+      preagg-delta-histogram      = 15
+      preagg-otel-delta-histogram = 15
+      preagg-delta-histogram-v2   = 15
 
       # All exponential histograms.
-      otel-exp-delta-histogram        = 50
-      preagg-otel-exp-delta-histogram = 50
+      otel-exp-delta-histogram        = 30
+      preagg-otel-exp-delta-histogram = 30
     }
   }
 }

--- a/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
+++ b/core/src/main/scala/filodb.core/memstore/PartKeyLuceneIndex.scala
@@ -867,7 +867,7 @@ class CardinalityCountBuilder(partSchema: PartitionSchema, cardTracker: Cardinal
 
       try {
         // update the cardinality count by 1, since the shardKey for each document in index is unique
-        cardTracker.modifyCount(shardKey, 1, 0)
+        cardTracker.modifyCount(shardKey, 1, 0, 0)
       } catch {
         case t: Throwable =>
           logger.error("exception while modifying cardinality tracker count; shardKey=" + shardKey, t)

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -312,12 +312,13 @@ class TimeSeriesShard(val ref: DatasetRef,
   private val partKeyUpdatesPublishingEnabled = filodbConfig.getBoolean("memstore.index-updates-publishing-enabled")
 
   /**
-    * Active cardinality counts are updated according to the multipliers defined here.
-    * For example: if one prom-histogram series maps to 25 "virtual" series, then cardinality
-    *   counters will increment/decrement by 25 for each series accounted/unaccounted for.
+   * Billable cardinality counts are updated according to the multipliers returned here.
+   * For example: if one prom-histogram series maps to 25 "billable" series per "physical"
+   *   active series, then cardinality counters will increment/decrement by 25 for
+   *   each series accounted/unaccounted for.
     */
-  private val schemaNameToVirtualActiveCardinalityPerSeries =
-    filodbConfig.getConfig("cardinality.schema-name-to-virtual-active-cardinality-per-series")
+  val schemaNameToBillableCardinalityPerActiveSeries =
+    filodbConfig.getConfig("cardinality.schema-name-to-billable-cardinality-per-active-series")
       .entrySet().asScala.map { entry =>
         entry.getKey -> entry.getValue.unwrapped.asInstanceOf[Int]
       }.toMap
@@ -1222,35 +1223,30 @@ class TimeSeriesShard(val ref: DatasetRef,
   }
 
   /**
-   * Active cardinality counts are updated according to the multipliers returned here.
-   * For example: if one prom-histogram series maps to 25 "virtual" series, then cardinality
-   *   counters will increment/decrement by 25 for each series accounted/unaccounted for.
+   * Billable cardinality counts are updated according to the multipliers returned here.
+   * For example: if one prom-histogram series maps to 25 "billable" series per "physical"
+   *   active series, then cardinality counters will increment/decrement by 25 for
+   *   each series accounted/unaccounted for.
    */
-  private def getVirtualActiveCardinalityPerSeries(schema: Schema): Int = {
-    schemaNameToVirtualActiveCardinalityPerSeries.getOrElse(schema.name, 1)
+  private def getBillableCardinalityPerActiveSeries(schema: Schema): Int = {
+    schemaNameToBillableCardinalityPerActiveSeries.getOrElse(schema.name, 1)
   }
 
   /**
    * Modifies the cardinality count.
-   * @param totalDelta the "physical" delta; will *not* be multiplied by any factor.
-   * @param activeDelta the "physical" delta; will be multiplied according to
-   *                    [[getVirtualActiveCardinalityPerSeries()]].
    */
   private def modifyCardinalityCount(shardKey: Seq[String],
                                      schema: Schema,
                                      totalDelta: Int,
                                      activeDelta: Int): Unit = {
-    val virtualCardinalityPerSeries = getVirtualActiveCardinalityPerSeries(schema)
-    val virtualActiveDelta = activeDelta * virtualCardinalityPerSeries
-    cardTracker.modifyCount(shardKey, totalDelta, virtualActiveDelta)
+    val billableCardinalityPerSeries = getBillableCardinalityPerActiveSeries(schema)
+    val billableDelta = activeDelta * billableCardinalityPerSeries
+    cardTracker.modifyCount(shardKey, totalDelta, activeDelta, billableDelta)
   }
 
   /**
    * Modifies the cardinality count and catches/logs any exceptions.
    * Should only be used where an exception would otherwise cause ingestion/boostrap to fail.
-   * @param totalDelta the "physical" delta; will *not* be multiplied by any factor.
-   * @param activeDelta the "physical" delta; will be multiplied according to
-   *                    [[getVirtualActiveCardinalityPerSeries()]].
    */
   private def modifyCardinalityCountNoThrow(shardKey: Seq[String],
                                             schema: Schema,

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -311,6 +311,17 @@ class TimeSeriesShard(val ref: DatasetRef,
   // Configuration to enable/disable real-time publishing of index updates for downstream consumers.
   private val partKeyUpdatesPublishingEnabled = filodbConfig.getBoolean("memstore.index-updates-publishing-enabled")
 
+  /**
+    * Cardinality counts are updated according to the multipliers defined here.
+    * For example: if one prom-histogram series maps to 25 "virtual" series, then cardinality
+    *   counters will increment/decrement by 25 for each series accounted/unaccounted for.
+    */
+  private val schemaNameToVirtualCardinalityPerSeries =
+    filodbConfig.getConfig("cardinality.schema-name-to-virtual-cardinality-per-series")
+      .entrySet().asScala.map { entry =>
+        entry.getKey -> entry.getValue.unwrapped.asInstanceOf[Int]
+      }.toMap
+
   /////// END CONFIGURATION FIELDS ///////////////////
 
   /////// START MEMBER STATE FIELDS ///////////////////
@@ -833,7 +844,7 @@ class TimeSeriesShard(val ref: DatasetRef,
       if (storeConfig.meteringEnabled) {
         val shardKey = schema.partKeySchema.colValues(pk.partKey, UnsafeUtils.arayOffset,
           schema.options.shardKeyColumns)
-        modifyCardinalityCountNoThrow(shardKey, 1, if (pk.endTime == Long.MaxValue) 1 else 0)
+        modifyVirtualCardinalityCountNoThrow(shardKey, schema, 1, if (pk.endTime == Long.MaxValue) 1 else 0)
       }
     }
     partId
@@ -1001,7 +1012,7 @@ class TimeSeriesShard(val ref: DatasetRef,
         if (storeConfig.meteringEnabled) {
           val shardKey = p.schema.partKeySchema.colValues(p.partKeyBase, p.partKeyOffset,
                                                           p.schema.options.shardKeyColumns)
-          cardTracker.modifyCount(shardKey, 0, -1)
+          modifyVirtualCardinalityCount(shardKey, p.schema, 0, -1)
         }
       }
     }
@@ -1081,13 +1092,13 @@ class TimeSeriesShard(val ref: DatasetRef,
         updatedPartIdsForPublishing.foreach(publisher => publisher.store(partId))
         shardStats.partKeyIndexAdded.increment()
         if (storeConfig.meteringEnabled) {
-          modifyCardinalityCountNoThrow(shardKey, 1, 1)
+          modifyVirtualCardinalityCountNoThrow(shardKey, schema, 1, 1)
         }
       } else {
         // newly created partition is re-ingesting now, so update endTime
         updatePartEndTimeInIndex(newPart, Long.MaxValue)
         if (storeConfig.meteringEnabled) {
-          modifyCardinalityCountNoThrow(shardKey, 0, 1)
+          modifyVirtualCardinalityCountNoThrow(shardKey, schema, 0, 1)
           // TODO remove temporary debugging since we were seeing some negative counts when this increment was absent
           if (partId % 100 < 5) { // log for 5% of the cases
             logger.info(s"Increment activeDelta for ${newPart.stringPartition}")
@@ -1150,7 +1161,7 @@ class TimeSeriesShard(val ref: DatasetRef,
               val shardKey = tsp.schema.partKeySchema.colValues(tsp.partKeyBase, tsp.partKeyOffset,
                 tsp.schema.options.shardKeyColumns)
               if (storeConfig.meteringEnabled) {
-                modifyCardinalityCountNoThrow(shardKey, 0, 1)
+                modifyVirtualCardinalityCountNoThrow(shardKey, schema, 0, 1)
               }
             }
           }
@@ -1211,18 +1222,51 @@ class TimeSeriesShard(val ref: DatasetRef,
   }
 
   /**
-   * Modifies a cardinality count and catches/logs any exceptions.
-   * Should only be used where an exception would otherwise cause ingestion/boostrap to fail.
+   * Cardinality counts are updated according to the multipliers returned here.
+   * For example: if one prom-histogram series maps to 25 "virtual" series, then cardinality
+   *   counters will increment/decrement by 25 for each series accounted/unaccounted for.
    */
-  private def modifyCardinalityCountNoThrow(shardKey: Seq[String],
+  private def getVirtualCardinalityPerSeries(schema: Schema): Int = {
+    schemaNameToVirtualCardinalityPerSeries.getOrElse(schema.name, 1)
+  }
+
+  /**
+   * Modifies a "virtual" cardinality count.
+   */
+  private def modifyVirtualCardinalityCount(shardKey: Seq[String],
+                                            schema: Schema,
                                             totalDelta: Int,
                                             activeDelta: Int): Unit = {
+    val virtualCardinalityPerSeries = getVirtualCardinalityPerSeries(schema)
+    val virtualTotalDelta = totalDelta * virtualCardinalityPerSeries
+    val virtualActiveDelta = activeDelta * virtualCardinalityPerSeries
+    cardTracker.modifyCount(shardKey, virtualTotalDelta, virtualActiveDelta)
+  }
+
+  /**
+   * Modifies a "virtual" cardinality count and catches/logs any exceptions.
+   * Should only be used where an exception would otherwise cause ingestion/boostrap to fail.
+   */
+  private def modifyVirtualCardinalityCountNoThrow(shardKey: Seq[String],
+                                                   schema: Schema,
+                                                   totalDelta: Int,
+                                                   activeDelta: Int): Unit = {
     try {
-      cardTracker.modifyCount(shardKey, totalDelta, activeDelta)
+      modifyVirtualCardinalityCount(shardKey, schema, totalDelta, activeDelta)
     } catch {
       case t: Throwable =>
           logger.error("exception while modifying cardinality tracker count; shardKey=" + shardKey, t)
     }
+  }
+
+  /**
+   * Decrements a "virtual" cardinality count.
+   */
+  private def decrementVirtualCardinalityCount(shardKey: Seq[String],
+                                               schema: Schema): Unit = {
+
+    val virtualCardinalityPerSeries = getVirtualCardinalityPerSeries(schema)
+    cardTracker.decrementCount(shardKey, virtualCardinalityPerSeries)
   }
 
   /////// END SHARD INGESTION METHODS ///////////////////
@@ -1273,7 +1317,7 @@ class TimeSeriesShard(val ref: DatasetRef,
         val shardKey = schema.partKeySchema.colValues(p.partKeyBase, p.partKeyOffset, schema.options.shardKeyColumns)
         if (storeConfig.meteringEnabled) {
           try {
-            cardTracker.decrementCount(shardKey)
+            decrementVirtualCardinalityCount(shardKey, schema)
           } catch { case e: Exception =>
             logger.error("Got exception when reducing cardinality in tracker", e)
           }
@@ -1290,7 +1334,7 @@ class TimeSeriesShard(val ref: DatasetRef,
           schemas.part.options.shardKeyColumns)
         if (storeConfig.meteringEnabled) {
           try {
-            cardTracker.decrementCount(shardKey)
+            decrementVirtualCardinalityCount(shardKey, schema)
           } catch { case e: Exception =>
             logger.error("Got exception when reducing cardinality in tracker", e)
           }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -312,12 +312,12 @@ class TimeSeriesShard(val ref: DatasetRef,
   private val partKeyUpdatesPublishingEnabled = filodbConfig.getBoolean("memstore.index-updates-publishing-enabled")
 
   /**
-    * Cardinality counts are updated according to the multipliers defined here.
+    * Active cardinality counts are updated according to the multipliers defined here.
     * For example: if one prom-histogram series maps to 25 "virtual" series, then cardinality
     *   counters will increment/decrement by 25 for each series accounted/unaccounted for.
     */
-  private val schemaNameToVirtualCardinalityPerSeries =
-    filodbConfig.getConfig("cardinality.schema-name-to-virtual-cardinality-per-series")
+  private val schemaNameToVirtualActiveCardinalityPerSeries =
+    filodbConfig.getConfig("cardinality.schema-name-to-virtual-active-cardinality-per-series")
       .entrySet().asScala.map { entry =>
         entry.getKey -> entry.getValue.unwrapped.asInstanceOf[Int]
       }.toMap
@@ -844,7 +844,7 @@ class TimeSeriesShard(val ref: DatasetRef,
       if (storeConfig.meteringEnabled) {
         val shardKey = schema.partKeySchema.colValues(pk.partKey, UnsafeUtils.arayOffset,
           schema.options.shardKeyColumns)
-        modifyVirtualCardinalityCountNoThrow(shardKey, schema, 1, if (pk.endTime == Long.MaxValue) 1 else 0)
+        modifyCardinalityCountNoThrow(shardKey, schema, 1, if (pk.endTime == Long.MaxValue) 1 else 0)
       }
     }
     partId
@@ -1012,7 +1012,7 @@ class TimeSeriesShard(val ref: DatasetRef,
         if (storeConfig.meteringEnabled) {
           val shardKey = p.schema.partKeySchema.colValues(p.partKeyBase, p.partKeyOffset,
                                                           p.schema.options.shardKeyColumns)
-          modifyVirtualCardinalityCount(shardKey, p.schema, 0, -1)
+          modifyCardinalityCount(shardKey, p.schema, 0, -1)
         }
       }
     }
@@ -1092,13 +1092,13 @@ class TimeSeriesShard(val ref: DatasetRef,
         updatedPartIdsForPublishing.foreach(publisher => publisher.store(partId))
         shardStats.partKeyIndexAdded.increment()
         if (storeConfig.meteringEnabled) {
-          modifyVirtualCardinalityCountNoThrow(shardKey, schema, 1, 1)
+          modifyCardinalityCountNoThrow(shardKey, schema, 1, 1)
         }
       } else {
         // newly created partition is re-ingesting now, so update endTime
         updatePartEndTimeInIndex(newPart, Long.MaxValue)
         if (storeConfig.meteringEnabled) {
-          modifyVirtualCardinalityCountNoThrow(shardKey, schema, 0, 1)
+          modifyCardinalityCountNoThrow(shardKey, schema, 0, 1)
           // TODO remove temporary debugging since we were seeing some negative counts when this increment was absent
           if (partId % 100 < 5) { // log for 5% of the cases
             logger.info(s"Increment activeDelta for ${newPart.stringPartition}")
@@ -1161,7 +1161,7 @@ class TimeSeriesShard(val ref: DatasetRef,
               val shardKey = tsp.schema.partKeySchema.colValues(tsp.partKeyBase, tsp.partKeyOffset,
                 tsp.schema.options.shardKeyColumns)
               if (storeConfig.meteringEnabled) {
-                modifyVirtualCardinalityCountNoThrow(shardKey, schema, 0, 1)
+                modifyCardinalityCountNoThrow(shardKey, schema, 0, 1)
               }
             }
           }
@@ -1222,51 +1222,46 @@ class TimeSeriesShard(val ref: DatasetRef,
   }
 
   /**
-   * Cardinality counts are updated according to the multipliers returned here.
+   * Active cardinality counts are updated according to the multipliers returned here.
    * For example: if one prom-histogram series maps to 25 "virtual" series, then cardinality
    *   counters will increment/decrement by 25 for each series accounted/unaccounted for.
    */
-  private def getVirtualCardinalityPerSeries(schema: Schema): Int = {
-    schemaNameToVirtualCardinalityPerSeries.getOrElse(schema.name, 1)
+  private def getVirtualActiveCardinalityPerSeries(schema: Schema): Int = {
+    schemaNameToVirtualActiveCardinalityPerSeries.getOrElse(schema.name, 1)
   }
 
   /**
-   * Modifies a "virtual" cardinality count.
+   * Modifies the cardinality count.
+   * @param totalDelta the "physical" delta; will *not* be multiplied by any factor.
+   * @param activeDelta the "physical" delta; will be multiplied according to
+   *                    [[getVirtualActiveCardinalityPerSeries()]].
    */
-  private def modifyVirtualCardinalityCount(shardKey: Seq[String],
+  private def modifyCardinalityCount(shardKey: Seq[String],
+                                     schema: Schema,
+                                     totalDelta: Int,
+                                     activeDelta: Int): Unit = {
+    val virtualCardinalityPerSeries = getVirtualActiveCardinalityPerSeries(schema)
+    val virtualActiveDelta = activeDelta * virtualCardinalityPerSeries
+    cardTracker.modifyCount(shardKey, totalDelta, virtualActiveDelta)
+  }
+
+  /**
+   * Modifies the cardinality count and catches/logs any exceptions.
+   * Should only be used where an exception would otherwise cause ingestion/boostrap to fail.
+   * @param totalDelta the "physical" delta; will *not* be multiplied by any factor.
+   * @param activeDelta the "physical" delta; will be multiplied according to
+   *                    [[getVirtualActiveCardinalityPerSeries()]].
+   */
+  private def modifyCardinalityCountNoThrow(shardKey: Seq[String],
                                             schema: Schema,
                                             totalDelta: Int,
                                             activeDelta: Int): Unit = {
-    val virtualCardinalityPerSeries = getVirtualCardinalityPerSeries(schema)
-    val virtualTotalDelta = totalDelta * virtualCardinalityPerSeries
-    val virtualActiveDelta = activeDelta * virtualCardinalityPerSeries
-    cardTracker.modifyCount(shardKey, virtualTotalDelta, virtualActiveDelta)
-  }
-
-  /**
-   * Modifies a "virtual" cardinality count and catches/logs any exceptions.
-   * Should only be used where an exception would otherwise cause ingestion/boostrap to fail.
-   */
-  private def modifyVirtualCardinalityCountNoThrow(shardKey: Seq[String],
-                                                   schema: Schema,
-                                                   totalDelta: Int,
-                                                   activeDelta: Int): Unit = {
     try {
-      modifyVirtualCardinalityCount(shardKey, schema, totalDelta, activeDelta)
+      modifyCardinalityCount(shardKey, schema, totalDelta, activeDelta)
     } catch {
       case t: Throwable =>
           logger.error("exception while modifying cardinality tracker count; shardKey=" + shardKey, t)
     }
-  }
-
-  /**
-   * Decrements a "virtual" cardinality count.
-   */
-  private def decrementVirtualCardinalityCount(shardKey: Seq[String],
-                                               schema: Schema): Unit = {
-
-    val virtualCardinalityPerSeries = getVirtualCardinalityPerSeries(schema)
-    cardTracker.decrementCount(shardKey, virtualCardinalityPerSeries)
   }
 
   /////// END SHARD INGESTION METHODS ///////////////////
@@ -1317,7 +1312,7 @@ class TimeSeriesShard(val ref: DatasetRef,
         val shardKey = schema.partKeySchema.colValues(p.partKeyBase, p.partKeyOffset, schema.options.shardKeyColumns)
         if (storeConfig.meteringEnabled) {
           try {
-            decrementVirtualCardinalityCount(shardKey, schema)
+            cardTracker.decrementCount(shardKey)
           } catch { case e: Exception =>
             logger.error("Got exception when reducing cardinality in tracker", e)
           }
@@ -1334,7 +1329,7 @@ class TimeSeriesShard(val ref: DatasetRef,
           schemas.part.options.shardKeyColumns)
         if (storeConfig.meteringEnabled) {
           try {
-            decrementVirtualCardinalityCount(shardKey, schema)
+            cardTracker.decrementCount(shardKey)
           } catch { case e: Exception =>
             logger.error("Got exception when reducing cardinality in tracker", e)
           }

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -367,7 +367,7 @@ class TimeSeriesShard(val ref: DatasetRef,
     case x => sys.error(s"Unsupported part key index type: '$x'")
   }
 
-  private val cardTracker: CardinalityTracker = initCardTracker()
+  private[memstore] val cardTracker: CardinalityTracker = initCardTracker()
 
   /**
     * Keeps track of count of rows ingested into memstore, not necessarily flushed.
@@ -1235,10 +1235,10 @@ class TimeSeriesShard(val ref: DatasetRef,
   /**
    * Modifies the cardinality count.
    */
-  private def modifyCardinalityCount(shardKey: Seq[String],
-                                     schema: Schema,
-                                     totalDelta: Int,
-                                     activeDelta: Int): Unit = {
+  private[memstore] def modifyCardinalityCount(shardKey: Seq[String],
+                                               schema: Schema,
+                                               totalDelta: Int,
+                                               activeDelta: Int): Unit = {
     val billableCardinalityPerSeries = getBillableCardinalityPerActiveSeries(schema)
     val billableDelta = activeDelta * billableCardinalityPerSeries
     cardTracker.modifyCount(shardKey, totalDelta, activeDelta, billableDelta)

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
@@ -263,24 +263,30 @@ class CardinalityTracker(ref: DatasetRef,
    *
    * @param shardKey elements in the shard key of time series.
    *                 For example: (ws, ns, name). Full shard key is needed.
+   * @param count the count by which cardinality should be reduced; must be > 0.
    * @return current cardinality for each shard key prefix. There
    *         will be shardKeyLen + 1 items in the return value
    */
-  def decrementCount(shardKey: Seq[String]): Seq[CardinalityRecord] = synchronized {
+  def decrementCount(shardKey: Seq[String],
+                     count: Int): Seq[CardinalityRecord] = synchronized {
     // note this method is synchronized since the read-modify-write pattern that happens here is not thread-safe
     // modifyCount and decrementCount methods are protected this way
-
     try {
       require(shardKey.length == shardKeyLen, "full shard key is needed")
+      require(count > 0)
       val toStore = (0 to shardKey.length).map { i =>
         val prefix = shardKey.take(i)
         val old = store.getOrZero(prefix,
           CardinalityRecord(shard, Nil, CardinalityValue(0, 0, 0, defaultChildrenQuota(i))))
-        if (old.value.tsCount == 0)
-          throw new IllegalArgumentException(s"$prefix count is already zero - cannot reduce " +
-            s"further. A double delete likely happened.")
-        val neu = old.copy(value = old.value.copy(tsCount = old.value.tsCount - 1,
-                          childrenCount = if (i == shardKeyLen) old.value.childrenCount-1 else old.value.childrenCount))
+        if (old.value.tsCount - count < 0)
+          throw new IllegalArgumentException(
+            s"$prefix count is already less than $count - " +
+            s"cannot reduce. A double delete likely happened.")
+        val neu = old.copy(
+          value = old.value.copy(tsCount = old.value.tsCount - count,
+          childrenCount = if (i == shardKeyLen) old.value.childrenCount - count
+                          else old.value.childrenCount)
+        )
         (prefix, neu)
       }
       toStore.map { case (prefix, neu) =>

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
@@ -263,30 +263,24 @@ class CardinalityTracker(ref: DatasetRef,
    *
    * @param shardKey elements in the shard key of time series.
    *                 For example: (ws, ns, name). Full shard key is needed.
-   * @param count the count by which cardinality should be reduced; must be > 0.
    * @return current cardinality for each shard key prefix. There
    *         will be shardKeyLen + 1 items in the return value
    */
-  def decrementCount(shardKey: Seq[String],
-                     count: Int): Seq[CardinalityRecord] = synchronized {
+  def decrementCount(shardKey: Seq[String]): Seq[CardinalityRecord] = synchronized {
     // note this method is synchronized since the read-modify-write pattern that happens here is not thread-safe
     // modifyCount and decrementCount methods are protected this way
+
     try {
       require(shardKey.length == shardKeyLen, "full shard key is needed")
-      require(count > 0)
       val toStore = (0 to shardKey.length).map { i =>
         val prefix = shardKey.take(i)
         val old = store.getOrZero(prefix,
           CardinalityRecord(shard, Nil, CardinalityValue(0, 0, 0, defaultChildrenQuota(i))))
-        if (old.value.tsCount - count < 0)
-          throw new IllegalArgumentException(
-            s"$prefix count is already less than $count - " +
-            s"cannot reduce. A double delete likely happened.")
-        val neu = old.copy(
-          value = old.value.copy(tsCount = old.value.tsCount - count,
-          childrenCount = if (i == shardKeyLen) old.value.childrenCount - count
-                          else old.value.childrenCount)
-        )
+        if (old.value.tsCount == 0)
+          throw new IllegalArgumentException(s"$prefix count is already zero - cannot reduce " +
+            s"further. A double delete likely happened.")
+        val neu = old.copy(value = old.value.copy(tsCount = old.value.tsCount - 1,
+                          childrenCount = if (i == shardKeyLen) old.value.childrenCount-1 else old.value.childrenCount))
         (prefix, neu)
       }
       toStore.map { case (prefix, neu) =>

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/CardinalityTracker.scala
@@ -53,6 +53,12 @@ class CardinalityTracker(ref: DatasetRef,
   /**
    * Map used to track cardinality count in aggregated manner. This helps us to avoid frequent reads and writes to
    * RocksDB and increase the throughput when storing/measuring cardinality counts in burst scenarios.
+   * Maps key prefixes to tuples of (totalCardinalityDelta, childrenDelta).
+   *
+   * NOTE: As of this writing, this data structure is only made use of by
+   *   [[filodb.core.downsample.DownsampledTimeSeriesShard]];
+   *   [[filodb.core.memstore.TimeSeriesShard]] always initializes its [[CardinalityTracker]] with flushCount=None,
+   *   so [[modifyCountWithAggregation()]] is never invoked (see [[modifyCount()]]) for details.
    */
   private val cardinalityCountMap : collection.mutable.Map[Seq[String], (Int, Int)] = collection.mutable.Map()
 
@@ -65,7 +71,10 @@ class CardinalityTracker(ref: DatasetRef,
    * @return current cardinality for each shard key prefix. There
    *         will be shardKeyLen + 1 items in the return value
    */
-  def modifyCount(shardKey: Seq[String], totalDelta: Int, activeDelta: Int): Seq[CardinalityRecord] = synchronized {
+  def modifyCount(shardKey: Seq[String],
+                  totalDelta: Int,
+                  activeDelta: Int,
+                  billableDelta: Int): Seq[CardinalityRecord] = synchronized {
 
     // note this method is synchronized since the read-modify-write pattern that happens here is not thread-safe
     // modifyCount and decrementCount methods are protected this way
@@ -76,10 +85,17 @@ class CardinalityTracker(ref: DatasetRef,
             totalDelta == 0 && activeDelta == 1 || // existing inactive ts that became active
             totalDelta == 0 && activeDelta == -1,  // existing active ts that became inactive
             "invalid values for totalDelta / activeDelta") // Note: totalDelta = -1 is done via decrementCount method
+    require(
+      activeDelta == 0 && billableDelta == 0
+        || activeDelta == 1 && billableDelta > 0
+        || activeDelta == -1 && billableDelta < 0,
+      s"Invalid values for activeDelta / billableDelta; must have the same sign: " +
+      s"activeDelta=$activeDelta; billableDelta=$billableDelta; shardKey=$shardKey"
+    )
 
     flushCount match {
       case Some(threshold) => modifyCountWithAggregation(shardKey, threshold, totalDelta)
-      case None => modifyCountWithoutAggregation(shardKey, totalDelta, activeDelta)
+      case None => modifyCountWithoutAggregation(shardKey, totalDelta, activeDelta, billableDelta)
     }
   }
 
@@ -93,16 +109,18 @@ class CardinalityTracker(ref: DatasetRef,
    *         will be shardKeyLen + 1 items in the return value
    */
   private def modifyCountWithoutAggregation(shardKey: Seq[String], totalDelta: Int,
-                                            activeDelta: Int): Seq[CardinalityRecord] = {
+                                            activeDelta: Int, billableDelta: Int): Seq[CardinalityRecord] = {
     val toStore = ArrayBuffer[CardinalityRecord]()
     // first make sure there is no breach for any prefix
     (0 to shardKey.length).foreach { i =>
       val prefix = shardKey.take(i)
       val old = store.getOrZero(prefix,
-        CardinalityRecord(shard, prefix, CardinalityValue(0L, 0L, 0L, defaultChildrenQuota(i))))
+        CardinalityRecord(shard, prefix, CardinalityValue(0L, 0L, 0L, 0L, defaultChildrenQuota(i))))
 
-      val neu = old.copy(value = old.value.copy(tsCount = old.value.tsCount + totalDelta,
+      val neu = old.copy(value = old.value.copy(
+        tsCount = old.value.tsCount + totalDelta,
         activeTsCount = old.value.activeTsCount + activeDelta,
+        billableTsCount = old.value.billableTsCount + billableDelta,
         childrenCount = if (i == shardKeyLen) old.value.childrenCount + totalDelta else old.value.childrenCount))
 
       if (i == shardKeyLen && neu.value.tsCount > neu.value.childrenQuota) {
@@ -192,9 +210,12 @@ class CardinalityTracker(ref: DatasetRef,
   def flushCardinalityCount(): Unit = {
     if (cardinalityCountMap.size > 0) {
       // iterate through map and store each prefix and count to the rocksDB
-      cardinalityCountMap.foreach(kv => {
-        storeCardinalityCountInRocksDB(kv._1, kv._2._1, kv._2._1, kv._2._2)
-      })
+      cardinalityCountMap.foreach { case (prefix, (totalDelta, childrenDelta)) =>
+        // NOTE: Since the current implementation only supports batch writes for
+        //   totalCardinality deltas, the totalDelta is just passed to all
+        //   cardinality delta params.
+        storeCardinalityCountInRocksDB(prefix, totalDelta, totalDelta, totalDelta, childrenDelta)
+      }
       // clear the map
       cardinalityCountMap.clear()
     }
@@ -206,18 +227,21 @@ class CardinalityTracker(ref: DatasetRef,
    * @param prefix usually contains labels _ws_, _ns_, _metric_ and different combinations of it
    * @param totalDelta Increase in total timeseries
    * @param activeDelta Increase in active timeseries
+   * @param billableDelta Increase in billable timeseries
    * @param childrenDelta Increase in children count
    */
   private def storeCardinalityCountInRocksDB(prefix: Seq[String],
-                            totalDelta: Int, activeDelta: Int, childrenDelta: Int): Unit = {
+                            totalDelta: Int, activeDelta: Int, billableDelta: Int, childrenDelta: Int): Unit = {
 
     // get the current cardinality count from RocksDB for the given prefix. Also add a default if not present
     val old = store.getOrZero(prefix,
-      CardinalityRecord(shard, prefix, CardinalityValue(0, 0, 0, defaultChildrenQuota(prefix.length))))
+      CardinalityRecord(shard, prefix, CardinalityValue(0, 0, 0, 0, defaultChildrenQuota(prefix.length))))
 
     // update the count with the provided delta values
-    val neu = old.copy(value = old.value.copy(tsCount = old.value.tsCount + totalDelta,
+    val neu = old.copy(value = old.value.copy(
+      tsCount = old.value.tsCount + totalDelta,
       activeTsCount = old.value.activeTsCount + activeDelta,
+      billableTsCount = old.value.billableTsCount + billableDelta,
       childrenCount = old.value.childrenCount + childrenDelta))
 
     store.store(neu)
@@ -232,7 +256,8 @@ class CardinalityTracker(ref: DatasetRef,
     require(shardKeyPrefix.length <= shardKeyLen, s"Too many shard keys in $shardKeyPrefix - max $shardKeyLen")
     store.getOrZero(
       shardKeyPrefix,
-      CardinalityRecord(shard, shardKeyPrefix, CardinalityValue(0, 0, 0, defaultChildrenQuota(shardKeyPrefix.length))))
+      CardinalityRecord(
+        shard, shardKeyPrefix, CardinalityValue(0, 0, 0, 0, defaultChildrenQuota(shardKeyPrefix.length))))
   }
 
   /**
@@ -249,7 +274,8 @@ class CardinalityTracker(ref: DatasetRef,
     logger.debug(s"Setting children quota for $shardKeyPrefix as $childrenQuota")
     val old = store.getOrZero(
       shardKeyPrefix,
-      CardinalityRecord(shard, shardKeyPrefix, CardinalityValue(0, 0, 0, defaultChildrenQuota(shardKeyPrefix.length))))
+      CardinalityRecord(
+        shard, shardKeyPrefix, CardinalityValue(0, 0, 0, 0, defaultChildrenQuota(shardKeyPrefix.length))))
     val neu = old.copy(value = old.value.copy(childrenQuota = childrenQuota))
     store.store(neu)
     neu
@@ -275,7 +301,7 @@ class CardinalityTracker(ref: DatasetRef,
       val toStore = (0 to shardKey.length).map { i =>
         val prefix = shardKey.take(i)
         val old = store.getOrZero(prefix,
-          CardinalityRecord(shard, Nil, CardinalityValue(0, 0, 0, defaultChildrenQuota(i))))
+          CardinalityRecord(shard, Nil, CardinalityValue(0, 0, 0, 0, defaultChildrenQuota(i))))
         if (old.value.tsCount == 0)
           throw new IllegalArgumentException(s"$prefix count is already zero - cannot reduce " +
             s"further. A double delete likely happened.")
@@ -284,7 +310,9 @@ class CardinalityTracker(ref: DatasetRef,
         (prefix, neu)
       }
       toStore.map { case (prefix, neu) =>
-        if (neu == CardinalityRecord(shard, prefix, CardinalityValue(0, 0, 0, defaultChildrenQuota(prefix.length)))) {
+        val zeroCardinalityRecord = CardinalityRecord(
+          shard, prefix, CardinalityValue(0, 0, 0, 0, defaultChildrenQuota(prefix.length)))
+        if (neu == zeroCardinalityRecord) {
           // node can be removed
           store.remove(prefix)
         } else {

--- a/core/src/main/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStore.scala
@@ -25,7 +25,7 @@ import filodb.memory.format.UnsafeUtils
  *   (1) only the least-significant prefix name is stored.
  *   (2) no shard ID is store
  */
-case class CardinalityValue(tsCount: Long, activeTsCount: Long,
+case class CardinalityValue(tsCount: Long, activeTsCount: Long, billableTsCount: Long,
                             childrenCount: Long, childrenQuota: Long)
 
 case object CardinalityValue {
@@ -40,13 +40,18 @@ class CardinalityNodeSerializer extends Serializer[CardinalityValue] {
   def write(kryo: Kryo, output: Output, card: CardinalityValue): Unit = {
     output.writeLong(card.tsCount, true)
     output.writeLong(card.activeTsCount, true)
+    output.writeLong(card.billableTsCount, true)
     output.writeLong(card.childrenCount, true)
     output.writeLong(card.childrenQuota, true)
   }
 
   def read(kryo: Kryo, input: Input, t: Class[CardinalityValue]): CardinalityValue = {
-    CardinalityValue(input.readLong(true), input.readLong(true),
-                    input.readLong(true), input.readLong(true))
+    CardinalityValue(
+      input.readLong(true),
+      input.readLong(true),
+      input.readLong(true),
+      input.readLong(true),
+      input.readLong(true))
   }
 }
 
@@ -286,7 +291,7 @@ class RocksDbCardinalityStore(ref: DatasetRef, shard: Int) extends CardinalitySt
       // result reached MAX_RESULT_SIZE, but still more cardinalities
       if (it.isValid() && !complete) {
         // sum the remaining counts into these values
-        var tsCount, activeTsCount, childrenCount, childrenQuota = 0L
+        var tsCount, activeTsCount, billableTsCount, childrenCount, childrenQuota = 0L
         breakable {
           do {
             // note: the iterator is valid here on the first iteration
@@ -295,6 +300,7 @@ class RocksDbCardinalityStore(ref: DatasetRef, shard: Int) extends CardinalitySt
               val node = bytesToCardinalityValue(it.value())
               tsCount = tsCount + node.tsCount
               activeTsCount = activeTsCount + node.activeTsCount
+              billableTsCount = billableTsCount + node.billableTsCount
               childrenCount = childrenCount + node.childrenCount
               childrenQuota = childrenQuota + node.childrenQuota
             } else {
@@ -304,7 +310,7 @@ class RocksDbCardinalityStore(ref: DatasetRef, shard: Int) extends CardinalitySt
           } while (it.isValid())
         }
         buf.append(CardinalityRecord(shard, OVERFLOW_PREFIX, CardinalityValue(
-          tsCount, activeTsCount, childrenCount, childrenQuota)))
+          tsCount, activeTsCount, billableTsCount, childrenCount, childrenQuota)))
       }
     } finally {
       it.close();

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -28,6 +28,12 @@ filodb {
     }
   }
 
+  cardinality {
+    schema-name-to-billable-cardinality-per-active-series {
+      metrics2 = 5
+    }
+  }
+
   cassandra {
     hosts = localhost
     hosts = ${?CASSANDRA_HOST}

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -10,7 +10,8 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.time.{Millis, Seconds, Span}
 import filodb.core._
-import filodb.core.binaryrecord2.{RecordBuilder}
+import filodb.core.binaryrecord2.RecordBuilder
+import filodb.core.memstore.ratelimit.{CardinalityRecord, CardinalityValue}
 import filodb.core.metadata.Schemas
 import filodb.core.query.{ColumnFilter, Filter, QuerySession, ServiceUnavailableException}
 import filodb.core.store._
@@ -723,5 +724,36 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     } finally {
       store2.shutdown()    // release snd free the memory
     }
+  }
+
+  it("should correctly account for billable cardinality") {
+    memStore.setup(dataset2.ref, schemas2, 0, TestData.storeConf, 1, TestData.downsampleConf)
+
+    val shard = memStore.getShardE(dataset2.ref, 0)
+    val key = Seq("a", "b", "c")
+
+    def getBillableCardinality(): Long = {
+      val defaultCardinalityRecord = CardinalityRecord(0, Seq(), CardinalityValue(0, 0, 0, 0, 0))
+      shard.cardTracker.store.getOrZero(key, defaultCardinalityRecord).value.billableTsCount
+    }
+
+    def modifyCardinalityCount(activeDelta: Int): Unit = {
+      shard.modifyCardinalityCount(key, schema2, 0, activeDelta)
+    }
+
+    getBillableCardinality() shouldEqual 0
+
+    // NOTE: Cardinality per series is configured in application_test.conf.
+    modifyCardinalityCount(1)
+    getBillableCardinality() shouldEqual 5
+
+    modifyCardinalityCount(1)
+    getBillableCardinality() shouldEqual 10
+
+    modifyCardinalityCount(-1)
+    getBillableCardinality() shouldEqual 5
+
+    modifyCardinalityCount(-1)
+    getBillableCardinality() shouldEqual 0
   }
 }

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/CardinalityTrackerSpec.scala
@@ -19,47 +19,47 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
   it("should enforce quota when set explicitly for all levels") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(4, 4, 4, 4), newCardStore)
     t.setQuota(Seq("a", "aa", "aaa"), 1) shouldEqual
-      CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(0, 0, 0, 1))
+      CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(0, 0, 0, 0, 1))
     t.setQuota(Seq("a", "aa"), 2) shouldEqual
-      CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(0, 0, 0, 2))
-    t.setQuota(Seq("a"), 1) shouldEqual CardinalityRecord(0, Seq("a"), CardinalityValue(0, 0, 0, 1))
+      CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(0, 0, 0, 0, 2))
+    t.setQuota(Seq("a"), 1) shouldEqual CardinalityRecord(0, Seq("a"), CardinalityValue(0, 0, 0, 0, 1))
 
-    t.modifyCount(Seq("a", "aa", "aaa"), 1, 1) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(1, 1, 1, 4)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(1, 1, 1, 1)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(1, 1, 1, 2)),
-        CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(1, 1, 1, 1)))
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 1, 5) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(1, 1, 5, 1, 4)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(1, 1, 5, 1, 1)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(1, 1, 5, 1, 2)),
+        CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(1, 1, 5, 1, 1)))
 
-    t.modifyCount(Seq("a", "aa", "aab"), 1, 1) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(2, 2, 1, 4)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(2, 2, 1, 1)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(2, 2, 2, 2)),
-        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(1, 1, 1, 4)))
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 1, 5) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(2, 2, 10, 1, 4)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(2, 2, 10, 1, 1)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(2, 2, 10, 2, 2)),
+        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(1, 1, 5, 1, 4)))
 
     // aab stopped ingesting
-    t.modifyCount(Seq("a", "aa", "aab"), 0, -1) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(2, 1, 1, 4)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(2, 1, 1, 1)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(2, 1, 2, 2)),
-        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(1, 0, 1, 4)))
+    t.modifyCount(Seq("a", "aa", "aab"), 0, -1, -5) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(2, 1, 5, 1, 4)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(2, 1, 5, 1, 1)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(2, 1, 5, 2, 2)),
+        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(1, 0, 0, 1, 4)))
 
     val ex = intercept[QuotaReachedException] {
-      t.modifyCount(Seq("a", "aa", "aac"), 1, 0)
+      t.modifyCount(Seq("a", "aa", "aac"), 1, 0, 0)
     }
     ex.prefix shouldEqual (Seq("a", "aa"))
 
     // increment should not have been applied for any prefix
-    t.scan(Seq("a"), 1)(0) shouldEqual CardinalityRecord(0, Seq("a"), CardinalityValue(2, 1, 1, 1))
-    t.scan(Seq("a", "aa"), 2)(0) shouldEqual CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(2, 1, 2, 2))
+    t.scan(Seq("a"), 1)(0) shouldEqual CardinalityRecord(0, Seq("a"), CardinalityValue(2, 1, 5, 1, 1))
+    t.scan(Seq("a", "aa"), 2)(0) shouldEqual CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(2, 1, 5, 2, 2))
     t.scan(Seq("a", "aa", "aac"), 3)(0) shouldEqual
-      CardinalityRecord(0, Seq("a", "aa", "aac"), CardinalityValue(0, 0, 0, 4))
+      CardinalityRecord(0, Seq("a", "aa", "aac"), CardinalityValue(0, 0, 0, 0, 4))
 
     // aab was purged
     t.decrementCount(Seq("a", "aa", "aab")) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(1, 1, 1, 4)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(1, 1, 1, 1)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(1, 1, 2, 2)),
-        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(0, 0, 0, 4)))
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(1, 1, 5, 1, 4)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(1, 1, 5, 1, 1)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(1, 1, 5, 2, 2)),
+        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(0, 0, 0, 0, 4)))
 
     t.close()
   }
@@ -77,9 +77,9 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
     val qp = new MyQEP
     val t = new CardinalityTracker(ref, 0, 3, Seq(1, 1, 1, 1), newCardStore, qp)
-    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0, 0)
     val ex = intercept[QuotaReachedException] {
-      t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
+      t.modifyCount(Seq("a", "aa", "aaa"), 1, 0, 0)
     }
     qp.breachedQuota shouldEqual 1
     qp.breachedPrefix shouldEqual Seq("a", "aa", "aaa")
@@ -88,55 +88,55 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
   it("should enforce quota when not set for any level") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(4, 4, 4, 4), newCardStore)
-    t.modifyCount(Seq("a", "ab", "aba"), 1, 0) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(1, 0, 1, 4)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(1, 0, 1, 4)),
-        CardinalityRecord(0, Seq("a", "ab"), CardinalityValue(1, 0, 1, 4)),
-        CardinalityRecord(0, Seq("a", "ab", "aba"), CardinalityValue(1, 0, 1, 4)))
+    t.modifyCount(Seq("a", "ab", "aba"), 1, 0, 0) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(1, 0, 0, 1, 4)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(1, 0, 0, 1, 4)),
+        CardinalityRecord(0, Seq("a", "ab"), CardinalityValue(1, 0, 0, 1, 4)),
+        CardinalityRecord(0, Seq("a", "ab", "aba"), CardinalityValue(1, 0, 0, 1, 4)))
     t.close()
   }
 
   it("should be able to enforce for top 2 levels always, and enforce for 3rd level only in some cases") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(20, 20, 20, 20), newCardStore)
-    t.setQuota(Seq("a"), 10) shouldEqual CardinalityRecord(0, Seq("a"), CardinalityValue(0, 0, 0, 10))
+    t.setQuota(Seq("a"), 10) shouldEqual CardinalityRecord(0, Seq("a"), CardinalityValue(0, 0, 0, 0, 10))
     t.setQuota(Seq("a", "aa"), 10) shouldEqual
-      CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(0, 0, 0, 10))
+      CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(0, 0, 0, 0, 10))
     // enforce for 3rd level only for aaa
     t.setQuota(Seq("a", "aa", "aaa"), 2) shouldEqual
-      CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(0, 0, 0, 2))
-    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(1, 0, 1, 20)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(1, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(1, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(1, 0, 1, 2)))
-    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(2, 0, 1, 20)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(2, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(2, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(2, 0, 2, 2)))
-    t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(3, 0, 1, 20)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(3, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(3, 0, 2, 10)),
-        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(1, 0, 1, 20)))
-    t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(4, 0, 1, 20)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(4, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(4, 0, 2, 10)),
-        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(2, 0, 2, 20)))
-    t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(5, 0, 1, 20)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(5, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(5, 0, 2, 10)),
-        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(3, 0, 3, 20)))
-    t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(6, 0, 1, 20)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(6, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(6, 0, 2, 10)),
-        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(4, 0, 4, 20)))
+      CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(0, 0, 0, 0, 2))
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0, 0) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(1, 0, 0, 1, 20)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(1, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(1, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(1, 0, 0, 1, 2)))
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0, 0) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(2, 0, 0, 1, 20)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(2, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(2, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(2, 0, 0, 2, 2)))
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0, 0) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(3, 0, 0, 1, 20)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(3, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(3, 0, 0, 2, 10)),
+        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(1, 0, 0, 1, 20)))
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0, 0) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(4, 0, 0, 1, 20)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(4, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(4, 0, 0, 2, 10)),
+        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(2, 0, 0, 2, 20)))
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0, 0) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(5, 0, 0, 1, 20)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(5, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(5, 0, 0, 2, 10)),
+        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(3, 0, 0, 3, 20)))
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0, 0) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(6, 0, 0, 1, 20)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(6, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(6, 0, 0, 2, 10)),
+        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(4, 0, 0, 4, 20)))
 
     val ex = intercept[QuotaReachedException] {
-      t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
+      t.modifyCount(Seq("a", "aa", "aaa"), 1, 0, 0)
     }
      ex.prefix shouldEqual Seq("a", "aa", "aaa")
     t.close()
@@ -145,47 +145,47 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
   it("should be able to increase and decrease quota after it has been set before") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(20, 20, 20, 20), newCardStore)
-    t.setQuota(Seq("a"), 10) shouldEqual CardinalityRecord(0, Seq("a"), CardinalityValue(0, 0, 0, 10))
+    t.setQuota(Seq("a"), 10) shouldEqual CardinalityRecord(0, Seq("a"), CardinalityValue(0, 0, 0, 0, 10))
     t.setQuota(Seq("a", "aa"), 10) shouldEqual
-      CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(0, 0, 0, 10))
+      CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(0, 0, 0, 0, 10))
     // enforce for 3rd level only for aaa
     t.setQuota(Seq("a", "aa", "aaa"), 2) shouldEqual
-      CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(0, 0, 0, 2))
-    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(1, 0, 1, 20)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(1, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(1, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(1, 0, 1, 2)))
-    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(2, 0, 1, 20)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(2, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(2, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(2, 0, 2, 2)))
+      CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(0, 0, 0, 0, 2))
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0, 0) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(1, 0, 0, 1, 20)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(1, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(1, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(1, 0, 0, 1, 2)))
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0, 0) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(2, 0, 0, 1, 20)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(2, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(2, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(2, 0, 0, 2, 2)))
 
     val ex = intercept[QuotaReachedException] {
-      t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
+      t.modifyCount(Seq("a", "aa", "aaa"), 1, 0, 0)
     }
     ex.prefix shouldEqual (Seq("a", "aa", "aaa"))
 
     // increase quota
     t.setQuota(Seq("a", "aa", "aaa"), 5) shouldEqual
-      CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(2, 0, 2, 5))
-    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(3, 0, 1, 20)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(3, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(3, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(3, 0, 3, 5)))
+      CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(2, 0, 0, 2, 5))
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0, 0) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(3, 0, 0, 1, 20)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(3, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(3, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(3, 0, 0, 3, 5)))
 
     // decrease quota
     t.setQuota(Seq("a", "aa", "aaa"), 4) shouldEqual
-      CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(3, 0, 3, 4))
-    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(4, 0, 1, 20)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(4, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(4, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(4, 0, 4, 4)))
+      CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(3, 0, 0, 3, 4))
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0, 0) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(4, 0, 0, 1, 20)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(4, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(4, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa", "aaa"), CardinalityValue(4, 0, 0, 4, 4)))
     val ex2 = intercept[QuotaReachedException] {
-      t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
+      t.modifyCount(Seq("a", "aa", "aaa"), 1, 0, 0)
     }
     ex2.prefix shouldEqual Seq("a", "aa", "aaa")
     t.close()
@@ -194,38 +194,38 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
   it("should be able to decrease quota if count is higher than new quota") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(20, 20, 20, 20), newCardStore)
     t.setQuota(Seq("a"), 10) shouldEqual
-      CardinalityRecord(0, Seq("a"), CardinalityValue(0, 0, 0, 10))
+      CardinalityRecord(0, Seq("a"), CardinalityValue(0, 0, 0, 0, 10))
     t.setQuota(Seq("a", "aa"), 10) shouldEqual
-      CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(0, 0, 0, 10))
-    t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(1, 0, 1, 20)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(1, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(1, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(1, 0, 1, 20)))
-    t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(2, 0, 1, 20)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(2, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(2, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(2, 0, 2, 20)))
-    t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(3, 0, 1, 20)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(3, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(3, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(3, 0, 3, 20)))
-    t.modifyCount(Seq("a", "aa", "aab"), 1, 0) shouldEqual
-      Seq(CardinalityRecord(0, Nil, CardinalityValue(4, 0, 1, 20)),
-        CardinalityRecord(0, Seq("a"), CardinalityValue(4, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(4, 0, 1, 10)),
-        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(4, 0, 4, 20)))
+      CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(0, 0, 0, 0, 10))
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0, 0) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(1, 0, 0, 1, 20)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(1, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(1, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(1, 0, 0, 1, 20)))
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0, 0) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(2, 0, 0, 1, 20)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(2, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(2, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(2, 0, 0, 2, 20)))
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0, 0) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(3, 0, 0, 1, 20)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(3, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(3, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(3, 0, 0, 3, 20)))
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0, 0) shouldEqual
+      Seq(CardinalityRecord(0, Nil, CardinalityValue(4, 0, 0, 1, 20)),
+        CardinalityRecord(0, Seq("a"), CardinalityValue(4, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(4, 0, 0, 1, 10)),
+        CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(4, 0, 0, 4, 20)))
 
     t.scan(Seq("a", "aa", "aab"), 3)(0) shouldEqual
-      CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(4, 0, 4, 20))
+      CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(4, 0, 0, 4, 20))
 
     t.setQuota(Seq("a", "aa", "aab"), 3)
     t.scan(Seq("a", "aa", "aab"), 3)(0) shouldEqual
-      CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(4, 0, 4, 3))
+      CardinalityRecord(0, Seq("a", "aa", "aab"), CardinalityValue(4, 0, 0, 4, 3))
     val ex2 = intercept[QuotaReachedException] {
-      t.modifyCount(Seq("a", "aa", "aab"), 1, 0)
+      t.modifyCount(Seq("a", "aa", "aab"), 1, 0, 0)
     }
     ex2.prefix shouldEqual Seq("a", "aa", "aab")
     t.close()
@@ -234,66 +234,66 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
   it ("should be able to increment and decrement counters fast and correctly") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(50000, 50000, 50000, 50000), newCardStore)
 
-    (1 to 30000).foreach(_ => t.modifyCount(Seq("a", "b", "c"), 1, 1))
+    (1 to 30000).foreach(_ => t.modifyCount(Seq("a", "b", "c"), 1, 1, 5))
     t.scan(Seq("a", "b", "c"), 3)(0) shouldEqual
-      CardinalityRecord(0, Seq("a", "b", "c"), CardinalityValue(30000, 30000, 30000, 50000))
-    (1 to 30000).foreach(_ => t.modifyCount(Seq("a", "b", "c"), 0, -1))
+      CardinalityRecord(0, Seq("a", "b", "c"), CardinalityValue(30000, 30000, 150000, 30000, 50000))
+    (1 to 30000).foreach(_ => t.modifyCount(Seq("a", "b", "c"), 0, -1, -5))
     t.scan(Seq("a", "b", "c"), 3)(0) shouldEqual
-      CardinalityRecord(0, Seq("a", "b", "c"), CardinalityValue(30000, 0, 30000, 50000))
+      CardinalityRecord(0, Seq("a", "b", "c"), CardinalityValue(30000, 0, 0, 30000, 50000))
     (1 to 30000).foreach(_ => t.decrementCount(Seq("a", "b", "c")))
     t.scan(Seq("a", "b", "c"), 3)(0) shouldEqual
-      CardinalityRecord(0, Seq("a", "b", "c"), CardinalityValue(0, 0, 0, 50000))
+      CardinalityRecord(0, Seq("a", "b", "c"), CardinalityValue(0, 0, 0, 0, 50000))
   }
 
   it ("should be able to do scan") {
     val t = new CardinalityTracker(ref, 0, 3, Seq(100, 100, 100, 100), newCardStore)
-    (1 to 10).foreach(_ => t.modifyCount(Seq("a", "ac", "aca"), 1, 0))
-    (1 to 20).foreach(_ => t.modifyCount(Seq("a", "ac", "acb"), 1, 0))
-    (1 to 11).foreach(_ => t.modifyCount(Seq("a", "ac", "acc"), 1, 0))
-    (1 to 6).foreach(_ => t.modifyCount(Seq("a", "ac", "acd"), 1, 0))
-    (1 to 1).foreach(_ => t.modifyCount(Seq("a", "ac", "ace"), 1, 0))
-    (1 to 9).foreach(_ => t.modifyCount(Seq("a", "ac", "acf"), 1, 0))
-    (1 to 15).foreach(_ => t.modifyCount(Seq("a", "ac", "acg"), 1, 0))
+    (1 to 10).foreach(_ => t.modifyCount(Seq("a", "ac", "aca"), 1, 0, 0))
+    (1 to 20).foreach(_ => t.modifyCount(Seq("a", "ac", "acb"), 1, 0, 0))
+    (1 to 11).foreach(_ => t.modifyCount(Seq("a", "ac", "acc"), 1, 0, 0))
+    (1 to 6).foreach(_ => t.modifyCount(Seq("a", "ac", "acd"), 1, 0, 0))
+    (1 to 1).foreach(_ => t.modifyCount(Seq("a", "ac", "ace"), 1, 0, 0))
+    (1 to 9).foreach(_ => t.modifyCount(Seq("a", "ac", "acf"), 1, 0, 0))
+    (1 to 15).foreach(_ => t.modifyCount(Seq("a", "ac", "acg"), 1, 0, 0))
 
-    (1 to 15).foreach(_ => t.modifyCount(Seq("b", "bc", "bcg"), 1, 0))
-    (1 to 9).foreach(_ => t.modifyCount(Seq("b", "bc", "bch"), 1, 0))
-    (1 to 9).foreach(_ => t.modifyCount(Seq("b", "bd", "bdh"), 1, 0))
+    (1 to 15).foreach(_ => t.modifyCount(Seq("b", "bc", "bcg"), 1, 0, 0))
+    (1 to 9).foreach(_ => t.modifyCount(Seq("b", "bc", "bch"), 1, 0, 0))
+    (1 to 9).foreach(_ => t.modifyCount(Seq("b", "bd", "bdh"), 1, 0, 0))
 
-    (1 to 3).foreach(_ => t.modifyCount(Seq("c", "cc", "ccg"), 1, 0))
-    (1 to 2).foreach(_ => t.modifyCount(Seq("c", "cc", "cch"), 1, 0))
+    (1 to 3).foreach(_ => t.modifyCount(Seq("c", "cc", "ccg"), 1, 0, 0))
+    (1 to 2).foreach(_ => t.modifyCount(Seq("c", "cc", "cch"), 1, 0, 0))
 
-    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0)
-    t.modifyCount(Seq("a", "aa", "aab"), 1, 0)
-    t.modifyCount(Seq("a", "aa", "aac"), 1, 0)
-    t.modifyCount(Seq("a", "aa", "aad"), 1, 0)
-    t.modifyCount(Seq("b", "ba", "baa"), 1, 0)
-    t.modifyCount(Seq("b", "bb", "bba"), 1, 0)
-    t.modifyCount(Seq("a", "ab", "aba"), 1, 0)
-    t.modifyCount(Seq("a", "ab", "abb"), 1, 0)
-    t.modifyCount(Seq("a", "ab", "abc"), 1, 0)
-    t.modifyCount(Seq("a", "ab", "abd"), 1, 0)
-    t.modifyCount(Seq("a", "ab", "abe"), 1, 0)
+    t.modifyCount(Seq("a", "aa", "aaa"), 1, 0, 0)
+    t.modifyCount(Seq("a", "aa", "aab"), 1, 0, 0)
+    t.modifyCount(Seq("a", "aa", "aac"), 1, 0, 0)
+    t.modifyCount(Seq("a", "aa", "aad"), 1, 0, 0)
+    t.modifyCount(Seq("b", "ba", "baa"), 1, 0, 0)
+    t.modifyCount(Seq("b", "bb", "bba"), 1, 0, 0)
+    t.modifyCount(Seq("a", "ab", "aba"), 1, 0, 0)
+    t.modifyCount(Seq("a", "ab", "abb"), 1, 0, 0)
+    t.modifyCount(Seq("a", "ab", "abc"), 1, 0, 0)
+    t.modifyCount(Seq("a", "ab", "abd"), 1, 0, 0)
+    t.modifyCount(Seq("a", "ab", "abe"), 1, 0, 0)
 
     t.scan(Seq("a", "ac"), 3) should contain theSameElementsAs Seq(
-      CardinalityRecord(0, Seq("a", "ac", "aca"), CardinalityValue(10, 0, 10, 100)),
-      CardinalityRecord(0, Seq("a", "ac", "acb"), CardinalityValue(20, 0, 20, 100)),
-      CardinalityRecord(0, Seq("a", "ac", "acc"), CardinalityValue(11, 0, 11, 100)),
-      CardinalityRecord(0, Seq("a", "ac", "acd"), CardinalityValue(6, 0, 6, 100)),
-      CardinalityRecord(0, Seq("a", "ac", "ace"), CardinalityValue(1, 0, 1, 100)),
-      CardinalityRecord(0, Seq("a", "ac", "acf"), CardinalityValue(9, 0, 9, 100)),
-      CardinalityRecord(0, Seq("a", "ac", "acg"), CardinalityValue(15, 0, 15, 100)),
+      CardinalityRecord(0, Seq("a", "ac", "aca"), CardinalityValue(10, 0, 0, 10, 100)),
+      CardinalityRecord(0, Seq("a", "ac", "acb"), CardinalityValue(20, 0, 0, 20, 100)),
+      CardinalityRecord(0, Seq("a", "ac", "acc"), CardinalityValue(11, 0, 0, 11, 100)),
+      CardinalityRecord(0, Seq("a", "ac", "acd"), CardinalityValue(6, 0, 0, 6, 100)),
+      CardinalityRecord(0, Seq("a", "ac", "ace"), CardinalityValue(1, 0, 0, 1, 100)),
+      CardinalityRecord(0, Seq("a", "ac", "acf"), CardinalityValue(9, 0, 0, 9, 100)),
+      CardinalityRecord(0, Seq("a", "ac", "acg"), CardinalityValue(15, 0, 0, 15, 100)),
     )
 
     t.scan(Seq("a"), 2) should contain theSameElementsAs Seq(
-      CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(4, 0, 4, 100)),
-      CardinalityRecord(0, Seq("a", "ab"), CardinalityValue(5, 0, 5, 100)),
-      CardinalityRecord(0, Seq("a", "ac"), CardinalityValue(72, 0, 7, 100))
+      CardinalityRecord(0, Seq("a", "aa"), CardinalityValue(4, 0, 0, 4, 100)),
+      CardinalityRecord(0, Seq("a", "ab"), CardinalityValue(5, 0, 0, 5, 100)),
+      CardinalityRecord(0, Seq("a", "ac"), CardinalityValue(72, 0, 0, 7, 100))
     )
 
     t.scan(Nil, 1) should contain theSameElementsAs Seq(
-      CardinalityRecord(0, Seq("c"), CardinalityValue(5, 0, 1, 100)),
-      CardinalityRecord(0, Seq("a"), CardinalityValue(81, 0, 3, 100)),
-      CardinalityRecord(0, Seq("b"), CardinalityValue(35, 0, 4, 100))
+      CardinalityRecord(0, Seq("c"), CardinalityValue(5, 0, 0, 1, 100)),
+      CardinalityRecord(0, Seq("a"), CardinalityValue(81, 0, 0, 3, 100)),
+      CardinalityRecord(0, Seq("b"), CardinalityValue(35, 0, 0, 4, 100))
     )
 
     t.close()
@@ -302,45 +302,45 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
   it ("modifyCount with aggregation should update count correctly") {
     val t = new CardinalityTracker(ref, 1, 3, Seq(50000, 50000, 50000, 50000), dsCardStore,
       flushCount = Some(5000))
-    (1 to 1000).foreach(_ => t.modifyCount(Seq("a", "b", "c"), 1, 1))
-    (1 to 1000).foreach(_ => t.modifyCount(Seq("a", "b", "d"), 1, 1))
-    (1 to 1000).foreach(_ => t.modifyCount(Seq("a", "c", "d"), 1, 1))
-    (1 to 1000).foreach(_ => t.modifyCount(Seq("b", "c", "d"), 1, 1))
+    (1 to 1000).foreach(_ => t.modifyCount(Seq("a", "b", "c"), 1, 1, 5))
+    (1 to 1000).foreach(_ => t.modifyCount(Seq("a", "b", "d"), 1, 1, 5))
+    (1 to 1000).foreach(_ => t.modifyCount(Seq("a", "c", "d"), 1, 1, 5))
+    (1 to 1000).foreach(_ => t.modifyCount(Seq("b", "c", "d"), 1, 1, 5))
 
     // check no flush until flush is called
     // it should return the default value returned by cardinalityTracker.getCardinality
     t.scan(Seq("a", "b", "c"), 3)(0) shouldEqual
-      CardinalityRecord(1, Seq("a", "b", "c"), CardinalityValue(0, 0, 0, 50000))
+      CardinalityRecord(1, Seq("a", "b", "c"), CardinalityValue(0, 0, 0, 0, 50000))
 
     t.flushCardinalityCount()
 
     // validate expected records after flush is called
     t.scan(Seq("a", "b", "c"), 3)(0) shouldEqual
-      CardinalityRecord(1, Seq("a", "b", "c"), CardinalityValue(1000, 1000, 0, 50000))
+      CardinalityRecord(1, Seq("a", "b", "c"), CardinalityValue(1000, 1000, 1000, 0, 50000))
     t.scan(Seq("a", "b"), 2)(0) shouldEqual
-      CardinalityRecord(1, Seq("a", "b"), CardinalityValue(2000, 2000, 2000, 50000))
+      CardinalityRecord(1, Seq("a", "b"), CardinalityValue(2000, 2000, 2000, 2000, 50000))
     t.scan(Seq("a", "b", "d"), 3)(0) shouldEqual
-      CardinalityRecord(1, Seq("a", "b", "d"), CardinalityValue(1000, 1000, 0, 50000))
+      CardinalityRecord(1, Seq("a", "b", "d"), CardinalityValue(1000, 1000, 1000, 0, 50000))
     t.scan(Seq("b", "c"), 2)(0) shouldEqual
-      CardinalityRecord(1, Seq("b", "c"), CardinalityValue(1000, 1000, 1000, 50000))
+      CardinalityRecord(1, Seq("b", "c"), CardinalityValue(1000, 1000, 1000, 1000, 50000))
     t.scan(Seq("b", "c", "d"), 3)(0) shouldEqual
-      CardinalityRecord(1, Seq("b", "c", "d"), CardinalityValue(1000, 1000, 0, 50000))
+      CardinalityRecord(1, Seq("b", "c", "d"), CardinalityValue(1000, 1000, 1000, 0, 50000))
     t.scan(Seq("a"), 1)(0) shouldEqual
-      CardinalityRecord(1, Seq("a"), CardinalityValue(3000, 3000, 3000, 50000))
+      CardinalityRecord(1, Seq("a"), CardinalityValue(3000, 3000, 3000, 3000, 50000))
     t.scan(Seq("b"), 1)(0) shouldEqual
-      CardinalityRecord(1, Seq("b"), CardinalityValue(1000, 1000, 1000, 50000))
+      CardinalityRecord(1, Seq("b"), CardinalityValue(1000, 1000, 1000, 1000, 50000))
     t.scan(Seq(), 0)(0) shouldEqual
-      CardinalityRecord(1, Seq(), CardinalityValue(4000, 4000, 4000, 50000))
+      CardinalityRecord(1, Seq(), CardinalityValue(4000, 4000, 4000, 4000, 50000))
 
     t.close()
   }
 
   it ("modifyCount with aggregation should throw QuotaReachedException when childrenCount breached") {
     val t = new CardinalityTracker(ref, 1, 3, Seq(2, 2, 2, 2), dsCardStore, flushCount = Some(5000))
-    t.modifyCount(Seq("a", "b", "c"), 1, 1)
-    t.modifyCount(Seq("a", "b", "d"), 1, 1)
+    t.modifyCount(Seq("a", "b", "c"), 1, 1, 5)
+    t.modifyCount(Seq("a", "b", "d"), 1, 1, 5)
     val ex = intercept[QuotaReachedException] {
-      t.modifyCount(Seq("a", "b", "e"), 1, 1)
+      t.modifyCount(Seq("a", "b", "e"), 1, 1, 5)
     }
     ex.prefix shouldEqual Seq("a")
     t.close()
@@ -349,14 +349,14 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
   it("modifyCount with aggregation should flush counts to RocksDB if threshold reached") {
     val t = new CardinalityTracker(ref, 1, 3, Seq(5, 5, 5, 5),
       dsCardStore, flushCount = Some(5))
-    t.modifyCount(Seq("a", "b", "c"), 1, 1)
-    t.modifyCount(Seq("a", "b", "d"), 1, 1)
+    t.modifyCount(Seq("a", "b", "c"), 1, 1, 5)
+    t.modifyCount(Seq("a", "b", "d"), 1, 1, 5)
 
     // check not flushed until now since threshold not crossed
     t.getCardinalityCountMapDSClone().size shouldEqual 5
 
     // adding another child which triggers flush based on flushCount parameter
-    t.modifyCount(Seq("a", "b", "e"), 1, 1)
+    t.modifyCount(Seq("a", "b", "e"), 1, 1, 5)
     t.flushCardinalityCount()
 
     // check if map is cleared after flush
@@ -364,13 +364,13 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
     // check data integrity in RocksDB
     t.scan(Seq(), 0)(0) shouldEqual
-      CardinalityRecord(1, Seq(), CardinalityValue(3, 3, 3, 5))
+      CardinalityRecord(1, Seq(), CardinalityValue(3, 3, 3, 3, 5))
     t.scan(Seq("a"), 1)(0) shouldEqual
-      CardinalityRecord(1, Seq("a"), CardinalityValue(3, 3, 3, 5))
+      CardinalityRecord(1, Seq("a"), CardinalityValue(3, 3, 3, 3, 5))
     t.scan(Seq("a", "b"), 2)(0) shouldEqual
-      CardinalityRecord(1, Seq("a", "b"), CardinalityValue(3, 3, 3, 5))
+      CardinalityRecord(1, Seq("a", "b"), CardinalityValue(3, 3, 3, 3, 5))
     t.scan(Seq("a", "b", "c"), 3)(0) shouldEqual
-      CardinalityRecord(1, Seq("a", "b", "c"), CardinalityValue(1, 1, 0, 5))
+      CardinalityRecord(1, Seq("a", "b", "c"), CardinalityValue(1, 1, 1, 0, 5))
 
     t.close()
   }
@@ -381,16 +381,16 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
       flushCount = Some(5000))
 
     // update raw card count
-    (1 to 1000).foreach(_ => s.modifyCount(Seq("a", "b", "c"), 1, 1))
-    (1 to 1000).foreach(_ => s.modifyCount(Seq("a", "b", "d"), 1, 1))
-    (1 to 1000).foreach(_ => s.modifyCount(Seq("a", "c", "d"), 1, 1))
-    (1 to 1000).foreach(_ => s.modifyCount(Seq("b", "c", "d"), 1, 1))
+    (1 to 1000).foreach(_ => s.modifyCount(Seq("a", "b", "c"), 1, 1, 5))
+    (1 to 1000).foreach(_ => s.modifyCount(Seq("a", "b", "d"), 1, 1, 5))
+    (1 to 1000).foreach(_ => s.modifyCount(Seq("a", "c", "d"), 1, 1, 5))
+    (1 to 1000).foreach(_ => s.modifyCount(Seq("b", "c", "d"), 1, 1, 5))
 
     // update ds card count
-    (1 to 1000).foreach(_ => t.modifyCount(Seq("a", "b", "c"), 1, 1))
-    (1 to 1000).foreach(_ => t.modifyCount(Seq("a", "b", "d"), 1, 1))
-    (1 to 1000).foreach(_ => t.modifyCount(Seq("a", "c", "d"), 1, 1))
-    (1 to 1000).foreach(_ => t.modifyCount(Seq("b", "c", "d"), 1, 1))
+    (1 to 1000).foreach(_ => t.modifyCount(Seq("a", "b", "c"), 1, 1, 5))
+    (1 to 1000).foreach(_ => t.modifyCount(Seq("a", "b", "d"), 1, 1, 5))
+    (1 to 1000).foreach(_ => t.modifyCount(Seq("a", "c", "d"), 1, 1, 5))
+    (1 to 1000).foreach(_ => t.modifyCount(Seq("b", "c", "d"), 1, 1, 5))
 
     t.flushCardinalityCount()
 
@@ -417,5 +417,26 @@ class CardinalityTrackerSpec extends AnyFunSpec with Matchers {
 
     s.close()
     t.close()
+  }
+
+  it("modifyCount should require same-sign active & billable arguments") {
+    val cardTracker = new CardinalityTracker(
+      ref, 0, 3, Seq(20, 20, 20, 20), newCardStore)
+
+    // Sanity-check; should not throw.
+    cardTracker.modifyCount(Seq("abc", "def", "ghi"), 1, 1, 5)
+
+    assertThrows[IllegalArgumentException] {
+      cardTracker.modifyCount(Seq("abc", "def", "ghi"), 1, -1, 5)
+    }
+    assertThrows[IllegalArgumentException] {
+      cardTracker.modifyCount(Seq("abc", "def", "ghi"), 1, 1, -5)
+    }
+    assertThrows[IllegalArgumentException] {
+      cardTracker.modifyCount(Seq("abc", "def", "ghi"), 1, 0, 5)
+    }
+    assertThrows[IllegalArgumentException] {
+      cardTracker.modifyCount(Seq("abc", "def", "ghi"), 1, 1, 0)
+    }
   }
 }

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreMemoryCapSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreMemoryCapSpec.scala
@@ -36,7 +36,7 @@ class RocksDbCardinalityStoreMemoryCapSpec  extends AnyFunSpec with Matchers {
           name <- 0 until 50
           ts <- 0 until 100 } {
       val mName = s"name_really_really_really_really_very_really_long_metric_name_$name"
-      tracker.modifyCount(Seq( s"ws_prefix_$ws", s"ns_prefix_$ns", mName), 1, 0)
+      tracker.modifyCount(Seq( s"ws_prefix_$ws", s"ns_prefix_$ns", mName), 1, 0, 0)
       if (name == 0 && ts ==0 ) assertStats()
     }
     val end = System.nanoTime()

--- a/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/ratelimit/RocksDbCardinalityStoreSpec.scala
@@ -15,14 +15,14 @@ class RocksDbCardinalityStoreSpec extends AnyFunSpec with Matchers {
 
     (0 until MAX_RESULT_SIZE + numOverflow).foreach{ i =>
       val prefix = Seq("ws", "ns", s"metric-$i")
-      db.store(CardinalityRecord(shard, prefix, CardinalityValue(1, 1, 1, 1)))
+      db.store(CardinalityRecord(shard, prefix, CardinalityValue(1, 1, 1, 1, 1)))
     }
 
     Seq(Nil, Seq("ws"), Seq("ws", "ns")).foreach{ prefix =>
       val res = db.scanChildren(prefix, 3)
       res.size shouldEqual MAX_RESULT_SIZE + 1  // one extra for the overflow CardinalityRecord
       res.contains(CardinalityRecord(shard, OVERFLOW_PREFIX,
-        CardinalityValue(numOverflow, numOverflow, numOverflow, numOverflow))) shouldEqual true
+        CardinalityValue(numOverflow, numOverflow, numOverflow, numOverflow, numOverflow))) shouldEqual true
     }
   }
 
@@ -34,7 +34,7 @@ class RocksDbCardinalityStoreSpec extends AnyFunSpec with Matchers {
     (0 until 1000).foreach{ i =>
       val prefix = Seq("ws", "ns", s"metric-$i")
       // storing 3 billion ( this value is greater than ~2.15 billion max limit of int32)
-      val cardnalityVal = CardinalityValue(3000000000L+i, 3000000000L+i, 3000000000L+i, 3000000000L+i)
+      val cardnalityVal = CardinalityValue(3000000000L+i, 3000000000L+i, 3000000000L+i, 3000000000L+i, 3000000000L+i)
       db.store(CardinalityRecord(shard, prefix, cardnalityVal))
     }
 

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -95,13 +95,13 @@ final case class TsCardReduceExec(queryContext: QueryContext,
       // Check if we either (1) won't increase the size or (2) have enough room for another.
       // Accordingly retrieve the key to update and the counts to increment.
       val (groupKey, accCounts) = if (accCountsOpt.nonEmpty || acc.contains(data.group) || acc.size < resultSize) {
-        (data.group, accCountsOpt.getOrElse(CardCounts(0, 0)))
+        (data.group, accCountsOpt.getOrElse(CardCounts(0, 0, 0)))
       } else {
         // aggregate by dataset as well
         val groupArray = data.group.toString.split(TsCardExec.PREFIX_DELIM)
         val dataset = groupArray(groupArray.size - 1)
         val dataGroup = prefixToGroupWithDataset(CardinalityStore.OVERFLOW_PREFIX, dataset)
-        (dataGroup, acc.getOrElseUpdate(dataGroup, CardCounts(0, 0)))
+        (dataGroup, acc.getOrElseUpdate(dataGroup, CardCounts(0, 0, 0)))
       }
       acc.update(groupKey, accCounts.add(data.counts))
     }
@@ -485,6 +485,7 @@ final case object TsCardExec {
    */
   val RESULT_SCHEMA = ResultSchema(Seq(ColumnInfo("group", ColumnType.StringColumn),
                                        ColumnInfo("active", ColumnType.LongColumn),
+                                       ColumnInfo("billable", ColumnType.LongColumn),
                                        ColumnInfo("shortTerm", ColumnType.LongColumn),
                                        ColumnInfo("longTerm", ColumnType.LongColumn)), 1)
 
@@ -499,15 +500,19 @@ final case object TsCardExec {
 
   /**
    * @param active Actively (1 hourt) Ingesting Cardinality Count
+   * @param billable Series ingested within the last 1h (same as "active"), but where each series' cardinality
+   *                 is scaled by the multipliers defined in
+   *                 [[filodb.core.memstore.TimeSeriesShard.schemaNameToBillableCardinalityPerActiveSeries]]
    * @param shortTerm This is the 7 day running Cardinality Count
    * @param longTerm upto 6 month running Cardinality Count
    */
-  case class CardCounts(active: Long, shortTerm: Long, longTerm: Long = 0) {
+  case class CardCounts(active: Long, billable: Long, shortTerm: Long, longTerm: Long = 0) {
     if (shortTerm < active) {
       qLogger.warn(s"CardCounts created with total < active; shortTerm: $shortTerm, active: $active")
     }
     def add(other: CardCounts): CardCounts = {
       CardCounts(active + other.active,
+                 billable + other.billable,
                  shortTerm + other.shortTerm,
                  longTerm + other.longTerm)
     }
@@ -519,8 +524,9 @@ final case object TsCardExec {
     override def getInt(columnNo: Int): Int = ???
     override def getLong(columnNo: Int): Long = columnNo match {
       case 1 => counts.active
-      case 2 => counts.shortTerm
-      case 3 => counts.longTerm
+      case 2 => counts.billable
+      case 3 => counts.shortTerm
+      case 4 => counts.longTerm
       case _ => throw new IllegalArgumentException(s"illegal getInt columnNo: $columnNo")
     }
     override def getDouble(columnNo: Int): Double = ???
@@ -544,7 +550,9 @@ final case object TsCardExec {
   object RowData {
     def fromRowReader(rr: RowReader): RowData = {
       val group = rr.getAny(0).asInstanceOf[ZeroCopyUTF8String]
-      val counts = CardCounts(rr.getLong(1), rr.getLong(2), rr.getLong(3))
+      val counts = CardCounts(
+        rr.getLong(1), rr.getLong(2),
+        rr.getLong(3), rr.getLong(4))
       RowData(group, counts)
     }
   }
@@ -599,7 +607,7 @@ final case class TsCardExec(queryContext: QueryContext,
             else {
               CardRowReader(
                 groupKey,
-                CardCounts(card.value.activeTsCount, card.value.tsCount))
+                CardCounts(card.value.activeTsCount, card.value.billableTsCount, card.value.tsCount))
             }
           }.iterator
           IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty), NoCloseCursor(it), None)

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -485,9 +485,9 @@ final case object TsCardExec {
    */
   val RESULT_SCHEMA = ResultSchema(Seq(ColumnInfo("group", ColumnType.StringColumn),
                                        ColumnInfo("active", ColumnType.LongColumn),
-                                       ColumnInfo("billable", ColumnType.LongColumn),
                                        ColumnInfo("shortTerm", ColumnType.LongColumn),
-                                       ColumnInfo("longTerm", ColumnType.LongColumn)), 1)
+                                       ColumnInfo("longTerm", ColumnType.LongColumn),
+                                       ColumnInfo("billable", ColumnType.LongColumn)), 1)
 
   /**
    * @param prefix ShardKeyPrefix from the Cardinality Record
@@ -524,9 +524,9 @@ final case object TsCardExec {
     override def getInt(columnNo: Int): Int = ???
     override def getLong(columnNo: Int): Long = columnNo match {
       case 1 => counts.active
-      case 2 => counts.billable
-      case 3 => counts.shortTerm
-      case 4 => counts.longTerm
+      case 2 => counts.shortTerm
+      case 3 => counts.longTerm
+      case 4 => counts.billable
       case _ => throw new IllegalArgumentException(s"illegal getInt columnNo: $columnNo")
     }
     override def getDouble(columnNo: Int): Double = ???
@@ -550,9 +550,11 @@ final case object TsCardExec {
   object RowData {
     def fromRowReader(rr: RowReader): RowData = {
       val group = rr.getAny(0).asInstanceOf[ZeroCopyUTF8String]
-      val counts = CardCounts(
-        rr.getLong(1), rr.getLong(2),
-        rr.getLong(3), rr.getLong(4))
+      val active = rr.getLong(1)
+      val shortTerm = rr.getLong(2)
+      val longTerm = rr.getLong(3)
+      val billable = rr.getLong(4)
+      val counts = CardCounts(active, billable, shortTerm, longTerm)
       RowData(group, counts)
     }
   }

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -602,7 +602,7 @@ final case class TsCardExec(queryContext: QueryContext,
             if (clusterNameLowercase.contains("downsample")) {
               CardRowReader(
                 groupKey,
-                CardCounts(0, 0, card.value.tsCount))
+                CardCounts(0, 0, 0, card.value.tsCount))
             }
             else {
               CardRowReader(

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -89,8 +89,10 @@ case class MetadataRemoteExec(queryEndpoint: String,
       .map { ts =>
         val prefix = SHARD_KEY_LABELS.take(ts.group.size).map(l => ts.group(l))
         val counts = CardCounts(
-          ts.cardinality("active"), ts.cardinality("billable"),
-          ts.cardinality("shortTerm"), ts.cardinality("longTerm"))
+          ts.cardinality("active"),
+          ts.cardinality.getOrElse("billable", 0),  // Backwards compatibility.
+          ts.cardinality("shortTerm"),
+          ts.cardinality("longTerm"))
         CardRowReader(prefixToGroupWithDataset(prefix, ts._type), counts)
       }
     val rv = IteratorBackedRangeVector(CustomRangeVectorKey.empty, NoCloseCursor(rows.iterator), None)

--- a/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataRemoteExec.scala
@@ -88,7 +88,9 @@ case class MetadataRemoteExec(queryEndpoint: String,
     val rows = response.data.asInstanceOf[Seq[TsCardinalitiesSamplV2]]
       .map { ts =>
         val prefix = SHARD_KEY_LABELS.take(ts.group.size).map(l => ts.group(l))
-        val counts = CardCounts(ts.cardinality("active"), ts.cardinality("shortTerm"), ts.cardinality("longTerm"))
+        val counts = CardCounts(
+          ts.cardinality("active"), ts.cardinality("billable"),
+          ts.cardinality("shortTerm"), ts.cardinality("longTerm"))
         CardRowReader(prefixToGroupWithDataset(prefix, ts._type), counts)
       }
     val rv = IteratorBackedRangeVector(CustomRangeVectorKey.empty, NoCloseCursor(rows.iterator), None)

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -420,41 +420,41 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
     //   and converted to ZeroCopyUTF8Strings.
     Seq(
       TestSpec(Seq(), 1, Seq(
-        Seq("demo") -> CardCounts(4,4,4),
-        Seq("testws") -> CardCounts(1,1,1),
-        Seq("demo-A") -> CardCounts(1,1,1)
+        Seq("demo") -> CardCounts(4,4,4,4),
+        Seq("testws") -> CardCounts(1,1,1,1),
+        Seq("demo-A") -> CardCounts(1,1,1,1)
         )),
       TestSpec(Seq(), 2, Seq(
-        Seq("demo", "App-0") -> CardCounts(4,4,4),
-        Seq("testws", "testns") -> CardCounts(1,1,1),
-        Seq("demo-A", "App-A") -> CardCounts(1,1,1)
+        Seq("demo", "App-0") -> CardCounts(4,4,4,4),
+        Seq("testws", "testns") -> CardCounts(1,1,1,1),
+        Seq("demo-A", "App-A") -> CardCounts(1,1,1,1)
       )),
       TestSpec(Seq(), 3, Seq(
-        Seq("demo", "App-0", "http_req_total") -> CardCounts(2,2,2),
-        Seq("demo", "App-0", "http_bar_total") -> CardCounts(1,1,1),
-        Seq("demo", "App-0", "http_foo_total") -> CardCounts(1,1,1),
-        Seq("demo-A", "App-A", "http_req_total-A") -> CardCounts(1,1,1),
-        Seq("testws", "testns", "long_labels_metric") -> CardCounts(1,1,1)
+        Seq("demo", "App-0", "http_req_total") -> CardCounts(2,2,2,2),
+        Seq("demo", "App-0", "http_bar_total") -> CardCounts(1,1,1,1),
+        Seq("demo", "App-0", "http_foo_total") -> CardCounts(1,1,1,1),
+        Seq("demo-A", "App-A", "http_req_total-A") -> CardCounts(1,1,1,1),
+        Seq("testws", "testns", "long_labels_metric") -> CardCounts(1,1,1,1)
       )),
       TestSpec(Seq("demo"), 1, Seq(
-        Seq("demo") -> CardCounts(4,4,4))),
+        Seq("demo") -> CardCounts(4,4,4,4))),
       TestSpec(Seq("demo"), 2, Seq(
-        Seq("demo", "App-0") -> CardCounts(4,4,4))),
+        Seq("demo", "App-0") -> CardCounts(4,4,4,4))),
       TestSpec(Seq("demo"), 3, Seq(
-        Seq("demo", "App-0", "http_req_total") -> CardCounts(2,2,2),
-        Seq("demo", "App-0", "http_bar_total") -> CardCounts(1,1,1),
-        Seq("demo", "App-0", "http_foo_total") -> CardCounts(1,1,1)
+        Seq("demo", "App-0", "http_req_total") -> CardCounts(2,2,2,2),
+        Seq("demo", "App-0", "http_bar_total") -> CardCounts(1,1,1,1),
+        Seq("demo", "App-0", "http_foo_total") -> CardCounts(1,1,1,1)
       )),
       TestSpec(Seq("demo", "App-0"), 2, Seq(
-        Seq("demo", "App-0") -> CardCounts(4,4,4)
+        Seq("demo", "App-0") -> CardCounts(4,4,4,4)
       )),
       TestSpec(Seq("demo", "App-0"), 3, Seq(
-        Seq("demo", "App-0", "http_req_total") -> CardCounts(2,2,2),
-        Seq("demo", "App-0", "http_bar_total") -> CardCounts(1,1,1),
-        Seq("demo", "App-0", "http_foo_total") -> CardCounts(1,1,1)
+        Seq("demo", "App-0", "http_req_total") -> CardCounts(2,2,2,2),
+        Seq("demo", "App-0", "http_bar_total") -> CardCounts(1,1,1,1),
+        Seq("demo", "App-0", "http_foo_total") -> CardCounts(1,1,1,1)
       )),
       TestSpec(Seq("demo", "App-0", "http_req_total"), 3, Seq(
-        Seq("demo", "App-0", "http_req_total") -> CardCounts(2,2,2)))
+        Seq("demo", "App-0", "http_req_total") -> CardCounts(2,2,2,2)))
     ).foreach{ testSpec =>
 
       val leavesRaw = (0 until shardPartKeyLabelValues.size).map{ ishard =>
@@ -495,11 +495,11 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
     case class TestSpec(shardKeyPrefix: Seq[String], numGroupByFields: Int, exp: Seq[(Seq[String], CardCounts)])
 
    val testSpec = TestSpec(Seq(), 3, Seq(
-     Seq("demo", "App-0", "http_req_total") -> CardCounts(2, 2, 2),
-     Seq("demo", "App-0", "http_bar_total") -> CardCounts(1, 1, 1),
-     Seq("demo", "App-0", "http_foo_total") -> CardCounts(1, 1, 1),
-     Seq("demo-A", "App-A", "http_req_total-A") -> CardCounts(1, 1, 1),
-     Seq("testws", "testns", "long_labels_metric") -> CardCounts(1, 1, 1)
+     Seq("demo", "App-0", "http_req_total") -> CardCounts(2, 2, 2, 2),
+     Seq("demo", "App-0", "http_bar_total") -> CardCounts(1, 1, 1, 1),
+     Seq("demo", "App-0", "http_foo_total") -> CardCounts(1, 1, 1, 1),
+     Seq("demo-A", "App-A", "http_req_total-A") -> CardCounts(1, 1, 1, 1),
+     Seq("testws", "testns", "long_labels_metric") -> CardCounts(1, 1, 1, 1)
    ))
 
     val leavesRaw = (0 until shardPartKeyLabelValues.size).map { ishard =>
@@ -539,7 +539,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
         testMap.contains(nonOverflowRow.group) shouldEqual true
         testMap.get(nonOverflowRow.group).get shouldEqual nonOverflowRow.counts
 
-        var totalCardCountWithoutOverflow = CardCounts(0, 0, 0)
+        var totalCardCountWithoutOverflow = CardCounts(0, 0, 0, 0)
         val cardCountsWithoutNonOverflow = testMap.filter(x => (x._1 != nonOverflowRow.group)).toList
 
         cardCountsWithoutNonOverflow.map(x => totalCardCountWithoutOverflow = totalCardCountWithoutOverflow.add(x._2))

--- a/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
@@ -249,6 +249,58 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
 
     val samples = Seq(
       TsCardinalitiesSamplV2(Map("_ws_" -> "foo", "_ns_" -> "bar", "__name__" -> "baz"),
+        Map("active" -> 123, "billable" -> 234, "shortTerm" -> 345, "longTerm" -> 500), "raw", "prometheus"),
+      TsCardinalitiesSamplV2(Map("_ws_" -> "foo", "_ns_" -> "bar", "__name__" -> "bat"),
+        Map("active" -> 234, "billable" -> 345, "shortTerm" -> 456, "longTerm" -> 1000), "aggregated", "prometheus_preagg"),
+      TsCardinalitiesSamplV2(Map("_ws_" -> "foo", "_ns_" -> "bar", "__name__" -> "bak"),
+        Map("active" -> 456, "billable" -> 567, "shortTerm" -> 678, "longTerm" -> 0), "recordingrules", "prometheus_rules_1m"),
+    )
+
+    val testingBackendTsCard: SttpBackend[Future, Nothing] = SttpBackendStub.asynchronousFuture
+      .whenRequestMatches(_.uri.path.startsWith(List("api", "v2", "metering", "cardinality", "timeseries"))
+      )
+      .thenRespondWrapped(Future {
+        Response(Right(Right(MetadataSuccessResponse(samples, "success", Option.empty, Option.empty))),
+          StatusCodes.PartialContent, "", Nil, Nil)
+      })
+
+    val exec: MetadataRemoteExec = MetadataRemoteExec(
+      "http://localhost:31007/api/v2/metering/cardinality/timeseries", 10000L,
+      Map("match[]" -> """{_ws_="foo", _ns_="bar"}""", "numGroupByFields" -> "3", "verbose" -> "true",
+      "datasets" -> "longtime-prometheus,longtime-prometheus_preagg,recordingrules-prometheus_rules_1m"),
+      QueryContext(origQueryParams = PromQlQueryParams("test", 123L, 234L, 15L,
+        Option("http://localhost:31007/api/v2/metering/cardinality/timeseries"))),
+      InProcessPlanDispatcher(queryConfig), timeseriesDataset.ref, RemoteHttpClient(configBuilder.build(),
+        testingBackendTsCard), queryConfig)
+
+    val resp = exec.execute(memStore, querySession).runToFuture.futureValue
+    val result = (resp: @unchecked) match {
+      case QueryResult(id, _, response, _, _, _, _) =>
+        // should only contain a single RV where each row describes a single group's cardinalities
+        response.size shouldEqual 1
+        val rows = response.head.rows().map { rr =>
+          RowData.fromRowReader(rr)
+        }.toSet
+        val expRows = samples.map { s =>
+          // order the shard keys according to precedence
+          val prefix = SHARD_KEY_LABELS.map(s.group(_))
+          val counts = CardCounts(
+            s.cardinality("active"),
+            s.cardinality("billable"),
+            s.cardinality("shortTerm"),
+            s.cardinality("longTerm"))
+          RowData(prefixToGroupWithDataset(prefix, s._type), counts)
+        }.toSet
+        rows shouldEqual expRows
+    }
+  }
+
+  it("timeseries cardinality version 2 remote exec backwards compatibility") {
+    import TsCardExec._
+    import TsCardinalities._
+
+    val samples = Seq(
+      TsCardinalitiesSamplV2(Map("_ws_" -> "foo", "_ns_" -> "bar", "__name__" -> "baz"),
         Map("active" -> 123, "shortTerm" -> 234, "longTerm" -> 500), "raw", "prometheus"),
       TsCardinalitiesSamplV2(Map("_ws_" -> "foo", "_ns_" -> "bar", "__name__" -> "bat"),
         Map("active" -> 345, "shortTerm" -> 456, "longTerm" -> 1000), "aggregated", "prometheus_preagg"),
@@ -284,7 +336,11 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
         val expRows = samples.map { s =>
           // order the shard keys according to precedence
           val prefix = SHARD_KEY_LABELS.map(s.group(_))
-          val counts = CardCounts(s.cardinality("active"), s.cardinality("shortTerm"), s.cardinality("longTerm"))
+          val counts = CardCounts(
+            s.cardinality("active"),
+            0,  // billable
+            s.cardinality("shortTerm"),
+            s.cardinality("longTerm"))
           RowData(prefixToGroupWithDataset(prefix, s._type), counts)
         }.toSet
         rows shouldEqual expRows


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Currently, `TimeSeriesShard` increments/decrements cardinality counts by `1` for all series.

This does not accurately reflect the resource-utilization weight of heavier series (i.e. histograms).

**New behavior :**

This PR updates `TimeSeriesShard` to instead count "billable" cardinalities; each series' "physical" active cardinality is multiplied by a configurable factor intended to reflect its resource-utilization weight.

For example, with a configuration such as this:
```
filodb {
  schema-name-to-billable-cardinality-per-active-series {
    prom-histogram = 15
  }
}
```
-- billable cardinalities would increment/decrement by `15` for `prom-histogram`s.

**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: