### PR TITLE
feat(core): add MapEncoder utility and addEncodedMap to RecordBuilder

### DIFF
--- a/core/src/main/scala/filodb.core/binaryrecord2/MapEncoder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/MapEncoder.scala
@@ -1,0 +1,126 @@
+package filodb.core.binaryrecord2
+
+import java.nio.charset.StandardCharsets
+import java.util
+
+import filodb.memory.UTF8StringMedium
+import filodb.memory.UTF8StringShort
+import filodb.memory.format.UnsafeUtils
+import filodb.memory.format.UnsafeUtils.{arayOffset, setByte}
+
+// scalastyle:off null
+/**
+ * Stateless utility for encoding/decoding tag maps in RecordBuilder's exact wire format.
+ *
+ * Wire format per entry:
+ *   Predefined key: [0xC0 | predefKeyNum (1B)][valLen (2B native-endian)][valBytes]
+ *   Full key:       [keyLen (1B)][keyBytes UTF-8][valLen (2B native-endian)][valBytes UTF-8]
+ *
+ * The byte[] contains entries only — no 2-byte map length header (RecordBuilder adds that
+ * via addPreEncodedMap).
+ *
+ * IMPORTANT: The encoding in MapEncoder.encode() must exactly match
+ * RecordBuilder.addMapKeyValue(). If the wire format changes in either place,
+ * both must be updated together.
+ */
+object MapEncoder {
+
+  val EMPTY: Array[Byte] = new Array[Byte](0)
+
+  /**
+   * Encode a tag map into RecordBuilder's wire format with predefined key handling.
+   * TreeMap guarantees keys are sorted, matching RecordBuilder's convention.
+   *
+   * @param tags TreeMap of tag key-value pairs (sorted by key)
+   * @param schema the RecordSchema with predefined key definitions for encoding
+   * @return encoded byte[] in RecordBuilder wire format
+   */
+  def encode(tags: java.util.TreeMap[String, String], schema: RecordSchema): Array[Byte] = {
+    if (tags == null || tags.isEmpty) return EMPTY
+
+    // Upper bound: each entry at most 1 + keyLen*3 + 2 + valLen*3 (UTF-8 worst case)
+    var upperBound = 0
+    val iter = tags.entrySet().iterator()
+    while (iter.hasNext) {
+      val entry = iter.next()
+      upperBound += 1 + entry.getKey.length * 3 + 2 + entry.getValue.length * 3
+    }
+    val buf = new Array[Byte](upperBound)
+    var pos = 0
+
+    val iter2 = tags.entrySet().iterator()
+    while (iter2.hasNext) {
+      val entry = iter2.next()
+      val keyBytes = entry.getKey.getBytes(StandardCharsets.UTF_8)
+      val valBytes = entry.getValue.getBytes(StandardCharsets.UTF_8)
+
+      require(keyBytes.length < 192, s"Key too long: ${entry.getKey} (${keyBytes.length} bytes, max 191)")
+      require(valBytes.length < 65536, s"Value too long: ${entry.getValue} (${valBytes.length} bytes)")
+
+      // Predefined key lookup — matches RecordBuilder.addMapKeyValue exactly
+      val keyKey = RecordSchema.makeKeyKey(keyBytes, 0, keyBytes.length, 7)
+      val predefNum = schema.predefKeyNumMap.getOrElse(keyKey, -1)
+
+      if (predefNum >= 0) {
+        // Predefined key: 1-byte code
+        setByte(buf, arayOffset + pos, (0xC0 | predefNum).toByte)
+        pos += 1
+      } else {
+        // Full key: UTF8StringShort (1B length + bytes)
+        UTF8StringShort.copyByteArrayTo(keyBytes, buf, arayOffset + pos)
+        pos += 1 + keyBytes.length
+      }
+
+      // Value: UTF8StringMedium (2B length + bytes, native endian)
+      UTF8StringMedium.copyByteArrayTo(valBytes, buf, arayOffset + pos)
+      pos += 2 + valBytes.length
+    }
+
+    util.Arrays.copyOf(buf, pos)
+  }
+
+  /**
+   * Decode encoded map bytes into a sorted Java Map.
+   *
+   * @param data encoded byte[] in RecordBuilder wire format
+   * @param schema the RecordSchema with predefined key definitions for decoding key codes
+   * @return sorted TreeMap of decoded key-value pairs
+   */
+  def toJavaMap(data: Array[Byte], schema: RecordSchema): java.util.Map[String, String] = {
+    val map = new util.TreeMap[String, String]()
+    if (data == null || data.length == 0) return map
+
+    var pos = 0
+    while (pos < data.length) {
+      val firstByte = data(pos) & 0xFF
+      val predefIndex = firstByte ^ 0xC0
+
+      if (predefIndex < 64) {
+        // Predefined key — decode from schema
+        val keyOff = schema.predefKeyOffsets(predefIndex)
+        val keyLen = UTF8StringShort.numBytes(schema.predefKeyBytes, keyOff)
+        val keyStr = new String(schema.predefKeyBytes,
+          (keyOff + 1 - UnsafeUtils.arayOffset).toInt, keyLen, StandardCharsets.UTF_8)
+
+        val valLen = UnsafeUtils.getShort(data, UnsafeUtils.arayOffset + pos + 1) & 0xFFFF
+        val valStr = new String(data, pos + 3, valLen, StandardCharsets.UTF_8)
+        map.put(keyStr, valStr)
+        pos += 3 + valLen
+      } else {
+        // Full key
+        val keyLen = firstByte
+        val keyStr = new String(data, pos + 1, keyLen, StandardCharsets.UTF_8)
+
+        val valLenPos = pos + 1 + keyLen
+        val valLen = UnsafeUtils.getShort(data, UnsafeUtils.arayOffset + valLenPos) & 0xFFFF
+        val valStr = new String(data, valLenPos + 2, valLen, StandardCharsets.UTF_8)
+        map.put(keyStr, valStr)
+        pos += 1 + keyLen + 2 + valLen
+      }
+    }
+    map
+  }
+
+  /** Check if encoded map bytes are empty. */
+  def isEmpty(data: Array[Byte]): Boolean = data == null || data.length == 0
+}

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -331,6 +331,10 @@ class RecordBuilder(memFactory: MemFactory,
    * Takes care of matching and translating predefined keys into short codes.
    * Keys must be < 60KB and values must be < 64KB
    * Hash is not computed or added for you - it must be separately added by you!
+   *
+   * IMPORTANT: MapEncoder.encode() replicates this encoding logic. If the wire format
+   * changes here (predefined key codes, UTF8StringShort/Medium encoding, byte order),
+   * MapEncoder must be updated to match.
    */
   final def addMapKeyValue(keyBytes: Array[Byte], keyOffset: Int, keyLen: Int,
                            valueBytes: Array[Byte], valueOffset: Int, valueLen: Int,
@@ -394,6 +398,24 @@ class RecordBuilder(memFactory: MemFactory,
     }
     mapOffset = -1L
     fieldNo += 1
+  }
+
+  /**
+   * Adds an encoded map field directly from a byte array already in RecordBuilder wire format.
+   * Use MapEncoder.encode() to produce correctly encoded bytes.
+   */
+  final def addEncodedMap(mapBytes: Array[Byte]): Unit = {
+    val numBytes = mapBytes.length
+    require(numBytes < 65536, s"Map bytes too large: $numBytes")
+    startMap()
+    requireBytes(numBytes)
+    UnsafeUtils.unsafe.copyMemory(mapBytes, UnsafeUtils.arayOffset,
+                                  curBase, curRecEndOffset, numBytes)
+    curRecEndOffset += numBytes
+    // update map length and record length
+    setShort(curBase, mapOffset, numBytes.toShort)
+    setInt(curBase, curRecordOffset, (curRecEndOffset - curRecordOffset - 4).toInt)
+    endMap()
   }
 
   /**

--- a/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
@@ -447,6 +447,50 @@ class BinaryRecordSpec extends AnyFunSpec with Matchers with BeforeAndAfter with
       recSchema2.partitionHash(basebase, offset4) shouldEqual lastHash
     }
 
+    it("should produce identical record with addEncodedMap as with addMapKeyValue") {
+      val tags = new java.util.TreeMap[String, String]()
+      tags.put("__name__", "host_cpu_load")
+      tags.put("dc", "AWS-USE")
+      tags.put("instance", "0123892E342342A90")
+      tags.put("job", "prometheus")
+
+      // Traditional path
+      val builder1 = new RecordBuilder(MemFactory.onHeapFactory)
+      builder1.startNewRecord(schema2)
+      builder1.addLong(System.currentTimeMillis)
+      builder1.addDouble(1.0)
+      builder1.addDouble(2.5)
+      builder1.addDouble(10.1)
+      builder1.addLong(123456L)
+      builder1.addString("Series 1")
+      builder1.startMap()
+      tags.entrySet().forEach { entry =>
+        builder1.addMapKeyValue(
+          entry.getKey.getBytes(StandardCharsets.UTF_8),
+          entry.getValue.getBytes(StandardCharsets.UTF_8))
+      }
+      builder1.endMap()
+      val off1 = builder1.endRecord()
+
+      // addEncodedMap path
+      val encoded = MapEncoder.encode(tags, recSchema2)
+      val builder2 = new RecordBuilder(MemFactory.onHeapFactory)
+      builder2.startNewRecord(schema2)
+      builder2.addLong(System.currentTimeMillis)
+      builder2.addDouble(1.0)
+      builder2.addDouble(2.5)
+      builder2.addDouble(10.1)
+      builder2.addLong(123456L)
+      builder2.addString("Series 1")
+      builder2.addEncodedMap(encoded)
+      val off2 = builder2.endRecord()
+
+      // Partition hashes must match
+      val hash1 = recSchema2.partitionHash(builder1.allContainers.head.base, off1)
+      val hash2 = recSchema2.partitionHash(builder2.allContainers.head.base, off2)
+      hash1 shouldEqual hash2
+    }
+
     it("should copy records to new byte arrays and compare equally") {
       val builder = new RecordBuilder(MemFactory.onHeapFactory)
       val data = withMap(linearMultiSeries(), extraTags=extraTags).take(3)

--- a/core/src/test/scala/filodb.core/binaryrecord2/MapEncoderSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/MapEncoderSpec.scala
@@ -1,0 +1,306 @@
+package filodb.core.binaryrecord2
+
+import java.nio.charset.StandardCharsets
+import java.util.TreeMap
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import filodb.core.GlobalConfig
+import filodb.core.metadata.{Schema, Schemas}
+import filodb.memory._
+import filodb.memory.format.UnsafeUtils
+import filodb.memory.format.vectors.{BinaryHistogram, CustomBuckets}
+
+class MapEncoderSpec extends AnyFunSpec with Matchers {
+
+  // Load schemas from filodb-defaults.conf
+  private val schemas = Schemas.fromConfig(GlobalConfig.defaultFiloConfig).get
+  private val partSchema = schemas.part.binSchema
+
+  // All preagg schema types
+  private val gaugeSchema = schemas.schemas("preagg-gauge")
+  private val deltaCounterSchema = schemas.schemas("preagg-delta-counter")
+  private val deltaHistogramSchema = schemas.schemas("preagg-delta-histogram")
+  private val otelDeltaHistogramSchema = schemas.schemas("preagg-otel-delta-histogram")
+  private val otelExpDeltaHistogramSchema = schemas.schemas("preagg-otel-exp-delta-histogram")
+  private val deltaHistogramV2Schema = schemas.schemas("preagg-delta-histogram-v2")
+
+  // Non-preagg schema (raw Prometheus counter)
+  private val promCounterSchema = schemas.schemas("prom-counter")
+
+  // Multiple tag maps with varying key/value sizes for exhaustive testing
+  private val testTagMaps: Seq[(String, java.util.TreeMap[String, String])] = Seq(
+    "small keys and small values" -> sortedMap(
+      "_ns_" -> "ns",
+      "_ws_" -> "ws",
+      "a" -> "1"
+    ),
+    "small keys and large values" -> sortedMap(
+      "_ns_" -> "a" * 100,
+      "_ws_" -> "b" * 200,
+      "dc" -> "c" * 500
+    ),
+    "large keys and small values" -> sortedMap(
+      "_ns_" -> "x",
+      "_ws_" -> "y",
+      "k" * 100 -> "v",
+      "long_label_name_that_is_verbose" -> "1"
+    ),
+    "large keys and large values" -> sortedMap(
+      "_ns_" -> "a" * 300,
+      "_ws_" -> "b" * 300,
+      "k" * 80 -> "v" * 500,
+      "another_long_key_name" -> "another_long_value_" * 20
+    ),
+    "mixed predefined and non-predefined keys" -> sortedMap(
+      "_ns_" -> "filodb-local",
+      "_ws_" -> "aci-telemetry",
+      "dc" -> "us-west-2",
+      "instance" -> "i-12345",
+      "label1" -> "value1",
+      "region" -> "us-east-1"
+    ),
+    "predefined keys only" -> sortedMap(
+      "_ns_" -> "filodb-local",
+      "_ws_" -> "aci-telemetry"
+    )
+  )
+
+  describe("MapEncoder.encode and toJavaMap round-trip") {
+    testTagMaps.foreach { case (desc, tags) =>
+      it(s"should round-trip: $desc") {
+        val encoded = MapEncoder.encode(tags, partSchema)
+        encoded.length should be > 0
+        MapEncoder.toJavaMap(encoded, partSchema) shouldEqual tags
+      }
+    }
+
+    it("should handle empty map") {
+      val encoded = MapEncoder.encode(new TreeMap[String, String](), partSchema)
+      MapEncoder.isEmpty(encoded) shouldBe true
+      encoded.length shouldEqual 0
+      MapEncoder.toJavaMap(encoded, partSchema).isEmpty shouldBe true
+    }
+
+    it("should handle null map") {
+      val encoded = MapEncoder.encode(null, partSchema)
+      MapEncoder.isEmpty(encoded) shouldBe true
+    }
+  }
+
+  describe("MapEncoder round-trip via byte[]") {
+    testTagMaps.foreach { case (desc, tags) =>
+      it(s"should decode back correctly: $desc") {
+        val encoded = MapEncoder.encode(tags, partSchema)
+        val decoded = MapEncoder.toJavaMap(encoded, partSchema)
+        decoded shouldEqual tags
+      }
+    }
+
+    it("should handle null bytes") {
+      MapEncoder.isEmpty(null) shouldBe true
+      MapEncoder.toJavaMap(null, partSchema).isEmpty shouldBe true
+    }
+
+    it("should handle empty bytes") {
+      MapEncoder.isEmpty(MapEncoder.EMPTY) shouldBe true
+      MapEncoder.toJavaMap(MapEncoder.EMPTY, partSchema).isEmpty shouldBe true
+    }
+  }
+
+  describe("predefined key compression") {
+    it("should produce smaller bytes when keys are predefined") {
+      val tags = sortedMap("_ns_" -> "filodb-local", "_ws_" -> "aci-telemetry", "instance" -> "i-001")
+      val encoded = MapEncoder.encode(tags, partSchema)
+      encoded.length should be < (4 + 4 + 12 + 8 + 8 + 5 + 6 + 6) // raw size without compression
+    }
+  }
+
+  describe("different tags produce different hashes") {
+    it("should produce different partition hashes for records with different tags") {
+      val tags1 = sortedMap("_ns_" -> "ns1", "_ws_" -> "ws1")
+      val tags2 = sortedMap("_ns_" -> "ns2", "_ws_" -> "ws2")
+
+      val builder1 = new RecordBuilder(MemFactory.onHeapFactory, 4096)
+      builder1.startNewRecord(gaugeSchema)
+      builder1.addLong(12345L); builder1.addDouble(1.0); builder1.addDouble(0.0)
+      builder1.addDouble(1.0); builder1.addDouble(1.0)
+      builder1.addString("metric1")
+      builder1.addEncodedMap(MapEncoder.encode(tags1, gaugeSchema.ingestionSchema))
+      val off1 = builder1.endRecord()
+      val hash1 = gaugeSchema.ingestionSchema.partitionHash(builder1.currentContainer.get.base, off1)
+
+      val builder2 = new RecordBuilder(MemFactory.onHeapFactory, 4096)
+      builder2.startNewRecord(gaugeSchema)
+      builder2.addLong(12345L); builder2.addDouble(1.0); builder2.addDouble(0.0)
+      builder2.addDouble(1.0); builder2.addDouble(1.0)
+      builder2.addString("metric1")
+      builder2.addEncodedMap(MapEncoder.encode(tags2, gaugeSchema.ingestionSchema))
+      val off2 = builder2.endRecord()
+      val hash2 = gaugeSchema.ingestionSchema.partitionHash(builder2.currentContainer.get.base, off2)
+
+      hash1 should not equal hash2
+    }
+  }
+
+  describe("consumeMapItems reads back MapEncoder bytes correctly") {
+    it("should read back all key-value pairs from a record built with addEncodedMap") {
+      val tags = sortedMap(
+        "_ns_" -> "filodb-local",
+        "_ws_" -> "aci-telemetry",
+        "dc" -> "us-west-2",
+        "region" -> "us-east-1"
+      )
+      val ingestion = gaugeSchema.ingestionSchema
+      val encoded = MapEncoder.encode(tags, ingestion)
+
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, 4096)
+      builder.startNewRecord(gaugeSchema)
+      builder.addLong(12345L); builder.addDouble(1.0); builder.addDouble(0.0)
+      builder.addDouble(1.0); builder.addDouble(1.0)
+      builder.addString("test_metric")
+      builder.addEncodedMap(encoded)
+      val recOff = builder.endRecord()
+
+      val base = builder.currentContainer.get.base
+      val mapFieldIdx = ingestion.numFields - 1
+      val readBack = new StringifyMapItemConsumer()
+      ingestion.consumeMapItems(base, recOff, mapFieldIdx, readBack)
+
+      val result = new TreeMap[String, String]()
+      val pairs = readBack.stringPairs
+      for (i <- 0 until pairs.size) {
+        val t = pairs.apply(i)
+        result.put(t._1, t._2)
+      }
+      result shouldEqual tags
+    }
+  }
+
+  describe("addEncodedMap produces identical records to startMap/addMapKeyValue/endMap") {
+    val schemaTests: Seq[(String, Schema, RecordBuilder => Unit)] = Seq(
+      ("prom-counter", promCounterSchema, { b: RecordBuilder =>
+        b.addLong(12345L)
+        b.addDouble(42.0)
+        b.addString("http_requests_total")
+      }),
+      ("preagg-gauge", gaugeSchema, { b: RecordBuilder =>
+        b.addLong(12345L); b.addDouble(5.0); b.addDouble(1.0)
+        b.addDouble(15.0); b.addDouble(5.0)
+        b.addString("test_gauge:::suffix")
+      }),
+      ("preagg-delta-counter", deltaCounterSchema, { b: RecordBuilder =>
+        b.addLong(12345L); b.addDouble(10.0); b.addDouble(2.0)
+        b.addDouble(20.0); b.addDouble(8.0)
+        b.addString("test_counter:::suffix")
+      }),
+      ("preagg-delta-histogram", deltaHistogramSchema, { b: RecordBuilder =>
+        b.addLong(12345L); b.addDouble(100.0); b.addDouble(50.0)
+        b.addDouble(10.0); b.addBlob(testHistogramBlob())
+        b.addString("test_histogram:::suffix")
+      }),
+      ("preagg-otel-delta-histogram", otelDeltaHistogramSchema, { b: RecordBuilder =>
+        b.addLong(12345L); b.addDouble(100.0); b.addDouble(50.0)
+        b.addDouble(10.0); b.addBlob(testHistogramBlob())
+        b.addDouble(1.0); b.addDouble(99.0)
+        b.addString("test_otel_hist:::suffix")
+      }),
+      ("preagg-otel-exp-delta-histogram", otelExpDeltaHistogramSchema, { b: RecordBuilder =>
+        b.addLong(12345L); b.addDouble(100.0); b.addDouble(50.0)
+        b.addDouble(10.0); b.addBlob(testHistogramBlob())
+        b.addDouble(1.0); b.addDouble(99.0)
+        b.addString("test_otel_exp_hist:::suffix")
+      }),
+      ("preagg-delta-histogram-v2", deltaHistogramV2Schema, { b: RecordBuilder =>
+        b.addLong(12345L); b.addDouble(100.0); b.addDouble(50.0)
+        b.addDouble(10.0); b.addBlob(testHistogramBlob())
+        b.addDouble(1.0); b.addDouble(99.0); b.addDouble(42.0)
+        b.addString("test_hist_v2:::suffix")
+      })
+    )
+
+    for {
+      (schemaName, schema, addCols) <- schemaTests
+      (tagDesc, tags) <- testTagMaps
+    } {
+      it(s"$schemaName with $tagDesc") {
+        verifySchemaCompatibility(schema, addCols, tags)
+      }
+    }
+  }
+
+  private def sortedMap(entries: (String, String)*): java.util.TreeMap[String, String] = {
+    val map = new TreeMap[String, String]()
+    entries.foreach { case (k, v) => map.put(k, v) }
+    map
+  }
+
+  /** Creates a test histogram blob for hist columns. */
+  private def testHistogramBlob(): org.agrona.DirectBuffer = {
+    val buckets = new CustomBuckets(Array(1.0, 5.0, 10.0, 50.0, 100.0))
+    val values = Array(10L, 20L, 30L, 40L, 50L, 60L)
+    val buf = BinaryHistogram.histBuf
+    BinaryHistogram.writeDelta(buckets, values, buf)
+    buf
+  }
+
+  /**
+   * Builds a record using startMap/addMapKeyValue/endMap (the traditional path)
+   * and another using addEncodedMap, then verifies:
+   * 1. Full record bytes are identical
+   * 2. Map bytes are identical
+   * 3. Partition hashes are identical
+   */
+  private def verifySchemaCompatibility(schema: Schema,
+                                        addDataColumns: RecordBuilder => Unit,
+                                        tags: java.util.TreeMap[String, String]): Unit = {
+    // Traditional path
+    val builder1 = new RecordBuilder(MemFactory.onHeapFactory, 16384)
+    builder1.startNewRecord(schema)
+    addDataColumns(builder1)
+    builder1.startMap()
+    tags.entrySet().forEach { entry =>
+      builder1.addMapKeyValue(
+        entry.getKey.getBytes(StandardCharsets.UTF_8),
+        entry.getValue.getBytes(StandardCharsets.UTF_8))
+    }
+    builder1.endMap()
+    val recOff1 = builder1.endRecord()
+
+    // addEncodedMap path
+    val ingestion = schema.ingestionSchema
+    val encoded = MapEncoder.encode(tags, ingestion)
+
+    val builder2 = new RecordBuilder(MemFactory.onHeapFactory, 16384)
+    builder2.startNewRecord(schema)
+    addDataColumns(builder2)
+    builder2.addEncodedMap(encoded)
+    val recOff2 = builder2.endRecord()
+
+    val container1 = builder1.currentContainer.get
+    val container2 = builder2.currentContainer.get
+
+    // Compare full record bytes
+    val recLen1 = UnsafeUtils.getInt(container1.base, recOff1) + 4
+    val recLen2 = UnsafeUtils.getInt(container2.base, recOff2) + 4
+    val recBytes1 = new Array[Byte](recLen1)
+    val recBytes2 = new Array[Byte](recLen2)
+    UnsafeUtils.unsafe.copyMemory(container1.base, recOff1, recBytes1, UnsafeUtils.arayOffset, recLen1)
+    UnsafeUtils.unsafe.copyMemory(container2.base, recOff2, recBytes2, UnsafeUtils.arayOffset, recLen2)
+    recBytes1 shouldEqual recBytes2
+
+    // Compare map bytes
+    val mapFieldIdx = ingestion.numFields - 1
+    val mapFieldOffset1 = recOff1 + UnsafeUtils.getInt(container1.base, recOff1 + ingestion.fieldOffset(mapFieldIdx))
+    val mapLen1 = UnsafeUtils.getShort(container1.base, mapFieldOffset1) & 0xFFFF
+    val mapBytes1 = new Array[Byte](mapLen1)
+    UnsafeUtils.unsafe.copyMemory(container1.base, mapFieldOffset1 + 2, mapBytes1, UnsafeUtils.arayOffset, mapLen1)
+    encoded shouldEqual mapBytes1
+
+    // Compare partition hashes
+    val hash1 = ingestion.partitionHash(container1.base, recOff1)
+    val hash2 = ingestion.partitionHash(container2.base, recOff2)
+    hash1 shouldEqual hash2
+  }
+}


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**New behavior :**
Added a new `MapEncoder` class which allows encoding a tag map once into RecordBuilder's binary wire format, then reusing the raw bytes across multiple records.
- `MapEncoder.encode(Map, RecordSchema)` encodes a sorted tag map into RecordBuilder's exact wire format (including predefined key compression) as a byte[] — once.              
- `MapEncoder.toJavaMap(byte[], RecordSchema)` decodes bytes back to a sorted Map when needed.
- `RecordBuilder.addEncodedMap(byte[])` writes pre-encoded map bytes in a single memcpy, bypassing per-entry addMapKeyValue overhead. Produces byte-identical records and identical partition hashes as the traditional path.  

**IMPORTANT**: 
1.  Added additional support to support `byte[]` encoded map directly into RecordBuilder, clients can continue using `startMap()` / `addMapKeyValue()` / `endMap()` directly. 
2. No changes to existing mechanism used by clients to create RecordBuilder
