### PR TITLE
feat(core): add PreEncodedMap class and addPreEncodedMap to RecordBuilder

### DIFF
--- a/core/src/main/scala/filodb.core/binaryrecord2/PreEncodedMap.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/PreEncodedMap.scala
@@ -1,0 +1,143 @@
+package filodb.core.binaryrecord2
+
+import java.nio.charset.StandardCharsets
+import java.util
+
+import filodb.memory.UTF8StringMedium
+import filodb.memory.UTF8StringShort
+import filodb.memory.format.UnsafeUtils
+import filodb.memory.format.UnsafeUtils.{arayOffset, setByte}
+
+// scalastyle:off null
+/**
+ * Pre-encoded tag map in RecordBuilder's exact wire format, including predefined key handling.
+ *
+ * Stores tags as a single byte[] using the same encoding as RecordBuilder.addMapKeyValue():
+ *   Predefined key: [0xC0 | predefKeyNum (1B)][valLen (2B native-endian)][valBytes]
+ *   Full key:       [keyLen (1B)][keyBytes UTF-8][valLen (2B native-endian)][valBytes UTF-8]
+ *
+ * The byte[] stores entries only — no 2-byte map length header (RecordBuilder adds that).
+ * Immutable after construction. Thread-safe for reads.
+ */
+final class PreEncodedMap private(private val data: Array[Byte], val schema: RecordSchema) {
+
+  /** Raw entry bytes. */
+  def bytes(): Array[Byte] = data
+
+  /** Number of bytes in the encoded data. */
+  def size(): Int = data.length
+
+  /** Whether this map has no entries. */
+  def isEmpty: Boolean = data.length == 0
+
+  /**
+   * Decode all entries into a sorted Java Map.
+   *
+   * Uses the exact same encoding as RecordBuilder.addMapKeyValue:
+   * - Predefined key lookup via RecordSchema.makeKeyKey + predefKeyNumMap
+   * - UTF8StringShort for non-predefined keys (1B length + bytes)
+   * - UTF8StringMedium for values (2B length + bytes, native endian)
+   */
+  def toJavaMap(): java.util.Map[String, String] = {
+    val map = new util.TreeMap[String, String]()
+    if (data.length == 0) return map
+
+    var pos = 0
+    while (pos < data.length) {
+      val firstByte = data(pos) & 0xFF
+      val predefIndex = firstByte ^ 0xC0
+
+      if (predefIndex < 64) {
+        // Predefined key — decode from schema
+        val keyOff = schema.predefKeyOffsets(predefIndex)
+        val keyLen = UTF8StringShort.numBytes(schema.predefKeyBytes, keyOff)
+        val keyStr = new String(schema.predefKeyBytes,
+          (keyOff + 1 - UnsafeUtils.arayOffset).toInt, keyLen, StandardCharsets.UTF_8)
+
+        val valLen = UnsafeUtils.getShort(data, UnsafeUtils.arayOffset + pos + 1) & 0xFFFF
+        val valStr = new String(data, pos + 3, valLen, StandardCharsets.UTF_8)
+        map.put(keyStr, valStr)
+        pos += 3 + valLen
+      } else {
+        // Full key
+        val keyLen = firstByte
+        val keyStr = new String(data, pos + 1, keyLen, StandardCharsets.UTF_8)
+
+        val valLenPos = pos + 1 + keyLen
+        val valLen = UnsafeUtils.getShort(data, UnsafeUtils.arayOffset + valLenPos) & 0xFFFF
+        val valStr = new String(data, valLenPos + 2, valLen, StandardCharsets.UTF_8)
+        map.put(keyStr, valStr)
+        pos += 1 + keyLen + 2 + valLen
+      }
+    }
+    map
+  }
+
+  override def toString: String = toJavaMap().toString
+}
+
+object PreEncodedMap {
+  private val EMPTY_DATA = new Array[Byte](0)
+
+  /**
+   * Encode a sorted tag map into RecordBuilder's wire format with predefined key handling.
+   * The input map MUST be sorted by key (e.g. TreeMap) to match RecordBuilder's convention.
+   *
+   * Uses the exact same encoding as RecordBuilder.addMapKeyValue:
+   * - Predefined key lookup via RecordSchema.makeKeyKey + predefKeyNumMap
+   * - UTF8StringShort for non-predefined keys (1B length + bytes)
+   * - UTF8StringMedium for values (2B length + bytes, native endian)
+   */
+  def encode(tags: java.util.Map[String, String], schema: RecordSchema): PreEncodedMap = {
+    if (tags == null || tags.isEmpty) return empty(schema)
+
+    // Upper bound: each entry at most 1 + keyLen*3 + 2 + valLen*3 (UTF-8 worst case)
+    var upperBound = 0
+    val iter = tags.entrySet().iterator()
+    while (iter.hasNext) {
+      val entry = iter.next()
+      upperBound += 1 + entry.getKey.length * 3 + 2 + entry.getValue.length * 3
+    }
+    val buf = new Array[Byte](upperBound)
+    var pos = 0
+
+    val iter2 = tags.entrySet().iterator()
+    while (iter2.hasNext) {
+      val entry = iter2.next()
+      val keyBytes = entry.getKey.getBytes(StandardCharsets.UTF_8)
+      val valBytes = entry.getValue.getBytes(StandardCharsets.UTF_8)
+
+      require(keyBytes.length < 192, s"Key too long: ${entry.getKey} (${keyBytes.length} bytes, max 191)")
+      require(valBytes.length < 65536, s"Value too long: ${entry.getValue} (${valBytes.length} bytes)")
+
+      // Predefined key lookup
+      val keyKey = RecordSchema.makeKeyKey(keyBytes, 0, keyBytes.length, 7)
+      val predefNum = schema.predefKeyNumMap.getOrElse(keyKey, -1)
+
+      if (predefNum >= 0) {
+        // Predefined key: 1-byte code
+        setByte(buf, arayOffset + pos, (0xC0 | predefNum).toByte)
+        pos += 1
+      } else {
+        // Full key: UTF8StringShort (1B length + bytes)
+        UTF8StringShort.copyByteArrayTo(keyBytes, buf, arayOffset + pos)
+        pos += 1 + keyBytes.length
+      }
+
+      // Value: UTF8StringMedium (2B length + bytes, native endian)
+      UTF8StringMedium.copyByteArrayTo(valBytes, buf, arayOffset + pos)
+      pos += 2 + valBytes.length
+    }
+
+    new PreEncodedMap(util.Arrays.copyOf(buf, pos), schema)
+  }
+
+  /** Wrap raw pre-encoded bytes from deserialization. Zero-copy. */
+  def fromBytes(data: Array[Byte], schema: RecordSchema): PreEncodedMap = {
+    if (data == null || data.length == 0) empty(schema)
+    else new PreEncodedMap(data, schema)
+  }
+
+  /** Create an empty PreEncodedMap. */
+  def empty(schema: RecordSchema): PreEncodedMap = new PreEncodedMap(EMPTY_DATA, schema)
+}

