### PR TITLE
Add metrics for labels-churn-finder-job

### DIFF
--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelChurnFinder.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelChurnFinder.scala
@@ -1,9 +1,12 @@
 package filodb.labelchurnfinder
 
+import java.util.concurrent.TimeUnit
+
 import scala.concurrent.duration.DurationInt
 
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
+import kamon.Kamon
 import monix.execution.Scheduler
 import net.ceedubs.ficus.Ficus._
 import org.apache.datasketches.hll.HllSketch
@@ -14,11 +17,25 @@ import org.apache.spark.sql.functions._
 import filodb.cassandra.columnstore.{CassandraColumnStore, CassandraTokenRangeSplit}
 import filodb.core.DatasetRef
 import filodb.core.metadata.Schemas
+import filodb.core.metrics.FilodbMetrics
 import filodb.downsampler.DownsamplerContext
 import filodb.downsampler.chunk.DownsamplerSettings
 import filodb.memory.format.UnsafeUtils
 
 object LabelChurnFinderMain extends App {
+  Kamon.init()
+
+  private val jobStartMs = System.currentTimeMillis()
+
+  @transient private lazy val jobDuration         =
+    FilodbMetrics.timeHistogram("label_churn_finder_job_duration", TimeUnit.MILLISECONDS)
+  @transient private lazy val workspacesPublished =
+    FilodbMetrics.counter("label_churn_finder_workspaces_published_total")
+  @transient private lazy val labelsPublished     =
+    FilodbMetrics.counter("label_churn_finder_labels_published_total")
+  @transient private lazy val kafkaFailures       =
+    FilodbMetrics.counter("label_churn_finder_kafka_publish_failures_total")
+
   private val dsSettings = new DownsamplerSettings()
   private val labelChurnFinder = new LabelChurnFinder(dsSettings)
   private val sparkConf = new SparkConf(loadDefaults = true)
@@ -27,10 +44,26 @@ object LabelChurnFinderMain extends App {
     .appName("LabelChurnFinder")
     .config(sparkConf)
     .getOrCreate()
-  private val labelStats = labelChurnFinder.computeLabelStats(spark)
+
+  // Spark accumulators collect executor-side counts back to the driver
+  private val failuresAcc   = spark.sparkContext.longAccumulator("lcf_kafka_failures")
+  private val labelsAcc     = spark.sparkContext.longAccumulator("lcf_labels_published")
+  private val workspacesAcc = spark.sparkContext.longAccumulator("lcf_workspaces_published")
+
+  private val labelStats     = labelChurnFinder.computeLabelStats(spark)
   private val publishToKafka = dsSettings.filodbConfig.as[Boolean]("labelchurnfinder.publish-to-kafka")
-  private val producer = if (publishToKafka) Some(new LabelStatsKafkaProducer(dsSettings.filodbConfig)) else None
+  private val producer = if (publishToKafka)
+    Some(new LabelStatsKafkaProducer(dsSettings.filodbConfig, failuresAcc, labelsAcc, workspacesAcc))
+  else None
+
   labelChurnFinder.actionOnLabelStats(labelStats, producer)
+
+  // After the Spark job completes, read accumulator totals and record to OTel on the driver
+  workspacesPublished.increment(workspacesAcc.value)
+  labelsPublished.increment(labelsAcc.value)
+  kafkaFailures.increment(failuresAcc.value)
+  jobDuration.record(System.currentTimeMillis() - jobStartMs)
+
   spark.stop()
 }
 

--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelChurnFinder.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelChurnFinder.scala
@@ -28,13 +28,13 @@ object LabelChurnFinderMain extends App {
   private val jobStartMs = System.currentTimeMillis()
 
   @transient private lazy val jobDuration         =
-    FilodbMetrics.timeHistogram("label_churn_finder_job_duration", TimeUnit.MILLISECONDS)
+    FilodbMetrics.timeHistogram("lcf_job_duration", TimeUnit.MILLISECONDS)
   @transient private lazy val workspacesPublished =
-    FilodbMetrics.counter("label_churn_finder_workspaces_published_total")
+    FilodbMetrics.counter("lcf_workspaces_published_total")
   @transient private lazy val labelsPublished     =
-    FilodbMetrics.counter("label_churn_finder_labels_published_total")
+    FilodbMetrics.counter("lcf_labels_published_total")
   @transient private lazy val kafkaFailures       =
-    FilodbMetrics.counter("label_churn_finder_kafka_publish_failures_total")
+    FilodbMetrics.counter("lcf_kafka_publish_failures_total")
 
   private val dsSettings = new DownsamplerSettings()
   private val labelChurnFinder = new LabelChurnFinder(dsSettings)

--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelStatsKafkaProducer.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelStatsKafkaProducer.scala
@@ -184,7 +184,7 @@ object LabelStatsKafkaProducer {
   ): Unit = {
     val workspaceId = row.getAs[String](WsCol)
     val nsGroup = row.getAs[String](NsGroupCol)
-    val labelsArray = row.getAs[Seq[Row]]("labels")
+    val labelsArray = row.getAs[scala.collection.Seq[Row]]("labels")
 
     val labels = buildLabelsFromRows(labelsArray)
     labelsAcc.add(labels.size)
@@ -203,7 +203,8 @@ object LabelStatsKafkaProducer {
   /**
    * Builds label statistics from Spark Row data.
    */
-  private[labelchurnfinder] def buildLabelsFromRows(labelsArray: Seq[Row]): Seq[LabelStatDto] = {
+  private[labelchurnfinder] def buildLabelsFromRows(labelsArray: scala.collection.Seq[Row]):
+  scala.collection.Seq[LabelStatDto] = {
     labelsArray.map { labelRow =>
       LabelStatDto(
         labelName = labelRow.getAs[String](0),

--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelStatsKafkaProducer.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelStatsKafkaProducer.scala
@@ -10,6 +10,7 @@ import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, Produce
 import org.apache.kafka.common.serialization.StringSerializer
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions._
+import org.apache.spark.util.LongAccumulator
 
 /**
  * Distributed Kafka producer for publishing label statistics from Spark executors.
@@ -20,7 +21,10 @@ import org.apache.spark.sql.functions._
  * 3. Publish messages in parallel from all executors
  *
  */
-class LabelStatsKafkaProducer(config: Config) extends StrictLogging {
+class LabelStatsKafkaProducer(config: Config,
+                               failuresAcc: LongAccumulator,
+                               labelsAcc: LongAccumulator,
+                               workspacesAcc: LongAccumulator) extends StrictLogging {
 
   import LabelChurnFinder._
 
@@ -103,7 +107,9 @@ class LabelStatsKafkaProducer(config: Config) extends StrictLogging {
       try {
         partition.foreach { row =>
           LabelStatsKafkaProducer.publishRow(row, localProducer,
-            broadcastTopic.value, broadcastPartition.value, jobTimestamp)
+            broadcastTopic.value, broadcastPartition.value, jobTimestamp,
+            failuresAcc, labelsAcc)
+          workspacesAcc.add(1)
         }
         localProducer.flush()
       } finally {
@@ -167,18 +173,22 @@ object LabelStatsKafkaProducer {
    * Publishes a single row (workspace) to Kafka.
    * Extracts labels, builds message, and sends asynchronously.
    */
-  private def publishRow(
+  private[labelchurnfinder] def publishRow(
     row: Row,
     producer: KafkaProducer[String, String],
     topic: String,
     partition: String,
-    jobTimestamp: Instant
+    jobTimestamp: Instant,
+    failuresAcc: LongAccumulator,
+    labelsAcc: LongAccumulator
   ): Unit = {
     val workspaceId = row.getAs[String](WsCol)
     val nsGroup = row.getAs[String](NsGroupCol)
     val labelsArray = row.getAs[Seq[Row]]("labels")
 
     val labels = buildLabelsFromRows(labelsArray)
+    labelsAcc.add(labels.size)
+
     val message = LabelStatisticsMessage(
       workspaceId = workspaceId,
       mosaicPartition = partition,
@@ -187,7 +197,7 @@ object LabelStatsKafkaProducer {
       labels = labels
     )
 
-    sendToKafka(producer, topic, workspaceId, message, partition)
+    sendToKafka(producer, topic, workspaceId, message, partition, failuresAcc)
   }
 
   /**
@@ -215,13 +225,15 @@ object LabelStatsKafkaProducer {
     topic: String,
     key: String,
     message: LabelStatisticsMessage,
-    partition: String
+    partition: String,
+    failuresAcc: LongAccumulator
   ): Unit = {
     val record = new ProducerRecord[String, String](topic, key, message.asJson.noSpaces)
 
     producer.send(record, (metadata: RecordMetadata, exception: Exception) => {
       if (exception != null) {
         logger.error(s"Failed to publish for workspace=$key, partition=$partition: ${exception.getMessage}")
+        failuresAcc.add(1)
       }
     })
   }

--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelStatsMessage.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelStatsMessage.scala
@@ -16,7 +16,7 @@ case class LabelStatisticsMessage(
   mosaicPartition: String,
   nsGroup: String,
   jobTimestamp: Instant,
-  labels: Seq[LabelStatDto]
+  labels: scala.collection.Seq[LabelStatDto]
 )
 
 /**

--- a/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelStatsKafkaProducerSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelStatsKafkaProducerSpec.scala
@@ -150,7 +150,10 @@ class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAn
           |}
           |""".stripMargin)
 
-      val producer = new LabelStatsKafkaProducer(config)
+      val producer = new LabelStatsKafkaProducer(config,
+        spark.sparkContext.longAccumulator("failures"),
+        spark.sparkContext.longAccumulator("labels"),
+        spark.sparkContext.longAccumulator("workspaces"))
 
       val grouped = producer.groupLabelsByWorkspace(df)
 
@@ -216,7 +219,10 @@ class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAn
           |}
           |""".stripMargin)
 
-      val producer = new LabelStatsKafkaProducer(config)
+      val producer = new LabelStatsKafkaProducer(config,
+        spark.sparkContext.longAccumulator("failures"),
+        spark.sparkContext.longAccumulator("labels"),
+        spark.sparkContext.longAccumulator("workspaces"))
 
       producer.topic shouldBe "test-topic"
       producer.kafkaProps("pie.queue.kaffe.connect") shouldBe "test-server:9092"

--- a/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelStatsKafkaProducerSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelStatsKafkaProducerSpec.scala
@@ -3,9 +3,13 @@ package filodb.labelchurnfinder
 import com.typesafe.config.ConfigFactory
 import io.circe.parser._
 import io.circe.syntax._
+import org.apache.kafka.clients.producer.{Callback, KafkaProducer, ProducerRecord, RecordMetadata}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.types._
+import org.mockito.ArgumentMatchers.any
+import org.mockito.MockitoSugar
+import org.mockito.invocation.InvocationOnMock
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -15,7 +19,7 @@ import java.time.Instant
 /**
  * Unit tests for LabelStatsKafkaProducer.
  */
-class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll {
+class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll with MockitoSugar {
 
   import LabelStatisticsMessage._
 
@@ -208,7 +212,6 @@ class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAn
   }
 
   describe("Producer configuration") {
-
     it("should use correct Kafka configuration values") {
       val config = ConfigFactory.parseString(
         """
@@ -227,6 +230,66 @@ class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAn
       producer.topic shouldBe "test-topic"
       producer.kafkaProps("pie.queue.kaffe.connect") shouldBe "test-server:9092"
       producer.mosaicPartition shouldBe "us-east-1-p1"
+    }
+  }
+
+  describe("Accumulator tracking") {
+
+    val accConfig = ConfigFactory.parseString(
+      """
+        |partition = "us-east-1-p1"
+        |labelchurnfinder.kafka {
+        |  topic = "test-topic"
+        |  pie.queue.kaffe.connect = "localhost:9092"
+        |}
+        |""".stripMargin)
+
+    it("should increment labelsAcc by the number of labels in the published row") {
+      val failuresAcc   = spark.sparkContext.longAccumulator("failures")
+      val labelsAcc     = spark.sparkContext.longAccumulator("labels")
+      val workspacesAcc = spark.sparkContext.longAccumulator("workspaces")
+
+      val df = createTestDataFrame(Seq(
+        ("ws-1", "All", "pod",      100L, 200L, 300L, Array[Byte](1), Array[Byte](2), Array[Byte](3)),
+        ("ws-1", "All", "instance",  50L, 100L, 150L, Array[Byte](4), Array[Byte](5), Array[Byte](6)),
+        ("ws-1", "All", "container", 30L,  60L,  90L, Array[Byte](7), Array[Byte](8), Array[Byte](9))
+      ))
+
+      val producer = new LabelStatsKafkaProducer(accConfig, failuresAcc, labelsAcc, workspacesAcc)
+      val row = producer.groupLabelsByWorkspace(df).collect().head
+
+      val mockProducer = mock[KafkaProducer[String, String]]
+      LabelStatsKafkaProducer.publishRow(row, mockProducer, "test-topic", "us-east-1-p1",
+        Instant.now(), failuresAcc, labelsAcc)
+
+      labelsAcc.value shouldBe 3
+      failuresAcc.value shouldBe 0
+    }
+
+    it("should increment failuresAcc when Kafka send callback fires with an exception") {
+      val failuresAcc   = spark.sparkContext.longAccumulator("failures")
+      val labelsAcc     = spark.sparkContext.longAccumulator("labels")
+      val workspacesAcc = spark.sparkContext.longAccumulator("workspaces")
+
+      val df = createTestDataFrame(Seq(
+        ("ws-2", "All", "pod", 100L, 200L, 300L, Array[Byte](1), Array[Byte](2), Array[Byte](3))
+      ))
+
+      val producer = new LabelStatsKafkaProducer(accConfig, failuresAcc, labelsAcc, workspacesAcc)
+      val row = producer.groupLabelsByWorkspace(df).collect().head
+
+      val mockProducer = mock[KafkaProducer[String, String]]
+      doAnswer((invocation: InvocationOnMock) => {
+        val callback = invocation.getArgument[Callback](1)
+        callback.onCompletion(null, new RuntimeException("broker unavailable"))
+        null.asInstanceOf[java.util.concurrent.Future[RecordMetadata]]
+      }).when(mockProducer).send(any[ProducerRecord[String, String]], any[Callback])
+
+      LabelStatsKafkaProducer.publishRow(row, mockProducer, "test-topic", "us-east-1-p1",
+        Instant.now(), failuresAcc, labelsAcc)
+
+      failuresAcc.value shouldBe 1
+      labelsAcc.value shouldBe 1
     }
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

Add OpenTelemetry metrics to the labels churn finder Spark job via FilodbMetrics

What was added:                                                                                                                        
                                                                                                                                         
Driver-side metrics (recorded after job completes):                                                                                  
    - label_churn_finder_job_duration — total job time in milliseconds                                                        
    - label_churn_finder_workspaces_published_total — number of workspaces published to Kafka                                            
    - label_churn_finder_labels_published_total — total number of labels published across all workspaces                                 
    - label_churn_finder_kafka_publish_failures_total — number of Kafka send failures                                                    
  
Executor-side counts (workspaces, labels, Kafka failures) are collected using Spark LongAccumulators and recorded to metrics on the driver after the job completes

