### PR TITLE
feat(query): Add HAPlanner support for TsCardinalities

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -204,12 +204,7 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
     // at all since we know that both clusters have corrupted/invalid/non existent data.
     // Instead we should keep shards down and FailureTimeRanges information separate!
     // Keeping the existing logic in place for now but allow one to switch to the new logic.
-    // Some metadata plans (e.g. TsCardinalities) are timeless — they have no start/end times,
-    // so they cannot go through materializeLegacy which depends on time ranges for failure routing.
-    // Handle HA routing for them directly here.
-    if (!logicalPlan.hasTimeRange && logicalPlan.isRoutable && !notPromQlQuery && !markedNotToBeFailedOver) {
-      materializeTimelessHA(logicalPlan, qContext)
-    } else if (unroutableLogicalPlan || notPromQlQuery || markedNotToBeFailedOver || hasMultipleTimeRanges) {
+    if (unroutableLogicalPlan || notPromQlQuery || markedNotToBeFailedOver || hasMultipleTimeRanges) {
       // we don't want to do any complicated shard level logic and instead
       // even want to turn it off completely to make sure that the logic stays
       // exactly the same
@@ -273,50 +268,6 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
       }
       logger.debug("Routes: " + routes)
       routeExecPlanMapper(routes, logicalPlan, qContext, lookBackTime)
-    }
-  }
-
-  /**
-    * Builds the URL parameters for a remote metadata exec call for timeless plans.
-    */
-  private def getTimelessPlanUrlParams(logicalPlan: LogicalPlan,
-                                       queryParams: PromQlQueryParams): Map[String, String] = {
-    logicalPlan match {
-      case lp: TsCardinalities => lp.queryParams()
-      case _ => Map("match[]" -> queryParams.promQl)
-    }
-  }
-
-  /**
-    * HA routing for timeless metadata plans that have no start/end times.
-    * These cannot use materializeLegacy which depends on time ranges for failure routing.
-    * Instead, we check current shard health (via ActiveShardMapper when available,
-    * or FailureProvider as fallback) and route accordingly:
-    *   - Local shards healthy → execute locally
-    *   - Local shards unhealthy → route to buddy via MetadataRemoteExec
-    */
-  private def materializeTimelessHA(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
-    val queryParams = qContext.origQueryParams.asInstanceOf[PromQlQueryParams]
-    // Timeless plans only care about current cluster health, not historical failures.
-    // Use real-time shard health if available, otherwise check failure provider with a recent window.
-    val localShardsHealthy = buddyShardMapperProvider match {
-      case Some(_) => getLocalActiveShardMapper(qContext.plannerParams).allShardsActive
-      case None =>
-        // Check for failures in a recent 5-minute window to capture any active issues
-        val now = System.currentTimeMillis()
-        val fiveMinMs = 5 * 60 * 1000
-        failureProvider.getFailures(dsRef, TimeRange(now - fiveMinMs, now)).isEmpty
-    }
-    if (localShardsHealthy) {
-      localPlanner.materialize(logicalPlan, qContext)
-    } else {
-      // Local shards unhealthy — route entirely to buddy
-      val newQueryContext = qContext.copy(
-        plannerParams = qContext.plannerParams.copy(processFailure = false, processMultiPartition = false))
-      val httpEndpoint = remoteHttpEndpoint + queryParams.remoteQueryPath.getOrElse("")
-      MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
-        getTimelessPlanUrlParams(logicalPlan, queryParams), newQueryContext,
-        inProcessPlanDispatcher, dsRef, remoteExecHttpClient, queryConfig)
     }
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -15,7 +15,7 @@ import filodb.core.metrics.FilodbMetrics
 import filodb.core.query.{ActiveShardMapper, DownPartition, LegacyFailoverMode, PlannerParams, ShardLevelFailoverMode}
 import filodb.core.query.{PromQlQueryParams, QueryConfig, QueryContext}
 import filodb.grpc.GrpcCommonUtils
-import filodb.query.{LabelNames, LabelValues, LogicalPlan, SeriesKeysByFilters}
+import filodb.query.{LabelNames, LabelValues, LogicalPlan, SeriesKeysByFilters, TsCardinalities}
 import filodb.query.exec._
 
 object HighAvailabilityPlanner {
@@ -99,6 +99,8 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
           LabelNamesDistConcatExec(queryContext, inProcessPlanDispatcher, localMetaFirst)
         case lp: SeriesKeysByFilters =>
           PartKeysDistConcatExec(queryContext, inProcessPlanDispatcher, localMetaFirst)
+        case lp: TsCardinalities     =>
+          TsCardReduceExec(queryContext, inProcessPlanDispatcher, localMetaFirst)
         case _                       => StitchRvsExec(queryContext, inProcessPlanDispatcher,
                                          rvRangeFromPlan(rootLogicalPlan),
                                          PlannerUtil.localPlansFirst(execPlans))
@@ -155,6 +157,9 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
                                             MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
                                               urlParams, newQueryContext, inProcessPlanDispatcher,
                                               dsRef, remoteExecHttpClient, queryConfig)
+            case lp: TsCardinalities    => MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
+                                            lp.queryParams(), newQueryContext,
+                                            inProcessPlanDispatcher, dsRef, remoteExecHttpClient, queryConfig)
             case _                       =>
               if (remoteGrpcEndpoint.isDefined && !(queryConfig.grpcPartitionsDenyList.contains("*") ||
                 queryConfig.grpcPartitionsDenyList.contains(partitionName.toLowerCase))) {
@@ -199,7 +204,12 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
     // at all since we know that both clusters have corrupted/invalid/non existent data.
     // Instead we should keep shards down and FailureTimeRanges information separate!
     // Keeping the existing logic in place for now but allow one to switch to the new logic.
-    if (unroutableLogicalPlan || notPromQlQuery || markedNotToBeFailedOver || hasMultipleTimeRanges) {
+    // Some metadata plans (e.g. TsCardinalities) are timeless — they have no start/end times,
+    // so they cannot go through materializeLegacy which depends on time ranges for failure routing.
+    // Handle HA routing for them directly here.
+    if (!logicalPlan.hasTimeRange && logicalPlan.isRoutable && !notPromQlQuery && !markedNotToBeFailedOver) {
+      materializeTimelessHA(logicalPlan, qContext)
+    } else if (unroutableLogicalPlan || notPromQlQuery || markedNotToBeFailedOver || hasMultipleTimeRanges) {
       // we don't want to do any complicated shard level logic and instead
       // even want to turn it off completely to make sure that the logic stays
       // exactly the same
@@ -263,6 +273,50 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
       }
       logger.debug("Routes: " + routes)
       routeExecPlanMapper(routes, logicalPlan, qContext, lookBackTime)
+    }
+  }
+
+  /**
+    * Builds the URL parameters for a remote metadata exec call for timeless plans.
+    */
+  private def getTimelessPlanUrlParams(logicalPlan: LogicalPlan,
+                                       queryParams: PromQlQueryParams): Map[String, String] = {
+    logicalPlan match {
+      case lp: TsCardinalities => lp.queryParams()
+      case _ => Map("match[]" -> queryParams.promQl)
+    }
+  }
+
+  /**
+    * HA routing for timeless metadata plans that have no start/end times.
+    * These cannot use materializeLegacy which depends on time ranges for failure routing.
+    * Instead, we check current shard health (via ActiveShardMapper when available,
+    * or FailureProvider as fallback) and route accordingly:
+    *   - Local shards healthy → execute locally
+    *   - Local shards unhealthy → route to buddy via MetadataRemoteExec
+    */
+  private def materializeTimelessHA(logicalPlan: LogicalPlan, qContext: QueryContext): ExecPlan = {
+    val queryParams = qContext.origQueryParams.asInstanceOf[PromQlQueryParams]
+    // Timeless plans only care about current cluster health, not historical failures.
+    // Use real-time shard health if available, otherwise check failure provider with a recent window.
+    val localShardsHealthy = buddyShardMapperProvider match {
+      case Some(_) => getLocalActiveShardMapper(qContext.plannerParams).allShardsActive
+      case None =>
+        // Check for failures in a recent 5-minute window to capture any active issues
+        val now = System.currentTimeMillis()
+        val fiveMinMs = 5 * 60 * 1000
+        failureProvider.getFailures(dsRef, TimeRange(now - fiveMinMs, now)).isEmpty
+    }
+    if (localShardsHealthy) {
+      localPlanner.materialize(logicalPlan, qContext)
+    } else {
+      // Local shards unhealthy — route entirely to buddy
+      val newQueryContext = qContext.copy(
+        plannerParams = qContext.plannerParams.copy(processFailure = false, processMultiPartition = false))
+      val httpEndpoint = remoteHttpEndpoint + queryParams.remoteQueryPath.getOrElse("")
+      MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
+        getTimelessPlanUrlParams(logicalPlan, queryParams), newQueryContext,
+        inProcessPlanDispatcher, dsRef, remoteExecHttpClient, queryConfig)
     }
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -226,6 +226,10 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
       )
       val q = qContext.copy(plannerParams = plannerParams)
       localPlanner.materialize(logicalPlan, q)
+    } else if (logicalPlan.isInstanceOf[TsCardinalities]) {
+      // Metadata query — shard-level failover is unnecessary. Use materializeLegacy
+      // for simple all-or-nothing routing to buddy when local has failures.
+      materializeLegacy(logicalPlan, qContext)
     } else if (useShardLevelFailover || qContext.plannerParams.failoverMode == ShardLevelFailoverMode) {
       // we need to populate planner params with the shard maps
       val localActiveShardMapper = getLocalActiveShardMapper(qContext.plannerParams)

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/HighAvailabilityPlanner.scala
@@ -135,41 +135,54 @@ class HighAvailabilityPlanner(dsRef: DatasetRef,
           legacyFailoverCounter.increment()
           val timeRange = route.timeRange.get
           val queryParams = qContext.origQueryParams.asInstanceOf[PromQlQueryParams]
-          // rootLogicalPlan can be different from queryParams.promQl
-          // because rootLogicalPlan may not include the transformer that will not sent to remote.
-          // For instance, when promql = 1 - sum(foo), rootLogicalPlan = sum(foo).
-          // Because the logic "1 - " is translated to a transformer that runs locally.
-          // Divide by 1000 to convert millis to seconds. PromQL params are in seconds.
-          val promQlParams = PromQlQueryParams(LogicalPlanParser.convertToQuery(rootLogicalPlan),
-            (timeRange.startMs + offsetMs.max) / 1000, queryParams.stepSecs, (timeRange.endMs + offsetMs.min) / 1000)
-          val newQueryContext = qContext.copy(origQueryParams = promQlParams, plannerParams = qContext.plannerParams.
-            copy(processFailure = false, processMultiPartition = false) )
-          logger.debug("PromQlExec params:" + promQlParams)
           val httpEndpoint = remoteHttpEndpoint + queryParams.remoteQueryPath.getOrElse("")
+          // TsCardinalities cannot be converted to PromQL — handle before convertToQuery
           rootLogicalPlan match {
-            case lp: LabelValues         => MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
-                                            PlannerUtil.getLabelValuesUrlParams(lp, queryParams), newQueryContext,
-                                            inProcessPlanDispatcher, dsRef, remoteExecHttpClient, queryConfig)
-            case lp: LabelNames         => MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
-                                            Map("match[]" -> queryParams.promQl), newQueryContext,
-                                            inProcessPlanDispatcher, dsRef, remoteExecHttpClient, queryConfig)
-            case lp: SeriesKeysByFilters => val urlParams = Map("match[]" -> queryParams.promQl)
-                                            MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
-                                              urlParams, newQueryContext, inProcessPlanDispatcher,
-                                              dsRef, remoteExecHttpClient, queryConfig)
-            case lp: TsCardinalities    => MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
-                                            lp.queryParams(), newQueryContext,
-                                            inProcessPlanDispatcher, dsRef, remoteExecHttpClient, queryConfig)
-            case _                       =>
-              if (remoteGrpcEndpoint.isDefined && !(queryConfig.grpcPartitionsDenyList.contains("*") ||
-                queryConfig.grpcPartitionsDenyList.contains(partitionName.toLowerCase))) {
-                val endpoint = remoteGrpcEndpoint.get
-                val channel = channels.getOrElseUpdate(endpoint, GrpcCommonUtils.buildChannelFromEndpoint(endpoint))
-                PromQLGrpcRemoteExec(channel, remoteHttpTimeoutMs, newQueryContext, inProcessPlanDispatcher,
-                  dsRef, plannerSelector, s"${partitionName}-${buddyWorkUnit}")
-              } else
-                PromQlRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
-                                            newQueryContext, inProcessPlanDispatcher, dsRef, remoteExecHttpClient)
+            case lp: TsCardinalities =>
+              val newQueryContext = qContext.copy(plannerParams = qContext.plannerParams.
+                copy(processFailure = false, processMultiPartition = false))
+              MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
+                lp.queryParams(), newQueryContext,
+                inProcessPlanDispatcher, dsRef, remoteExecHttpClient, queryConfig)
+            case _ =>
+              // rootLogicalPlan can be different from queryParams.promQl
+              // because rootLogicalPlan may not include the transformer that will not sent to remote.
+              // For instance, when promql = 1 - sum(foo), rootLogicalPlan = sum(foo).
+              // Because the logic "1 - " is translated to a transformer that runs locally.
+              // Divide by 1000 to convert millis to seconds. PromQL params are in seconds.
+              val promQlParams = PromQlQueryParams(
+                LogicalPlanParser.convertToQuery(rootLogicalPlan),
+                (timeRange.startMs + offsetMs.max) / 1000,
+                queryParams.stepSecs,
+                (timeRange.endMs + offsetMs.min) / 1000)
+              val newQueryContext = qContext.copy(
+                origQueryParams = promQlParams,
+                plannerParams = qContext.plannerParams.
+                  copy(processFailure = false,
+                    processMultiPartition = false))
+              logger.debug("PromQlExec params:" + promQlParams)
+              rootLogicalPlan match {
+                case lp: LabelValues         => MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
+                                                PlannerUtil.getLabelValuesUrlParams(lp, queryParams), newQueryContext,
+                                                inProcessPlanDispatcher, dsRef, remoteExecHttpClient, queryConfig)
+                case lp: LabelNames         => MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
+                                                Map("match[]" -> queryParams.promQl), newQueryContext,
+                                                inProcessPlanDispatcher, dsRef, remoteExecHttpClient, queryConfig)
+                case lp: SeriesKeysByFilters => val urlParams = Map("match[]" -> queryParams.promQl)
+                                                MetadataRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
+                                                  urlParams, newQueryContext, inProcessPlanDispatcher,
+                                                  dsRef, remoteExecHttpClient, queryConfig)
+                case _                       =>
+                  if (remoteGrpcEndpoint.isDefined && !(queryConfig.grpcPartitionsDenyList.contains("*") ||
+                    queryConfig.grpcPartitionsDenyList.contains(partitionName.toLowerCase))) {
+                    val endpoint = remoteGrpcEndpoint.get
+                    val channel = channels.getOrElseUpdate(endpoint, GrpcCommonUtils.buildChannelFromEndpoint(endpoint))
+                    PromQLGrpcRemoteExec(channel, remoteHttpTimeoutMs, newQueryContext, inProcessPlanDispatcher,
+                      dsRef, plannerSelector, s"${partitionName}-${buddyWorkUnit}")
+                  } else
+                    PromQlRemoteExec(httpEndpoint, remoteHttpTimeoutMs,
+                                                newQueryContext, inProcessPlanDispatcher, dsRef, remoteExecHttpClient)
+              }
           }
 
       }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanUtils.scala
@@ -74,8 +74,8 @@ object LogicalPlanUtils extends StrictLogging {
       case lp: LabelValues                 => TimeRange(lp.startMs, lp.endMs)
       case lp: LabelCardinality            => TimeRange(lp.startMs, lp.endMs)
       case lp: LabelNames                  => TimeRange(lp.startMs, lp.endMs)
-      case lp: TsCardinalities             => throw new UnsupportedOperationException(
-                                                          "TsCardinalities does not have times")
+      case lp: TsCardinalities             => val now = System.currentTimeMillis()
+                                              TimeRange(now - 300000, now)
       case lp: SeriesKeysByFilters         => TimeRange(lp.startMs, lp.endMs)
       case lp: ApplyInstantFunctionRaw     => getTimeFromLogicalPlan(lp.vectors)
       case lp: ScalarBinaryOperation       => TimeRange(lp.rangeParams.startSecs * 1000, lp.rangeParams.endSecs * 1000)
@@ -88,6 +88,7 @@ object LogicalPlanUtils extends StrictLogging {
     }
   }
   // scalastyle:on cyclomatic.complexity
+
 
   /**
    * Used to change start and end time (with 'second' precision) of LogicalPlan

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
@@ -15,7 +15,8 @@ import filodb.query.exec._
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
-class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
+// scalastyle:off line.size.limit
+class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers with PlanValidationSpec {
 
   private implicit val system: ActorSystem = ActorSystem()
   private val node = TestProbe().ref
@@ -562,6 +563,11 @@ class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
     remoteExec.urlParams.contains("numGroupByFields") shouldEqual true
     remoteExec.urlParams("numGroupByFields") shouldEqual "3"
     remoteExec.urlParams.contains("match[]") shouldEqual true
+
+    // Validate the complete plan tree
+    val expected =
+      """E~MetadataRemoteExec(PromQlQueryParams(sum(heap_usage0),100,1,1000,None,false), PlannerParams(filodb,None,None,None,None,60000,PerQueryLimits(1000000,1000000,18000000,100000,100000,300000000,1000000,200000000),PerQueryLimits(50000,1000000,15000000,50000,50000,150000000,500000,100000000),None,None,None,false,86400000,86400000,false,false,false,false,true,10,false,true,TreeSet(),LegacyFailoverMode,None,None,None,None), queryEndpoint=localhost, requestTimeoutMs=10000) on InProcessPlanDispatcher(QueryConfig(10 seconds,300000,1,50,antlr,true,true,Some(p1),Some(10000),Some(localhost),None,25,true,false,true,Set(),Some(plannerSelector),Map(filodb-query-exec-metadataexec -> 65536, filodb-query-exec-aggregate-large-container -> 65536),RoutingConfig(false,1800000 milliseconds,true,0,Set(),_ws_),CachingConfig(true,2048),false))""".stripMargin
+    validatePlan(execPlan, expected)
   }
 
   it("should execute TsCardinalities locally when no failures are present") {
@@ -666,6 +672,11 @@ class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
     // Local failure exists — routes to buddy even if buddy also has failures.
     // materializeLegacy only considers local failures for routing decisions.
     execPlan.isInstanceOf[MetadataRemoteExec] shouldEqual true
+
+    // Validate the complete plan tree
+    val expected =
+      """E~MetadataRemoteExec(PromQlQueryParams(sum(heap_usage0),100,1,1000,None,false), PlannerParams(filodb,None,None,None,None,60000,PerQueryLimits(1000000,1000000,18000000,100000,100000,300000000,1000000,200000000),PerQueryLimits(50000,1000000,15000000,50000,50000,150000000,500000,100000000),None,None,None,false,86400000,86400000,false,false,false,false,true,10,false,true,TreeSet(),LegacyFailoverMode,None,None,None,None), queryEndpoint=localhost, requestTimeoutMs=10000) on InProcessPlanDispatcher(QueryConfig(10 seconds,300000,1,50,antlr,true,true,Some(p1),Some(10000),Some(localhost),None,25,true,false,true,Set(),Some(plannerSelector),Map(filodb-query-exec-metadataexec -> 65536, filodb-query-exec-aggregate-large-container -> 65536),RoutingConfig(false,1800000 milliseconds,true,0,Set(),_ws_),CachingConfig(true,2048),false))""".stripMargin
+    validatePlan(execPlan, expected)
   }
 
   it("should route TsCardinalities with multiple datasets to buddy on local failure") {

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
@@ -539,4 +539,67 @@ class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
     queryParams.endSecs shouldEqual (to)
 
   }
+
+  it("should generate MetadataRemoteExec for TsCardinalities when local failure is present") {
+    val lp = TsCardinalities(Seq("ws_foo", "ns_bar"), 3)
+
+    val failureProvider = new FailureProvider {
+      override def getFailures(datasetRef: DatasetRef, queryTimeRange: TimeRange): Seq[FailureTimeRange] = {
+        // Return a failure that overlaps with the queried time range
+        Seq(FailureTimeRange("local", datasetRef, queryTimeRange, false))
+      }
+    }
+
+    val engine = new HighAvailabilityPlanner(dsRef, localPlanner, mapperRef, failureProvider, queryConfig,
+      workUnit = null, buddyWorkUnit = null, clusterName = null, useShardLevelFailover = false)
+
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+
+    execPlan.isInstanceOf[MetadataRemoteExec] shouldEqual true
+    execPlan.queryContext.plannerParams.processFailure shouldEqual false
+
+    val remoteExec = execPlan.asInstanceOf[MetadataRemoteExec]
+    remoteExec.urlParams.contains("numGroupByFields") shouldEqual true
+    remoteExec.urlParams("numGroupByFields") shouldEqual "3"
+    remoteExec.urlParams.contains("match[]") shouldEqual true
+  }
+
+  it("should execute TsCardinalities locally when no failures are present at current time") {
+    val lp = TsCardinalities(Seq("ws_foo", "ns_bar"), 3)
+
+    val failureProvider = new FailureProvider {
+      override def getFailures(datasetRef: DatasetRef, queryTimeRange: TimeRange): Seq[FailureTimeRange] = {
+        Seq.empty
+      }
+    }
+
+    val engine = new HighAvailabilityPlanner(dsRef, localPlanner, mapperRef, failureProvider, queryConfig,
+      workUnit = null, buddyWorkUnit = null, clusterName = null, useShardLevelFailover = false)
+
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+
+    // Should NOT be a remote exec — should stay local
+    execPlan.isInstanceOf[MetadataRemoteExec] shouldEqual false
+    execPlan.isInstanceOf[PromQlRemoteExec] shouldEqual false
+  }
+
+  it("should route TsCardinalities to buddy and set processFailure=false to prevent loop") {
+    val lp = TsCardinalities(Seq("ws_foo", "ns_bar"), 3)
+
+    val failureProvider = new FailureProvider {
+      override def getFailures(datasetRef: DatasetRef, queryTimeRange: TimeRange): Seq[FailureTimeRange] = {
+        Seq(FailureTimeRange("local", datasetRef, queryTimeRange, false))
+      }
+    }
+
+    val engine = new HighAvailabilityPlanner(dsRef, localPlanner, mapperRef, failureProvider, queryConfig,
+      workUnit = null, buddyWorkUnit = null, clusterName = null, useShardLevelFailover = false)
+
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+
+    execPlan.isInstanceOf[MetadataRemoteExec] shouldEqual true
+    // Verify loop prevention: buddy should not attempt failover again
+    execPlan.queryContext.plannerParams.processFailure shouldEqual false
+    execPlan.queryContext.plannerParams.processMultiPartition shouldEqual false
+  }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
@@ -6,7 +6,7 @@ import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import filodb.coordinator.ShardMapper
 import filodb.core.{DatasetRef, MetricsTestData}
 import filodb.core.metadata.Schemas
-import filodb.core.query.{ColumnFilter, Filter, PromQlQueryParams, QueryConfig, QueryContext}
+import filodb.core.query.{ColumnFilter, Filter, PlannerParams, PromQlQueryParams, QueryConfig, QueryContext}
 import filodb.core.store.TimeRangeChunkScan
 import filodb.prometheus.ast.TimeStepParams
 import filodb.prometheus.parse.Parser
@@ -601,5 +601,113 @@ class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
     // Verify loop prevention: buddy should not attempt failover again
     execPlan.queryContext.plannerParams.processFailure shouldEqual false
     execPlan.queryContext.plannerParams.processMultiPartition shouldEqual false
+  }
+
+  it("should execute TsCardinalities locally when processMultiPartition=false (buddy received query)") {
+    val lp = TsCardinalities(Seq("ws_foo", "ns_bar"), 3)
+
+    val failureProvider = new FailureProvider {
+      override def getFailures(datasetRef: DatasetRef, queryTimeRange: TimeRange): Seq[FailureTimeRange] = {
+        Seq(FailureTimeRange("local", datasetRef, queryTimeRange, false))
+      }
+    }
+
+    val engine = new HighAvailabilityPlanner(dsRef, localPlanner, mapperRef, failureProvider, queryConfig,
+      workUnit = null, buddyWorkUnit = null, clusterName = null, useShardLevelFailover = false)
+
+    // Simulate buddy receiving the rerouted query: processFailure=false skips HA routing
+    val qContext = QueryContext(origQueryParams = promQlQueryParams,
+      plannerParams = PlannerParams(processFailure = false, processMultiPartition = false))
+    val execPlan = engine.materialize(lp, qContext)
+
+    // Should execute locally even though failures exist — processFailure=false bypasses HA
+    execPlan.isInstanceOf[MetadataRemoteExec] shouldEqual false
+    execPlan.isInstanceOf[PromQlRemoteExec] shouldEqual false
+  }
+
+  it("should execute TsCardinalities locally when only remote failures exist") {
+    val lp = TsCardinalities(Seq("ws_foo", "ns_bar"), 3)
+
+    val failureProvider = new FailureProvider {
+      override def getFailures(datasetRef: DatasetRef, queryTimeRange: TimeRange): Seq[FailureTimeRange] = {
+        // Only remote/buddy failures — local is healthy
+        Seq(FailureTimeRange("remote", datasetRef, queryTimeRange, true))
+      }
+    }
+
+    val engine = new HighAvailabilityPlanner(dsRef, localPlanner, mapperRef, failureProvider, queryConfig,
+      workUnit = null, buddyWorkUnit = null, clusterName = null, useShardLevelFailover = false)
+
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+
+    // Remote failure only — should stay local, not route to unhealthy buddy
+    execPlan.isInstanceOf[MetadataRemoteExec] shouldEqual false
+    execPlan.isInstanceOf[PromQlRemoteExec] shouldEqual false
+  }
+
+  it("should route TsCardinalities to buddy when both local and remote failures exist") {
+    val lp = TsCardinalities(Seq("ws_foo", "ns_bar"), 3)
+
+    val failureProvider = new FailureProvider {
+      override def getFailures(datasetRef: DatasetRef, queryTimeRange: TimeRange): Seq[FailureTimeRange] = {
+        // Both local and remote have failures
+        Seq(
+          FailureTimeRange("local", datasetRef, queryTimeRange, false),
+          FailureTimeRange("remote", datasetRef, queryTimeRange, true)
+        )
+      }
+    }
+
+    val engine = new HighAvailabilityPlanner(dsRef, localPlanner, mapperRef, failureProvider, queryConfig,
+      workUnit = null, buddyWorkUnit = null, clusterName = null, useShardLevelFailover = false)
+
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+
+    // Local failure exists — routes to buddy even if buddy also has failures.
+    // materializeLegacy only considers local failures for routing decisions.
+    execPlan.isInstanceOf[MetadataRemoteExec] shouldEqual true
+  }
+
+  it("should route TsCardinalities with multiple datasets to buddy on local failure") {
+    val lp = TsCardinalities(Seq("ws_foo", "ns_bar"), 3,
+      Seq("raw", "recordingrules"), "raw,recordingrules")
+
+    val failureProvider = new FailureProvider {
+      override def getFailures(datasetRef: DatasetRef, queryTimeRange: TimeRange): Seq[FailureTimeRange] = {
+        Seq(FailureTimeRange("local", datasetRef, queryTimeRange, false))
+      }
+    }
+
+    val engine = new HighAvailabilityPlanner(dsRef, localPlanner, mapperRef, failureProvider, queryConfig,
+      workUnit = null, buddyWorkUnit = null, clusterName = null, useShardLevelFailover = false)
+
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+
+    execPlan.isInstanceOf[MetadataRemoteExec] shouldEqual true
+    val remoteExec = execPlan.asInstanceOf[MetadataRemoteExec]
+    // Verify datasets are passed through in URL params
+    remoteExec.urlParams("datasets") shouldEqual "raw,recordingrules"
+    remoteExec.urlParams("numGroupByFields") shouldEqual "3"
+  }
+
+  it("should route TsCardinalities with empty shardKeyPrefix to buddy on local failure") {
+    // Empty prefix (numGroupByFields=1) — dispatched to all partitions at MPP level,
+    // but at HA level it's the same all-or-nothing routing
+    val lp = TsCardinalities(Seq(), 1)
+
+    val failureProvider = new FailureProvider {
+      override def getFailures(datasetRef: DatasetRef, queryTimeRange: TimeRange): Seq[FailureTimeRange] = {
+        Seq(FailureTimeRange("local", datasetRef, queryTimeRange, false))
+      }
+    }
+
+    val engine = new HighAvailabilityPlanner(dsRef, localPlanner, mapperRef, failureProvider, queryConfig,
+      workUnit = null, buddyWorkUnit = null, clusterName = null, useShardLevelFailover = false)
+
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+
+    execPlan.isInstanceOf[MetadataRemoteExec] shouldEqual true
+    val remoteExec = execPlan.asInstanceOf[MetadataRemoteExec]
+    remoteExec.urlParams("numGroupByFields") shouldEqual "1"
   }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/HighAvailabilityPlannerSpec.scala
@@ -545,7 +545,7 @@ class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
 
     val failureProvider = new FailureProvider {
       override def getFailures(datasetRef: DatasetRef, queryTimeRange: TimeRange): Seq[FailureTimeRange] = {
-        // Return a failure that overlaps with the queried time range
+        // Return a failure that overlaps with the synthetic time range (now-5min, now)
         Seq(FailureTimeRange("local", datasetRef, queryTimeRange, false))
       }
     }
@@ -564,7 +564,7 @@ class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
     remoteExec.urlParams.contains("match[]") shouldEqual true
   }
 
-  it("should execute TsCardinalities locally when no failures are present at current time") {
+  it("should execute TsCardinalities locally when no failures are present") {
     val lp = TsCardinalities(Seq("ws_foo", "ns_bar"), 3)
 
     val failureProvider = new FailureProvider {
@@ -578,7 +578,7 @@ class HighAvailabilityPlannerSpec extends AnyFunSpec with Matchers {
 
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
 
-    // Should NOT be a remote exec — should stay local
+    // No failures — should stay local
     execPlan.isInstanceOf[MetadataRemoteExec] shouldEqual false
     execPlan.isInstanceOf[PromQlRemoteExec] shouldEqual false
   }

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -18,13 +18,6 @@ sealed trait LogicalPlan {
   def isRoutable: Boolean = true
 
   /**
-    * Whether this plan has an associated time range.
-    * Plans that return false cannot go through time-based failure routing (e.g. materializeLegacy).
-    * Override to false for timeless metadata queries like TsCardinalities.
-    */
-  def hasTimeRange: Boolean = true
-
-  /**
     * Whether to Time-Split queries into smaller range queries if the range exceeds configured limit.
     * This flag will be overridden by plans, which either do not support splitting or will not help in improving
     * performance. For e.g. metadata query plans.
@@ -362,8 +355,6 @@ case class TsCardinalities(shardKeyPrefix: Seq[String],
     "cannot group at the metric level when prefix does not contain ws and ns")
 
   override def isRoutable: Boolean = true
-  override def hasTimeRange: Boolean = false
-
   def filters(): Seq[ColumnFilter] = SHARD_KEY_LABELS.zip(shardKeyPrefix).map{ case (label, value) =>
     ColumnFilter(label, Equals(value))}
 
@@ -391,7 +382,6 @@ case class RawChunkMeta(rangeSelector: RangeSelector,
                         filters: Seq[ColumnFilter],
                         column: String) extends PeriodicSeriesPlan {
   override def isRoutable: Boolean = false
-  override def hasTimeRange: Boolean = false
 
   // FIXME - TechDebt - This class should not be a PeriodicSeriesPlan
   override def startMs: Long = ???

--- a/query/src/main/scala/filodb/query/LogicalPlan.scala
+++ b/query/src/main/scala/filodb/query/LogicalPlan.scala
@@ -18,6 +18,13 @@ sealed trait LogicalPlan {
   def isRoutable: Boolean = true
 
   /**
+    * Whether this plan has an associated time range.
+    * Plans that return false cannot go through time-based failure routing (e.g. materializeLegacy).
+    * Override to false for timeless metadata queries like TsCardinalities.
+    */
+  def hasTimeRange: Boolean = true
+
+  /**
     * Whether to Time-Split queries into smaller range queries if the range exceeds configured limit.
     * This flag will be overridden by plans, which either do not support splitting or will not help in improving
     * performance. For e.g. metadata query plans.
@@ -354,8 +361,8 @@ case class TsCardinalities(shardKeyPrefix: Seq[String],
   require(numGroupByFields < 3 || shardKeyPrefix.size >= 2,
     "cannot group at the metric level when prefix does not contain ws and ns")
 
-  // TODO: this should eventually be "true" to enable HAP/LTRP routing
-  override def isRoutable: Boolean = false
+  override def isRoutable: Boolean = true
+  override def hasTimeRange: Boolean = false
 
   def filters(): Seq[ColumnFilter] = SHARD_KEY_LABELS.zip(shardKeyPrefix).map{ case (label, value) =>
     ColumnFilter(label, Equals(value))}
@@ -384,6 +391,7 @@ case class RawChunkMeta(rangeSelector: RangeSelector,
                         filters: Seq[ColumnFilter],
                         column: String) extends PeriodicSeriesPlan {
   override def isRoutable: Boolean = false
+  override def hasTimeRange: Boolean = false
 
   // FIXME - TechDebt - This class should not be a PeriodicSeriesPlan
   override def startMs: Long = ???


### PR DESCRIPTION
## Summary

Add HAPlanner support for TsCardinalities metric cardinality queries, enabling HA failover when local shards are down.

### Problem
Cardinality queries (TsCardinalities) returned 503 errors when local shards were down because:
1. `TsCardinalities.isRoutable` was false, bypassing HA routing entirely
2. `TsCardinalities` has no time range, so `getTimeFromLogicalPlan` threw `UnsupportedOperationException`
3. `routeExecPlanMapper` didn't have a case for `TsCardinalities`, falling to `PromQlRemoteExec`
4. `stitchPlans` lacked a `TsCardinalities` case, falling to `StitchRvsExec`

### Solution (4 files changed)

- **LogicalPlan.scala**: Set `isRoutable = true` on `TsCardinalities` (was false)
- **LogicalPlanUtils.scala**: Return a synthetic `TimeRange(now - 5min, now)` for `TsCardinalities` instead of throwing, allowing it to flow through `materializeLegacy`
- **HighAvailabilityPlanner.scala**:
  - `materialize()`: Added `TsCardinalities` guard to skip shard-level failover and route directly to `materializeLegacy` for all-or-nothing routing (shard-level failover is unnecessary for metadata queries)
  - `routeExecPlanMapper`: Added `TsCardinalities` match **before** `convertToQuery` (since it can't be converted to PromQL), routing to `MetadataRemoteExec` with `lp.queryParams()`
  - `stitchPlans`: Added `TsCardinalities` → `TsCardReduceExec` for correct cardinality result merging
- **HighAvailabilityPlannerSpec.scala**: Added 8 new tests (22 total)

## Test plan (22/22 passing)

**Pre-existing tests (14):**
- Standard HA failover scenarios (local failure, remote failure, offset, metadata queries, instant queries, etc.)

**New TsCardinalities tests (8):**
- [x] Local failure → route to buddy via `MetadataRemoteExec` with correct URL params
- [x] No failures → execute locally
- [x] Loop prevention: `processFailure=false` and `processMultiPartition=false` set on remote query
- [x] `processMultiPartition=false` (buddy receives query) → executes locally, no re-routing
- [x] Remote-only failure → stay local, don't route to unhealthy buddy
- [x] Both clusters have failures → routes to buddy (materializeLegacy only considers local failures)
- [x] Multiple datasets (raw, recordingrules) → datasets param passed through on failover
- [x] Empty shardKeyPrefix → HA routing works the same regardless of prefix size