--- a/core/src/main/scala/filodb.core/binaryrecord2/PreEncodedMap.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/PreEncodedMap.scala
@@ -18,6 +18,10 @@ import filodb.memory.format.UnsafeUtils.{arayOffset, setByte}
  *
  * The byte[] stores entries only — no 2-byte map length header (RecordBuilder adds that).
  * Immutable after construction. Thread-safe for reads.
+ *
+ * IMPORTANT: The encoding in PreEncodedMap.encode() must exactly match
+ * RecordBuilder.addMapKeyValue(). If the wire format changes in either place,
+ * both must be updated together.
  */
 final class PreEncodedMap private(private val data: Array[Byte], val schema: RecordSchema) {
 

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -397,6 +397,24 @@ class RecordBuilder(memFactory: MemFactory,
   }
 
   /**
+   * Adds a pre-encoded map field directly from a byte array already in RecordBuilder wire format.
+   * Use PreEncodedMap.encode() to produce correctly encoded bytes.
+   */
+  final def addPreEncodedMap(mapBytes: Array[Byte]): Unit = {
+    val numBytes = mapBytes.length
+    require(numBytes < 65536, s"Map bytes too large: $numBytes")
+    startMap()
+    requireBytes(numBytes)
+    UnsafeUtils.unsafe.copyMemory(mapBytes, UnsafeUtils.arayOffset,
+                                  curBase, curRecEndOffset, numBytes)
+    curRecEndOffset += numBytes
+    // update map length and record length
+    setShort(curBase, mapOffset, numBytes.toShort)
+    setInt(curBase, curRecordOffset, (curRecEndOffset - curRecordOffset - 4).toInt)
+    endMap()
+  }
+
+  /**
    * Ends the building of the current BinaryRecord.  Makes sures RecordContainer state is updated.
    * Aligns the next record on a 4-byte/short word boundary.
    * Returns the Long offset of the just finished BinaryRecord.  If the container is offheap, then this is the

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -331,6 +331,10 @@ class RecordBuilder(memFactory: MemFactory,
    * Takes care of matching and translating predefined keys into short codes.
    * Keys must be < 60KB and values must be < 64KB
    * Hash is not computed or added for you - it must be separately added by you!
+   *
+   * IMPORTANT: PreEncodedMap.encode() replicates this encoding logic. If the wire format
+   * changes here (predefined key codes, UTF8StringShort/Medium encoding, byte order),
+   * PreEncodedMap must be updated to match.
    */
   final def addMapKeyValue(keyBytes: Array[Byte], keyOffset: Int, keyLen: Int,
                            valueBytes: Array[Byte], valueOffset: Int, valueLen: Int,

--- a/core/src/test/scala/filodb.core/binaryrecord2/PreEncodedMapSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/PreEncodedMapSpec.scala
@@ -29,28 +29,55 @@ class PreEncodedMapSpec extends AnyFunSpec with Matchers {
   // Non-preagg schema (raw Prometheus counter)
   private val promCounterSchema = schemas.schemas("prom-counter")
 
-  private val testTags: java.util.TreeMap[String, String] = {
-    val map = new TreeMap[String, String]()
-    map.put("_ns_", "filodb-local")
-    map.put("_ws_", "aci-telemetry")
-    map.put("dc", "us-west-2")
-    map.put("instance", "i-12345")
-    map.put("label1", "value1")
-    map.put("region", "us-east-1")
-    map
-  }
+  // Multiple tag maps with varying key/value sizes for exhaustive testing
+  private val testTagMaps: Seq[(String, java.util.TreeMap[String, String])] = Seq(
+    "small keys and small values" -> sortedMap(
+      "_ns_" -> "ns",
+      "_ws_" -> "ws",
+      "a" -> "1"
+    ),
+    "small keys and large values" -> sortedMap(
+      "_ns_" -> "a" * 100,
+      "_ws_" -> "b" * 200,
+      "dc" -> "c" * 500
+    ),
+    "large keys and small values" -> sortedMap(
+      "_ns_" -> "x",
+      "_ws_" -> "y",
+      "k" * 100 -> "v",
+      "long_label_name_that_is_verbose" -> "1"
+    ),
+    "large keys and large values" -> sortedMap(
+      "_ns_" -> "a" * 300,
+      "_ws_" -> "b" * 300,
+      "k" * 80 -> "v" * 500,
+      "another_long_key_name" -> "another_long_value_" * 20
+    ),
+    "mixed predefined and non-predefined keys" -> sortedMap(
+      "_ns_" -> "filodb-local",
+      "_ws_" -> "aci-telemetry",
+      "dc" -> "us-west-2",
+      "instance" -> "i-12345",
+      "label1" -> "value1",
+      "region" -> "us-east-1"
+    ),
+    "predefined keys only" -> sortedMap(
+      "_ns_" -> "filodb-local",
+      "_ws_" -> "aci-telemetry"
+    )
+  )
+
+  // Default tag map used for single-test helpers
+  private val testTags: java.util.TreeMap[String, String] = testTagMaps.find(
+    _._1 == "mixed predefined and non-predefined keys").get._2
 
   describe("PreEncodedMap.encode and toJavaMap round-trip") {
-    it("should round-trip with predefined keys only") {
-      val t = sortedMap("_ns_" -> "filodb-local", "_ws_" -> "aci-telemetry")
-      val pem = PreEncodedMap.encode(t, partSchema)
-      pem.isEmpty shouldBe false
-      pem.toJavaMap() shouldEqual t
-    }
-
-    it("should round-trip with mixed predefined and non-predefined keys") {
-      val pem = PreEncodedMap.encode(testTags, partSchema)
-      pem.toJavaMap() shouldEqual testTags
+    testTagMaps.foreach { case (desc, tags) =>
+      it(s"should round-trip: $desc") {
+        val pem = PreEncodedMap.encode(tags, partSchema)
+        pem.isEmpty shouldBe false
+        pem.toJavaMap() shouldEqual tags
+      }
     }
 
     it("should handle empty map") {
@@ -67,11 +94,13 @@ class PreEncodedMapSpec extends AnyFunSpec with Matchers {
   }
 
   describe("PreEncodedMap.fromBytes") {
-    it("should wrap bytes zero-copy") {
-      val pem = PreEncodedMap.encode(testTags, partSchema)
-      val restored = PreEncodedMap.fromBytes(pem.bytes(), partSchema)
-      restored.bytes() should be theSameInstanceAs pem.bytes()
-      restored.toJavaMap() shouldEqual testTags
+    testTagMaps.foreach { case (desc, tags) =>
+      it(s"should wrap bytes zero-copy: $desc") {
+        val pem = PreEncodedMap.encode(tags, partSchema)
+        val restored = PreEncodedMap.fromBytes(pem.bytes(), partSchema)
+        restored.bytes() should be theSameInstanceAs pem.bytes()
+        restored.toJavaMap() shouldEqual tags
+      }
     }
 
     it("should handle null bytes") {
@@ -92,71 +121,129 @@ class PreEncodedMapSpec extends AnyFunSpec with Matchers {
     }
   }
 
+  describe("predefined key compression") {
+    it("should produce smaller bytes when keys are predefined") {
+      val tags = sortedMap("_ns_" -> "filodb-local", "_ws_" -> "aci-telemetry", "instance" -> "i-001")
+      val withPredef = PreEncodedMap.encode(tags, partSchema)
+      // Encode with a schema that has no predefined keys (use ingestion schema from prom-counter
+      // won't work — need partition schema). Instead, compare against raw key byte sizes.
+      // Each predefined key saves (keyLen) bytes vs the 1-byte code.
+      // _ns_ = 4 bytes key → saves 4 bytes, _ws_ = 4 bytes → saves 4, instance = 8 bytes → saves 8
+      // Total savings = 16 bytes (minus 3 bytes for the 3 predefined codes) = net 13 bytes saved
+      withPredef.size() should be < (4 + 4 + 12 + 8 + 8 + 5 + 6 + 6) // raw size without compression
+    }
+  }
+
+  describe("different tags produce different hashes") {
+    it("should produce different partition hashes for records with different tags") {
+      val tags1 = sortedMap("_ns_" -> "ns1", "_ws_" -> "ws1")
+      val tags2 = sortedMap("_ns_" -> "ns2", "_ws_" -> "ws2")
+
+      val builder1 = new RecordBuilder(MemFactory.onHeapFactory, 4096)
+      builder1.startNewRecord(gaugeSchema)
+      builder1.addLong(12345L); builder1.addDouble(1.0); builder1.addDouble(0.0)
+      builder1.addDouble(1.0); builder1.addDouble(1.0)
+      builder1.addString("metric1")
+      builder1.addPreEncodedMap(PreEncodedMap.encode(tags1, gaugeSchema.ingestionSchema).bytes())
+      val off1 = builder1.endRecord()
+      val hash1 = gaugeSchema.ingestionSchema.partitionHash(builder1.currentContainer.get.base, off1)
+
+      val builder2 = new RecordBuilder(MemFactory.onHeapFactory, 4096)
+      builder2.startNewRecord(gaugeSchema)
+      builder2.addLong(12345L); builder2.addDouble(1.0); builder2.addDouble(0.0)
+      builder2.addDouble(1.0); builder2.addDouble(1.0)
+      builder2.addString("metric1")
+      builder2.addPreEncodedMap(PreEncodedMap.encode(tags2, gaugeSchema.ingestionSchema).bytes())
+      val off2 = builder2.endRecord()
+      val hash2 = gaugeSchema.ingestionSchema.partitionHash(builder2.currentContainer.get.base, off2)
+
+      hash1 should not equal hash2
+    }
+  }
+
+  describe("consumeMapItems reads back PreEncodedMap bytes correctly") {
+    it("should read back all key-value pairs from a record built with addPreEncodedMap") {
+      val tags = sortedMap(
+        "_ns_" -> "filodb-local",
+        "_ws_" -> "aci-telemetry",
+        "dc" -> "us-west-2",
+        "region" -> "us-east-1"
+      )
+      val ingestion = gaugeSchema.ingestionSchema
+      val pem = PreEncodedMap.encode(tags, ingestion)
+
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, 4096)
+      builder.startNewRecord(gaugeSchema)
+      builder.addLong(12345L); builder.addDouble(1.0); builder.addDouble(0.0)
+      builder.addDouble(1.0); builder.addDouble(1.0)
+      builder.addString("test_metric")
+      builder.addPreEncodedMap(pem.bytes())
+      val recOff = builder.endRecord()
+
+      val base = builder.currentContainer.get.base
+      val mapFieldIdx = ingestion.numFields - 1
+      val readBack = new StringifyMapItemConsumer()
+      ingestion.consumeMapItems(base, recOff, mapFieldIdx, readBack)
+
+      val result = new TreeMap[String, String]()
+      val pairs = readBack.stringPairs
+      for (i <- 0 until pairs.size) {
+        val t = pairs.apply(i)
+        result.put(t._1, t._2)
+      }
+      result shouldEqual tags
+    }
+  }
+
   describe("wire format compatibility with RecordBuilder") {
-    it("prom-counter (non-preagg schema)") {
-      // columns: timestamp, count, metric, tags
-      verifySchemaCompatibility(promCounterSchema, { b =>
+    val schemaTests: Seq[(String, Schema, RecordBuilder => Unit)] = Seq(
+      ("prom-counter", promCounterSchema, { b: RecordBuilder =>
         b.addLong(12345L)
         b.addDouble(42.0)
         b.addString("http_requests_total")
-      })
-    }
-
-    it("preagg-gauge") {
-      // columns: timestamp, count, min, sum, max, metric, tags
-      verifySchemaCompatibility(gaugeSchema, { b =>
+      }),
+      ("preagg-gauge", gaugeSchema, { b: RecordBuilder =>
         b.addLong(12345L); b.addDouble(5.0); b.addDouble(1.0)
         b.addDouble(15.0); b.addDouble(5.0)
         b.addString("test_gauge:::suffix")
-      })
-    }
-
-    it("preagg-delta-counter") {
-      // columns: timestamp, count, min, sum, max, metric, tags
-      verifySchemaCompatibility(deltaCounterSchema, { b =>
+      }),
+      ("preagg-delta-counter", deltaCounterSchema, { b: RecordBuilder =>
         b.addLong(12345L); b.addDouble(10.0); b.addDouble(2.0)
         b.addDouble(20.0); b.addDouble(8.0)
         b.addString("test_counter:::suffix")
-      })
-    }
-
-    it("preagg-delta-histogram") {
-      // columns: timestamp, sum, count, tscount, h(hist), metric, tags
-      verifySchemaCompatibility(deltaHistogramSchema, { b =>
+      }),
+      ("preagg-delta-histogram", deltaHistogramSchema, { b: RecordBuilder =>
         b.addLong(12345L); b.addDouble(100.0); b.addDouble(50.0)
         b.addDouble(10.0); b.addBlob(testHistogramBlob())
         b.addString("test_histogram:::suffix")
-      })
-    }
-
-    it("preagg-otel-delta-histogram") {
-      // columns: timestamp, sum, count, tscount, h(hist), min, max, metric, tags
-      verifySchemaCompatibility(otelDeltaHistogramSchema, { b =>
+      }),
+      ("preagg-otel-delta-histogram", otelDeltaHistogramSchema, { b: RecordBuilder =>
         b.addLong(12345L); b.addDouble(100.0); b.addDouble(50.0)
         b.addDouble(10.0); b.addBlob(testHistogramBlob())
         b.addDouble(1.0); b.addDouble(99.0)
         b.addString("test_otel_hist:::suffix")
-      })
-    }
-
-    it("preagg-otel-exp-delta-histogram") {
-      // columns: timestamp, sum, count, tscount, h(hist:exp), min, max, metric, tags
-      verifySchemaCompatibility(otelExpDeltaHistogramSchema, { b =>
+      }),
+      ("preagg-otel-exp-delta-histogram", otelExpDeltaHistogramSchema, { b: RecordBuilder =>
         b.addLong(12345L); b.addDouble(100.0); b.addDouble(50.0)
         b.addDouble(10.0); b.addBlob(testHistogramBlob())
         b.addDouble(1.0); b.addDouble(99.0)
         b.addString("test_otel_exp_hist:::suffix")
-      })
-    }
-
-    it("preagg-delta-histogram-v2") {
-      // columns: timestamp, sum, count, tscount, h(hist), min, max, sumLast, metric, tags
-      verifySchemaCompatibility(deltaHistogramV2Schema, { b =>
+      }),
+      ("preagg-delta-histogram-v2", deltaHistogramV2Schema, { b: RecordBuilder =>
         b.addLong(12345L); b.addDouble(100.0); b.addDouble(50.0)
         b.addDouble(10.0); b.addBlob(testHistogramBlob())
         b.addDouble(1.0); b.addDouble(99.0); b.addDouble(42.0)
         b.addString("test_hist_v2:::suffix")
       })
+    )
+
+    for {
+      (schemaName, schema, addCols) <- schemaTests
+      (tagDesc, tags) <- testTagMaps
+    } {
+      it(s"$schemaName with $tagDesc") {
+        verifySchemaCompatibility(schema, addCols, tags)
+      }
     }
   }
 
@@ -183,13 +270,14 @@ class PreEncodedMapSpec extends AnyFunSpec with Matchers {
    * 3. Partition hashes are identical
    */
   private def verifySchemaCompatibility(schema: Schema,
-                                        addDataColumns: RecordBuilder => Unit): Unit = {
+                                        addDataColumns: RecordBuilder => Unit,
+                                        tags: java.util.TreeMap[String, String]): Unit = {
     // Traditional path
-    val builder1 = new RecordBuilder(MemFactory.onHeapFactory, 4096)
+    val builder1 = new RecordBuilder(MemFactory.onHeapFactory, 16384)
     builder1.startNewRecord(schema)
     addDataColumns(builder1)
     builder1.startMap()
-    testTags.entrySet().forEach { entry =>
+    tags.entrySet().forEach { entry =>
       builder1.addMapKeyValue(
         entry.getKey.getBytes(StandardCharsets.UTF_8),
         entry.getValue.getBytes(StandardCharsets.UTF_8))
@@ -199,9 +287,9 @@ class PreEncodedMapSpec extends AnyFunSpec with Matchers {
 
     // addPreEncodedMap path
     val ingestion = schema.ingestionSchema
-    val pem = PreEncodedMap.encode(testTags, ingestion)
+    val pem = PreEncodedMap.encode(tags, ingestion)
 
-    val builder2 = new RecordBuilder(MemFactory.onHeapFactory, 4096)
+    val builder2 = new RecordBuilder(MemFactory.onHeapFactory, 16384)
     builder2.startNewRecord(schema)
     addDataColumns(builder2)
     builder2.addPreEncodedMap(pem.bytes())

--- a/core/src/test/scala/filodb.core/binaryrecord2/PreEncodedMapSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/PreEncodedMapSpec.scala
@@ -1,0 +1,186 @@
+package filodb.core.binaryrecord2
+
+import java.nio.charset.StandardCharsets
+import java.util.TreeMap
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import filodb.core.GlobalConfig
+import filodb.core.metadata.Schemas
+import filodb.memory._
+import filodb.memory.format.UnsafeUtils
+
+class PreEncodedMapSpec extends AnyFunSpec with Matchers {
+
+  // Load schemas from filodb-defaults.conf
+  private val schemas = Schemas.fromConfig(GlobalConfig.defaultFiloConfig).get
+  private val partSchema = schemas.part.binSchema
+
+  // Use preagg-gauge as a representative ingestion schema (has map column for tags)
+  private val gaugeSchema = schemas.schemas("preagg-gauge")
+  private val ingestionSchema = gaugeSchema.ingestionSchema
+
+  private def sortedMap(entries: (String, String)*): java.util.TreeMap[String, String] = {
+    val map = new TreeMap[String, String]()
+    entries.foreach { case (k, v) => map.put(k, v) }
+    map
+  }
+
+  describe("PreEncodedMap.encode and toJavaMap round-trip") {
+    it("should round-trip with predefined keys only") {
+      val tags = sortedMap("_ns_" -> "filodb-local", "_ws_" -> "aci-telemetry")
+      val pem = PreEncodedMap.encode(tags, partSchema)
+
+      pem.isEmpty shouldBe false
+      pem.toJavaMap() shouldEqual tags
+    }
+
+    it("should round-trip with mixed predefined and non-predefined keys") {
+      val tags = sortedMap(
+        "_ns_" -> "filodb-local",
+        "_ws_" -> "aci-telemetry",
+        "dc" -> "us-west-2",
+        "instance" -> "i-12345",
+        "label1" -> "value1",
+        "region" -> "us-east-1"
+      )
+      val pem = PreEncodedMap.encode(tags, partSchema)
+      pem.toJavaMap() shouldEqual tags
+    }
+
+    it("should handle empty map") {
+      val pem = PreEncodedMap.encode(new TreeMap[String, String](), partSchema)
+      pem.isEmpty shouldBe true
+      pem.size() shouldEqual 0
+      pem.toJavaMap().isEmpty shouldBe true
+    }
+
+    it("should handle null map") {
+      val pem = PreEncodedMap.encode(null, partSchema)
+      pem.isEmpty shouldBe true
+    }
+  }
+
+  describe("PreEncodedMap.fromBytes") {
+    it("should wrap bytes zero-copy") {
+      val tags = sortedMap("_ns_" -> "filodb-local", "_ws_" -> "aci-telemetry", "dc" -> "us-west-2")
+      val pem = PreEncodedMap.encode(tags, partSchema)
+      val restored = PreEncodedMap.fromBytes(pem.bytes(), partSchema)
+      restored.bytes() should be theSameInstanceAs pem.bytes()
+      restored.toJavaMap() shouldEqual tags
+    }
+
+    it("should handle null bytes") {
+      val pem = PreEncodedMap.fromBytes(null, partSchema)
+      pem.isEmpty shouldBe true
+    }
+
+    it("should handle empty bytes") {
+      val pem = PreEncodedMap.fromBytes(new Array[Byte](0), partSchema)
+      pem.isEmpty shouldBe true
+    }
+  }
+
+  describe("wire format compatibility with RecordBuilder") {
+    it("should produce bytes identical to RecordBuilder.startMap/addMapKeyValue/endMap") {
+      val tags = sortedMap(
+        "_ns_" -> "filodb-local",
+        "_ws_" -> "aci-telemetry",
+        "dc" -> "us-west-2",
+        "instance" -> "i-12345",
+        "label1" -> "value1",
+        "region" -> "us-east-1"
+      )
+
+      val pem = PreEncodedMap.encode(tags, ingestionSchema)
+
+      // Encode same tags via RecordBuilder for byte-level comparison
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, 4096)
+      builder.startNewRecord(gaugeSchema)
+      // preagg-gauge columns: timestamp, count, min, sum, max, metric, tags
+      builder.addLong(12345L)          // timestamp
+      builder.addDouble(1.0)           // count
+      builder.addDouble(0.0)           // min
+      builder.addDouble(1.0)           // sum
+      builder.addDouble(1.0)           // max
+      builder.addString("test_metric") // metric
+      builder.startMap()
+      tags.entrySet().forEach { entry =>
+        builder.addMapKeyValue(
+          entry.getKey.getBytes(StandardCharsets.UTF_8),
+          entry.getValue.getBytes(StandardCharsets.UTF_8))
+      }
+      builder.endMap()
+      val recOffset = builder.endRecord()
+
+      // Extract map bytes from the binary record
+      val base = builder.currentContainer.get.base
+      val mapFieldIdx = 6 // tags is the 7th column (0-indexed)
+      val mapFieldOffset = recOffset + UnsafeUtils.getInt(base, recOffset + ingestionSchema.fieldOffset(mapFieldIdx))
+      val mapLen = UnsafeUtils.getShort(base, mapFieldOffset) & 0xFFFF
+      val mapBytes = new Array[Byte](mapLen)
+      UnsafeUtils.unsafe.copyMemory(base, mapFieldOffset + 2, mapBytes, UnsafeUtils.arayOffset, mapLen)
+
+      pem.bytes() shouldEqual mapBytes
+    }
+  }
+
+  describe("PreEncodedMap.empty") {
+    it("should create an empty map") {
+      val pem = PreEncodedMap.empty(partSchema)
+      pem.isEmpty shouldBe true
+      pem.size() shouldEqual 0
+      pem.toJavaMap().isEmpty shouldBe true
+    }
+  }
+
+  describe("addPreEncodedMap hash compatibility") {
+    it("should produce same partition hash as startMap/addMapKeyValue/endMap") {
+      val tags = sortedMap(
+        "_ns_" -> "filodb-local",
+        "_ws_" -> "aci-telemetry",
+        "dc" -> "us-west-2",
+        "instance" -> "i-12345",
+        "label1" -> "value1",
+        "region" -> "us-east-1"
+      )
+
+      val pem = PreEncodedMap.encode(tags, ingestionSchema)
+
+      // Build record via traditional startMap/addMapKeyValue/endMap path
+      val builder1 = new RecordBuilder(MemFactory.onHeapFactory, 4096)
+      builder1.startNewRecord(gaugeSchema)
+      builder1.addLong(12345L)
+      builder1.addDouble(1.0)
+      builder1.addDouble(0.0)
+      builder1.addDouble(1.0)
+      builder1.addDouble(1.0)
+      builder1.addString("test_metric")
+      builder1.startMap()
+      tags.entrySet().forEach { entry =>
+        builder1.addMapKeyValue(
+          entry.getKey.getBytes(StandardCharsets.UTF_8),
+          entry.getValue.getBytes(StandardCharsets.UTF_8))
+      }
+      builder1.endMap()
+      val recOff1 = builder1.endRecord()
+      val hash1 = ingestionSchema.partitionHash(builder1.currentContainer.get.base, recOff1)
+
+      // Build record via addPreEncodedMap path
+      val builder2 = new RecordBuilder(MemFactory.onHeapFactory, 4096)
+      builder2.startNewRecord(gaugeSchema)
+      builder2.addLong(12345L)
+      builder2.addDouble(1.0)
+      builder2.addDouble(0.0)
+      builder2.addDouble(1.0)
+      builder2.addDouble(1.0)
+      builder2.addString("test_metric")
+      builder2.addPreEncodedMap(pem.bytes())
+      val recOff2 = builder2.endRecord()
+      val hash2 = ingestionSchema.partitionHash(builder2.currentContainer.get.base, recOff2)
+
+      hash1 shouldEqual hash2
+    }
+  }
+}

--- a/core/src/test/scala/filodb.core/binaryrecord2/PreEncodedMapSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/PreEncodedMapSpec.scala
@@ -7,9 +7,10 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 import filodb.core.GlobalConfig
-import filodb.core.metadata.Schemas
+import filodb.core.metadata.{Schema, Schemas}
 import filodb.memory._
 import filodb.memory.format.UnsafeUtils
+import filodb.memory.format.vectors.{BinaryHistogram, CustomBuckets}
 
 class PreEncodedMapSpec extends AnyFunSpec with Matchers {
 
@@ -17,36 +18,39 @@ class PreEncodedMapSpec extends AnyFunSpec with Matchers {
   private val schemas = Schemas.fromConfig(GlobalConfig.defaultFiloConfig).get
   private val partSchema = schemas.part.binSchema
 
-  // Use preagg-gauge as a representative ingestion schema (has map column for tags)
+  // All preagg schema types
   private val gaugeSchema = schemas.schemas("preagg-gauge")
-  private val ingestionSchema = gaugeSchema.ingestionSchema
+  private val deltaCounterSchema = schemas.schemas("preagg-delta-counter")
+  private val deltaHistogramSchema = schemas.schemas("preagg-delta-histogram")
+  private val otelDeltaHistogramSchema = schemas.schemas("preagg-otel-delta-histogram")
+  private val otelExpDeltaHistogramSchema = schemas.schemas("preagg-otel-exp-delta-histogram")
+  private val deltaHistogramV2Schema = schemas.schemas("preagg-delta-histogram-v2")
 
-  private def sortedMap(entries: (String, String)*): java.util.TreeMap[String, String] = {
+  // Non-preagg schema (raw Prometheus counter)
+  private val promCounterSchema = schemas.schemas("prom-counter")
+
+  private val testTags: java.util.TreeMap[String, String] = {
     val map = new TreeMap[String, String]()
-    entries.foreach { case (k, v) => map.put(k, v) }
+    map.put("_ns_", "filodb-local")
+    map.put("_ws_", "aci-telemetry")
+    map.put("dc", "us-west-2")
+    map.put("instance", "i-12345")
+    map.put("label1", "value1")
+    map.put("region", "us-east-1")
     map
   }
 
   describe("PreEncodedMap.encode and toJavaMap round-trip") {
     it("should round-trip with predefined keys only") {
-      val tags = sortedMap("_ns_" -> "filodb-local", "_ws_" -> "aci-telemetry")
-      val pem = PreEncodedMap.encode(tags, partSchema)
-
+      val t = sortedMap("_ns_" -> "filodb-local", "_ws_" -> "aci-telemetry")
+      val pem = PreEncodedMap.encode(t, partSchema)
       pem.isEmpty shouldBe false
-      pem.toJavaMap() shouldEqual tags
+      pem.toJavaMap() shouldEqual t
     }
 
     it("should round-trip with mixed predefined and non-predefined keys") {
-      val tags = sortedMap(
-        "_ns_" -> "filodb-local",
-        "_ws_" -> "aci-telemetry",
-        "dc" -> "us-west-2",
-        "instance" -> "i-12345",
-        "label1" -> "value1",
-        "region" -> "us-east-1"
-      )
-      val pem = PreEncodedMap.encode(tags, partSchema)
-      pem.toJavaMap() shouldEqual tags
+      val pem = PreEncodedMap.encode(testTags, partSchema)
+      pem.toJavaMap() shouldEqual testTags
     }
 
     it("should handle empty map") {
@@ -64,65 +68,18 @@ class PreEncodedMapSpec extends AnyFunSpec with Matchers {
 
   describe("PreEncodedMap.fromBytes") {
     it("should wrap bytes zero-copy") {
-      val tags = sortedMap("_ns_" -> "filodb-local", "_ws_" -> "aci-telemetry", "dc" -> "us-west-2")
-      val pem = PreEncodedMap.encode(tags, partSchema)
+      val pem = PreEncodedMap.encode(testTags, partSchema)
       val restored = PreEncodedMap.fromBytes(pem.bytes(), partSchema)
       restored.bytes() should be theSameInstanceAs pem.bytes()
-      restored.toJavaMap() shouldEqual tags
+      restored.toJavaMap() shouldEqual testTags
     }
 
     it("should handle null bytes") {
-      val pem = PreEncodedMap.fromBytes(null, partSchema)
-      pem.isEmpty shouldBe true
+      PreEncodedMap.fromBytes(null, partSchema).isEmpty shouldBe true
     }
 
     it("should handle empty bytes") {
-      val pem = PreEncodedMap.fromBytes(new Array[Byte](0), partSchema)
-      pem.isEmpty shouldBe true
-    }
-  }
-
-  describe("wire format compatibility with RecordBuilder") {
-    it("should produce bytes identical to RecordBuilder.startMap/addMapKeyValue/endMap") {
-      val tags = sortedMap(
-        "_ns_" -> "filodb-local",
-        "_ws_" -> "aci-telemetry",
-        "dc" -> "us-west-2",
-        "instance" -> "i-12345",
-        "label1" -> "value1",
-        "region" -> "us-east-1"
-      )
-
-      val pem = PreEncodedMap.encode(tags, ingestionSchema)
-
-      // Encode same tags via RecordBuilder for byte-level comparison
-      val builder = new RecordBuilder(MemFactory.onHeapFactory, 4096)
-      builder.startNewRecord(gaugeSchema)
-      // preagg-gauge columns: timestamp, count, min, sum, max, metric, tags
-      builder.addLong(12345L)          // timestamp
-      builder.addDouble(1.0)           // count
-      builder.addDouble(0.0)           // min
-      builder.addDouble(1.0)           // sum
-      builder.addDouble(1.0)           // max
-      builder.addString("test_metric") // metric
-      builder.startMap()
-      tags.entrySet().forEach { entry =>
-        builder.addMapKeyValue(
-          entry.getKey.getBytes(StandardCharsets.UTF_8),
-          entry.getValue.getBytes(StandardCharsets.UTF_8))
-      }
-      builder.endMap()
-      val recOffset = builder.endRecord()
-
-      // Extract map bytes from the binary record
-      val base = builder.currentContainer.get.base
-      val mapFieldIdx = 6 // tags is the 7th column (0-indexed)
-      val mapFieldOffset = recOffset + UnsafeUtils.getInt(base, recOffset + ingestionSchema.fieldOffset(mapFieldIdx))
-      val mapLen = UnsafeUtils.getShort(base, mapFieldOffset) & 0xFFFF
-      val mapBytes = new Array[Byte](mapLen)
-      UnsafeUtils.unsafe.copyMemory(base, mapFieldOffset + 2, mapBytes, UnsafeUtils.arayOffset, mapLen)
-
-      pem.bytes() shouldEqual mapBytes
+      PreEncodedMap.fromBytes(new Array[Byte](0), partSchema).isEmpty shouldBe true
     }
   }
 
@@ -135,52 +92,144 @@ class PreEncodedMapSpec extends AnyFunSpec with Matchers {
     }
   }
 
-  describe("addPreEncodedMap hash compatibility") {
-    it("should produce same partition hash as startMap/addMapKeyValue/endMap") {
-      val tags = sortedMap(
-        "_ns_" -> "filodb-local",
-        "_ws_" -> "aci-telemetry",
-        "dc" -> "us-west-2",
-        "instance" -> "i-12345",
-        "label1" -> "value1",
-        "region" -> "us-east-1"
-      )
-
-      val pem = PreEncodedMap.encode(tags, ingestionSchema)
-
-      // Build record via traditional startMap/addMapKeyValue/endMap path
-      val builder1 = new RecordBuilder(MemFactory.onHeapFactory, 4096)
-      builder1.startNewRecord(gaugeSchema)
-      builder1.addLong(12345L)
-      builder1.addDouble(1.0)
-      builder1.addDouble(0.0)
-      builder1.addDouble(1.0)
-      builder1.addDouble(1.0)
-      builder1.addString("test_metric")
-      builder1.startMap()
-      tags.entrySet().forEach { entry =>
-        builder1.addMapKeyValue(
-          entry.getKey.getBytes(StandardCharsets.UTF_8),
-          entry.getValue.getBytes(StandardCharsets.UTF_8))
-      }
-      builder1.endMap()
-      val recOff1 = builder1.endRecord()
-      val hash1 = ingestionSchema.partitionHash(builder1.currentContainer.get.base, recOff1)
-
-      // Build record via addPreEncodedMap path
-      val builder2 = new RecordBuilder(MemFactory.onHeapFactory, 4096)
-      builder2.startNewRecord(gaugeSchema)
-      builder2.addLong(12345L)
-      builder2.addDouble(1.0)
-      builder2.addDouble(0.0)
-      builder2.addDouble(1.0)
-      builder2.addDouble(1.0)
-      builder2.addString("test_metric")
-      builder2.addPreEncodedMap(pem.bytes())
-      val recOff2 = builder2.endRecord()
-      val hash2 = ingestionSchema.partitionHash(builder2.currentContainer.get.base, recOff2)
-
-      hash1 shouldEqual hash2
+  describe("wire format compatibility with RecordBuilder") {
+    it("prom-counter (non-preagg schema)") {
+      // columns: timestamp, count, metric, tags
+      verifySchemaCompatibility(promCounterSchema, { b =>
+        b.addLong(12345L)
+        b.addDouble(42.0)
+        b.addString("http_requests_total")
+      })
     }
+
+    it("preagg-gauge") {
+      // columns: timestamp, count, min, sum, max, metric, tags
+      verifySchemaCompatibility(gaugeSchema, { b =>
+        b.addLong(12345L); b.addDouble(5.0); b.addDouble(1.0)
+        b.addDouble(15.0); b.addDouble(5.0)
+        b.addString("test_gauge:::suffix")
+      })
+    }
+
+    it("preagg-delta-counter") {
+      // columns: timestamp, count, min, sum, max, metric, tags
+      verifySchemaCompatibility(deltaCounterSchema, { b =>
+        b.addLong(12345L); b.addDouble(10.0); b.addDouble(2.0)
+        b.addDouble(20.0); b.addDouble(8.0)
+        b.addString("test_counter:::suffix")
+      })
+    }
+
+    it("preagg-delta-histogram") {
+      // columns: timestamp, sum, count, tscount, h(hist), metric, tags
+      verifySchemaCompatibility(deltaHistogramSchema, { b =>
+        b.addLong(12345L); b.addDouble(100.0); b.addDouble(50.0)
+        b.addDouble(10.0); b.addBlob(testHistogramBlob())
+        b.addString("test_histogram:::suffix")
+      })
+    }
+
+    it("preagg-otel-delta-histogram") {
+      // columns: timestamp, sum, count, tscount, h(hist), min, max, metric, tags
+      verifySchemaCompatibility(otelDeltaHistogramSchema, { b =>
+        b.addLong(12345L); b.addDouble(100.0); b.addDouble(50.0)
+        b.addDouble(10.0); b.addBlob(testHistogramBlob())
+        b.addDouble(1.0); b.addDouble(99.0)
+        b.addString("test_otel_hist:::suffix")
+      })
+    }
+
+    it("preagg-otel-exp-delta-histogram") {
+      // columns: timestamp, sum, count, tscount, h(hist:exp), min, max, metric, tags
+      verifySchemaCompatibility(otelExpDeltaHistogramSchema, { b =>
+        b.addLong(12345L); b.addDouble(100.0); b.addDouble(50.0)
+        b.addDouble(10.0); b.addBlob(testHistogramBlob())
+        b.addDouble(1.0); b.addDouble(99.0)
+        b.addString("test_otel_exp_hist:::suffix")
+      })
+    }
+
+    it("preagg-delta-histogram-v2") {
+      // columns: timestamp, sum, count, tscount, h(hist), min, max, sumLast, metric, tags
+      verifySchemaCompatibility(deltaHistogramV2Schema, { b =>
+        b.addLong(12345L); b.addDouble(100.0); b.addDouble(50.0)
+        b.addDouble(10.0); b.addBlob(testHistogramBlob())
+        b.addDouble(1.0); b.addDouble(99.0); b.addDouble(42.0)
+        b.addString("test_hist_v2:::suffix")
+      })
+    }
+  }
+
+  private def sortedMap(entries: (String, String)*): java.util.TreeMap[String, String] = {
+    val map = new TreeMap[String, String]()
+    entries.foreach { case (k, v) => map.put(k, v) }
+    map
+  }
+
+  /** Creates a test histogram blob for hist columns. */
+  private def testHistogramBlob(): org.agrona.DirectBuffer = {
+    val buckets = new CustomBuckets(Array(1.0, 5.0, 10.0, 50.0, 100.0))
+    val values = Array(10L, 20L, 30L, 40L, 50L, 60L)
+    val buf = BinaryHistogram.histBuf
+    BinaryHistogram.writeDelta(buckets, values, buf)
+    buf
+  }
+
+  /**
+   * Builds a record using startMap/addMapKeyValue/endMap (the traditional path)
+   * and another using addPreEncodedMap, then verifies:
+   * 1. Map bytes are identical
+   * 2. Full record bytes are identical
+   * 3. Partition hashes are identical
+   */
+  private def verifySchemaCompatibility(schema: Schema,
+                                        addDataColumns: RecordBuilder => Unit): Unit = {
+    // Traditional path
+    val builder1 = new RecordBuilder(MemFactory.onHeapFactory, 4096)
+    builder1.startNewRecord(schema)
+    addDataColumns(builder1)
+    builder1.startMap()
+    testTags.entrySet().forEach { entry =>
+      builder1.addMapKeyValue(
+        entry.getKey.getBytes(StandardCharsets.UTF_8),
+        entry.getValue.getBytes(StandardCharsets.UTF_8))
+    }
+    builder1.endMap()
+    val recOff1 = builder1.endRecord()
+
+    // addPreEncodedMap path
+    val ingestion = schema.ingestionSchema
+    val pem = PreEncodedMap.encode(testTags, ingestion)
+
+    val builder2 = new RecordBuilder(MemFactory.onHeapFactory, 4096)
+    builder2.startNewRecord(schema)
+    addDataColumns(builder2)
+    builder2.addPreEncodedMap(pem.bytes())
+    val recOff2 = builder2.endRecord()
+
+    val container1 = builder1.currentContainer.get
+    val container2 = builder2.currentContainer.get
+
+    // Compare full record bytes
+    val recLen1 = UnsafeUtils.getInt(container1.base, recOff1) + 4
+    val recLen2 = UnsafeUtils.getInt(container2.base, recOff2) + 4
+    val recBytes1 = new Array[Byte](recLen1)
+    val recBytes2 = new Array[Byte](recLen2)
+    UnsafeUtils.unsafe.copyMemory(container1.base, recOff1, recBytes1, UnsafeUtils.arayOffset, recLen1)
+    UnsafeUtils.unsafe.copyMemory(container2.base, recOff2, recBytes2, UnsafeUtils.arayOffset, recLen2)
+    recBytes1 shouldEqual recBytes2
+
+    // Compare map bytes
+    val mapFieldIdx = ingestion.numFields - 1
+    val mapFieldOffset1 = recOff1 + UnsafeUtils.getInt(container1.base, recOff1 + ingestion.fieldOffset(mapFieldIdx))
+    val mapLen1 = UnsafeUtils.getShort(container1.base, mapFieldOffset1) & 0xFFFF
+    val mapBytes1 = new Array[Byte](mapLen1)
+    UnsafeUtils.unsafe.copyMemory(container1.base, mapFieldOffset1 + 2, mapBytes1, UnsafeUtils.arayOffset, mapLen1)
+    pem.bytes() shouldEqual mapBytes1
+
+    // Compare partition hashes
+    val hash1 = ingestion.partitionHash(container1.base, recOff1)
+    val hash2 = ingestion.partitionHash(container2.base, recOff2)
+    hash1 shouldEqual hash2
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
Tags must be re-encoded on every record insertion via RecordBuilder.addMapKeyValue(). There's no way to pre-encode a tag map and reuse the bytes across multiple records with the same tags. 


**New behavior :**
PreEncodedMap allows encoding a tag map once into RecordBuilder's binary wire format, then reusing the raw bytes across multiple records. RecordBuilder.addPreEncodedMap() accepts these pre-encoded bytes directly, avoiding repeated key lookups and byte conversions. 



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: