### PR TITLE
feat(InputRecord): Support TreeMap overloaded methods for clients storing tags as TreeMap in memory 

### DIFF
--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -309,6 +309,39 @@ class RecordBuilder(memFactory: MemFactory,
     endMap()
   }
 
+  /**
+   * Encodes a Java TreeMap directly into the map field without Scala collection conversion.
+   * TreeMap is already sorted by key, so no re-sorting needed.
+   *
+   * This avoids the overhead of:
+   *   - convertToScalaImmutableMap (Stream, Tuple2, HashMap construction)
+   *   - Scala Map.toSeq.sortBy (TreeMap is already sorted)
+   *   - ZeroCopyUTF8String wrapping
+   *
+   * Produces the same wire format as addMap(Map[ZCUTF8, ZCUTF8]) — identical bytes,
+   * same predefined key handling, same partition hash.
+   *
+   * Usage from Java:
+   *   TreeMap<String, String> tags = new TreeMap<>();
+   *   tags.put("_ns_", "myapp");
+   *   tags.put("_ws_", "demo");
+   *   builder.startNewRecord(schema);
+   *   // ... add other fields ...
+   *   builder.encodeMapFrom(tags);
+   *   builder.endRecord();
+   */
+  final def encodeMapFrom(tags: java.util.TreeMap[String, String]): Unit = {
+    startMap()
+    val iter = tags.entrySet().iterator()
+    while (iter.hasNext) {
+      val entry = iter.next()
+      val keyBytes = entry.getKey.getBytes(StandardCharsets.UTF_8)
+      val valBytes = entry.getValue.getBytes(StandardCharsets.UTF_8)
+      addMapKeyValue(keyBytes, 0, keyBytes.length, valBytes, 0, valBytes.length)
+    }
+    endMap()
+  }
+
   final def updatePartitionHash(newHash: Int): Unit = {
     recHash = combineHash(recHash, newHash)
   }

--- a/core/src/test/scala/filodb.core/binaryrecord2/MapEncoderSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/MapEncoderSpec.scala
@@ -303,4 +303,294 @@ class MapEncoderSpec extends AnyFunSpec with Matchers {
     val hash2 = ingestion.partitionHash(container2.base, recOff2)
     hash1 shouldEqual hash2
   }
+
+  // ── RecordBuilder.encodeMapFrom(TreeMap) tests ─────────────────────
+  // Verifies that encodeMapFrom produces identical records to addMap (Scala path).
+
+  describe("RecordBuilder.encodeMapFrom(TreeMap)") {
+
+    /**
+     * Helper: builds a record using the Scala addMap path (baseline).
+     * Returns (container base, record offset).
+     */
+    def buildWithScalaMap(schema: Schema,
+                          tags: java.util.TreeMap[String, String]): (Any, Long) = {
+      import filodb.memory.format.{ZeroCopyUTF8String => ZCUTF8}
+      import ZCUTF8._
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, 16384)
+      builder.startNewRecord(schema)
+      builder.addLong(1000000L)       // timestamp
+      builder.addDouble(42.0)         // value
+      builder.addString("test-metric")
+      val scalaMap = {
+        val m = scala.collection.mutable.LinkedHashMap[ZCUTF8, ZCUTF8]()
+        val iter = tags.entrySet().iterator()
+        while (iter.hasNext) {
+          val e = iter.next()
+          m += (e.getKey.utf8 -> e.getValue.utf8)
+        }
+        m.toMap
+      }
+      builder.addMap(scalaMap)
+      val off = builder.endRecord()
+      (builder.currentContainer.get.base, off)
+    }
+
+    /**
+     * Helper: builds a record using the new encodeMapFrom path.
+     */
+    def buildWithTreeMap(schema: Schema,
+                         tags: java.util.TreeMap[String, String]): (Any, Long) = {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, 16384)
+      builder.startNewRecord(schema)
+      builder.addLong(1000000L)
+      builder.addDouble(42.0)
+      builder.addString("test-metric")
+      builder.encodeMapFrom(tags)
+      val off = builder.endRecord()
+      (builder.currentContainer.get.base, off)
+    }
+
+    /** Extract full record bytes for comparison */
+    def recordBytes(base: Any, offset: Long): Array[Byte] = {
+      val len = UnsafeUtils.getInt(base, offset) + 4
+      val bytes = new Array[Byte](len)
+      UnsafeUtils.unsafe.copyMemory(
+        base, offset, bytes, UnsafeUtils.arayOffset, len)
+      bytes
+    }
+
+    testTagMaps.foreach { case (desc, tags) =>
+      it(s"should produce identical bytes to addMap: $desc") {
+        val schema = gaugeSchema
+        val (scalaBase, scalaOff) = buildWithScalaMap(schema, tags)
+        val (treeBase, treeOff) = buildWithTreeMap(schema, tags)
+
+        recordBytes(scalaBase, scalaOff) shouldEqual
+          recordBytes(treeBase, treeOff)
+      }
+    }
+
+    it("should produce identical partition hash") {
+      val tags = sortedMap(
+        "_ns_" -> "filodb-local",
+        "_ws_" -> "aci-telemetry",
+        "dc" -> "us-west-2",
+        "instance" -> "i-12345"
+      )
+      val schema = gaugeSchema
+      val ingestion = schema.ingestionSchema
+      val (scalaBase, scalaOff) = buildWithScalaMap(schema, tags)
+      val (treeBase, treeOff) = buildWithTreeMap(schema, tags)
+
+      ingestion.partitionHash(scalaBase, scalaOff) shouldEqual
+        ingestion.partitionHash(treeBase, treeOff)
+    }
+
+    it("should handle empty TreeMap") {
+      val tags = new TreeMap[String, String]()
+      val schema = gaugeSchema
+      val (_, treeOff) = buildWithTreeMap(schema, tags)
+      // Should not throw, produces a valid record with empty map
+      treeOff should be > 0L
+    }
+
+    it("should handle single entry") {
+      val tags = sortedMap("_ws_" -> "demo")
+      val schema = gaugeSchema
+      val (scalaBase, scalaOff) = buildWithScalaMap(schema, tags)
+      val (treeBase, treeOff) = buildWithTreeMap(schema, tags)
+
+      recordBytes(scalaBase, scalaOff) shouldEqual
+        recordBytes(treeBase, treeOff)
+    }
+
+    it("should handle non-ASCII UTF-8 values") {
+      val tags = sortedMap(
+        "_ns_" -> "名前空間",
+        "_ws_" -> "作業空間",
+        "city" -> "München"
+      )
+      val schema = gaugeSchema
+      val (scalaBase, scalaOff) = buildWithScalaMap(schema, tags)
+      val (treeBase, treeOff) = buildWithTreeMap(schema, tags)
+
+      recordBytes(scalaBase, scalaOff) shouldEqual
+        recordBytes(treeBase, treeOff)
+    }
+
+    it("should handle many tags (10+)") {
+      val tags = new TreeMap[String, String]()
+      (0 until 15).foreach { i =>
+        tags.put(f"label_$i%02d", s"value_$i")
+      }
+      tags.put("_ns_", "myapp")
+      tags.put("_ws_", "prod")
+      val schema = gaugeSchema
+      val (scalaBase, scalaOff) = buildWithScalaMap(schema, tags)
+      val (treeBase, treeOff) = buildWithTreeMap(schema, tags)
+
+      recordBytes(scalaBase, scalaOff) shouldEqual
+        recordBytes(treeBase, treeOff)
+    }
+
+    it("should work with different schemas") {
+      val tags = sortedMap(
+        "_ns_" -> "app",
+        "_ws_" -> "demo",
+        "job" -> "prometheus"
+      )
+      Seq(gaugeSchema, deltaCounterSchema, promCounterSchema).foreach { schema =>
+        val (scalaBase, scalaOff) = buildWithScalaMap(schema, tags)
+        val (treeBase, treeOff) = buildWithTreeMap(schema, tags)
+        recordBytes(scalaBase, scalaOff) shouldEqual
+          recordBytes(treeBase, treeOff)
+      }
+    }
+
+    it("should handle max-length key (191 bytes)") {
+      val longKey = "k" * 191
+      val tags = sortedMap(
+        "_ws_" -> "demo",
+        longKey -> "value"
+      )
+      val schema = gaugeSchema
+      val (scalaBase, scalaOff) = buildWithScalaMap(schema, tags)
+      val (treeBase, treeOff) = buildWithTreeMap(schema, tags)
+
+      recordBytes(scalaBase, scalaOff) shouldEqual
+        recordBytes(treeBase, treeOff)
+    }
+
+    it("should handle empty string values") {
+      val tags = sortedMap(
+        "_ns_" -> "",
+        "_ws_" -> "",
+        "key" -> ""
+      )
+      val schema = gaugeSchema
+      val (scalaBase, scalaOff) = buildWithScalaMap(schema, tags)
+      val (treeBase, treeOff) = buildWithTreeMap(schema, tags)
+
+      recordBytes(scalaBase, scalaOff) shouldEqual
+        recordBytes(treeBase, treeOff)
+    }
+
+    it("should handle single-char keys and values") {
+      val tags = sortedMap(
+        "a" -> "1",
+        "b" -> "2",
+        "z" -> "0"
+      )
+      val schema = gaugeSchema
+      val (scalaBase, scalaOff) = buildWithScalaMap(schema, tags)
+      val (treeBase, treeOff) = buildWithTreeMap(schema, tags)
+
+      recordBytes(scalaBase, scalaOff) shouldEqual
+        recordBytes(treeBase, treeOff)
+    }
+
+    // Sort order test: TreeMap sorts by String.compareTo (UTF-16 code unit order)
+    // and addMap sorts by ZCUTF8 (UTF-8 byte order). For BMP characters these are
+    // equivalent because UTF-8 preserves Unicode code point ordering, and for BMP
+    // chars UTF-16 code unit == code point. This test verifies the order matches.
+    it("should sort identically for keys with underscores, digits, uppercase") {
+      // _ = 0x5F, A = 0x41, Z = 0x5A, a = 0x61, z = 0x7A, 0 = 0x30
+      // Sort order: 0 < A < Z < _ < a < z
+      val tags = sortedMap(
+        "Zulu" -> "v1",
+        "_metric_" -> "v2",
+        "alpha" -> "v3",
+        "0start" -> "v4",
+        "Azure" -> "v5",
+        "_ns_" -> "v6",
+        "_ws_" -> "v7"
+      )
+      val schema = gaugeSchema
+      val (scalaBase, scalaOff) = buildWithScalaMap(schema, tags)
+      val (treeBase, treeOff) = buildWithTreeMap(schema, tags)
+
+      recordBytes(scalaBase, scalaOff) shouldEqual
+        recordBytes(treeBase, treeOff)
+    }
+
+    it("sort order should match for Latin-1 chars (accented)") {
+      // Latin-1 chars: UTF-8 2-byte encoding, but sort order preserved
+      val tags = sortedMap(
+        "_ws_" -> "demo",
+        "café" -> "latte",
+        "naïve" -> "yes",
+        "über" -> "alles"
+      )
+      val schema = gaugeSchema
+      val (scalaBase, scalaOff) = buildWithScalaMap(schema, tags)
+      val (treeBase, treeOff) = buildWithTreeMap(schema, tags)
+
+      recordBytes(scalaBase, scalaOff) shouldEqual
+        recordBytes(treeBase, treeOff)
+    }
+
+    it("should produce identical bytes for all predefined keys") {
+      // Build a map using ONLY predefined keys from the schema
+      val predefKeys = partSchema.predefinedKeys
+      val tags = new TreeMap[String, String]()
+      predefKeys.zipWithIndex.foreach { case (key, i) =>
+        tags.put(key, s"value_$i")
+      }
+      if (!tags.isEmpty) {
+        val schema = gaugeSchema
+        val (scalaBase, scalaOff) = buildWithScalaMap(schema, tags)
+        val (treeBase, treeOff) = buildWithTreeMap(schema, tags)
+
+        recordBytes(scalaBase, scalaOff) shouldEqual
+          recordBytes(treeBase, treeOff)
+      }
+    }
+
+    it("should handle value near max size (1000 bytes)") {
+      val tags = sortedMap(
+        "_ws_" -> "demo",
+        "big" -> "x" * 1000
+      )
+      val schema = gaugeSchema
+      val (scalaBase, scalaOff) = buildWithScalaMap(schema, tags)
+      val (treeBase, treeOff) = buildWithTreeMap(schema, tags)
+
+      recordBytes(scalaBase, scalaOff) shouldEqual
+        recordBytes(treeBase, treeOff)
+    }
+
+    it("should handle keys that look similar to predefined but aren't") {
+      // Keys that might hash-collide with predefined keys but are different strings
+      val tags = sortedMap(
+        "_NS_" -> "uppercase-ns",
+        "_WS_" -> "uppercase-ws",
+        "_ns" -> "missing-trailing-underscore",
+        "_ws" -> "missing-trailing-underscore",
+        "ns_" -> "missing-leading-underscore"
+      )
+      val schema = gaugeSchema
+      val (scalaBase, scalaOff) = buildWithScalaMap(schema, tags)
+      val (treeBase, treeOff) = buildWithTreeMap(schema, tags)
+
+      recordBytes(scalaBase, scalaOff) shouldEqual
+        recordBytes(treeBase, treeOff)
+    }
+
+    it("should handle duplicate-length keys that sort differently") {
+      // Same length keys where byte order matters
+      val tags = sortedMap(
+        "aaa" -> "1",
+        "aab" -> "2",
+        "aba" -> "3",
+        "baa" -> "4"
+      )
+      val schema = gaugeSchema
+      val (scalaBase, scalaOff) = buildWithScalaMap(schema, tags)
+      val (treeBase, treeOff) = buildWithTreeMap(schema, tags)
+
+      recordBytes(scalaBase, scalaOff) shouldEqual
+        recordBytes(treeBase, treeOff)
+    }
+  }
 }

--- a/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
@@ -40,6 +40,219 @@ object InputRecord {
   import filodb.core.metadata.Schemas._
   import ZCUTF8._
 
+  // ── Java TreeMap overloads ─────────────────────────────────────────
+  // These accept java.util.TreeMap[String, String] directly, avoiding:
+  //   - convertToScalaImmutableMap (Stream, Tuple2, HashMap construction)
+  //   - Scala Map.toSeq.sortBy (TreeMap is already sorted)
+  //   - ZeroCopyUTF8String wrapping (k.utf8, v.utf8)
+  //
+  // Produces identical wire format — same bytes, same partition hash.
+  // Use from Java callers (e.g. MosaicRecordBuilder) for lower allocation overhead.
+
+  def writeGaugeRecord(builder: RecordBuilder,
+                       metric: String,
+                       tags: java.util.TreeMap[String, String],
+                       timestamp: Long,
+                       value: Double): Unit =
+    writeKVRecordJ(builder, metric, tags, timestamp, value, gauge)
+
+  def writePromCounterRecord(builder: RecordBuilder,
+                             metric: String,
+                             tags: java.util.TreeMap[String, String],
+                             timestamp: Long,
+                             count: Double): Unit =
+    writeKVRecordJ(builder, metric, tags, timestamp, count, promCounter)
+
+  def writeDeltaCounterRecord(builder: RecordBuilder,
+                              metric: String,
+                              tags: java.util.TreeMap[String, String],
+                              timestamp: Long,
+                              count: Double): Unit =
+    writeKVRecordJ(builder, metric, tags, timestamp, count, deltaCounter)
+
+  def writeUntypedRecord(builder: RecordBuilder,
+                         metric: String,
+                         tags: java.util.TreeMap[String, String],
+                         timestamp: Long,
+                         value: Double): Unit =
+    writeKVRecordJ(builder, metric, tags, timestamp, value, untyped)
+
+  private def writeKVRecordJ(builder: RecordBuilder,
+                             metric: String,
+                             tags: java.util.TreeMap[String, String],
+                             timestamp: Long,
+                             value: Double,
+                             schema: Schema): Unit = {
+    builder.startNewRecord(schema)
+    builder.addLong(timestamp)
+    builder.addDouble(value)
+    builder.addString(metric)
+    builder.encodeMapFrom(tags)
+    builder.endRecord()
+  }
+
+  def writePromHistRecord(builder: RecordBuilder,
+                          metric: String,
+                          tags: java.util.TreeMap[String, String],
+                          timestamp: Long,
+                          kvs: Seq[(String, Double)]): Unit = {
+    val (sum, count, sortedBuckets) = extractSumCountBuckets(kvs)
+    if (sortedBuckets.nonEmpty) {
+      val buckets = CustomBuckets(sortedBuckets.map(_._1).toArray)
+      val hist = LongHistogram(buckets, sortedBuckets.map(_._2).toArray)
+      builder.startNewRecord(promHistogram)
+      builder.addLong(timestamp)
+      builder.addDouble(sum)
+      builder.addDouble(count)
+      builder.addBlob(hist.serialize())
+      builder.addString(metric)
+      builder.encodeMapFrom(tags)
+      builder.endRecord()
+    }
+  }
+
+  def writeDeltaHistRecord(builder: RecordBuilder,
+                           metric: String,
+                           tags: java.util.TreeMap[String, String],
+                           timestamp: Long,
+                           kvs: Seq[(String, Double)]): Unit = {
+    val (sum, count, sortedBuckets) = extractSumCountBuckets(kvs)
+    if (sortedBuckets.nonEmpty) {
+      val buckets = CustomBuckets(sortedBuckets.map(_._1).toArray)
+      val hist = LongHistogram(buckets, sortedBuckets.map(_._2).toArray)
+      builder.startNewRecord(deltaHistogram)
+      builder.addLong(timestamp)
+      builder.addDouble(sum)
+      builder.addDouble(count)
+      builder.addBlob(hist.serialize())
+      builder.addString(metric)
+      builder.encodeMapFrom(tags)
+      builder.endRecord()
+    }
+  }
+
+  def writeOtelCumulativeHistRecord(builder: RecordBuilder,
+                                    metric: String,
+                                    tags: java.util.TreeMap[String, String],
+                                    timestamp: Long,
+                                    kvs: Seq[(String, Double)]): Unit = {
+    val (sum, count, min, max, sortedBuckets) = extractSumCountMinMaxBuckets(kvs)
+    if (sortedBuckets.nonEmpty) {
+      val buckets = CustomBuckets(sortedBuckets.map(_._1).toArray)
+      val hist = LongHistogram(buckets, sortedBuckets.map(_._2).toArray)
+      builder.startNewRecord(otelCumulativeHistogram)
+      builder.addLong(timestamp)
+      builder.addDouble(sum)
+      builder.addDouble(count)
+      builder.addBlob(hist.serialize())
+      builder.addDouble(min)
+      builder.addDouble(max)
+      builder.addString(metric)
+      builder.encodeMapFrom(tags)
+      builder.endRecord()
+    }
+  }
+
+  def writeOtelDeltaHistRecord(builder: RecordBuilder,
+                               metric: String,
+                               tags: java.util.TreeMap[String, String],
+                               timestamp: Long,
+                               kvs: Seq[(String, Double)]): Unit = {
+    val (sum, count, min, max, sortedBuckets) = extractSumCountMinMaxBuckets(kvs)
+    if (sortedBuckets.nonEmpty) {
+      val buckets = CustomBuckets(sortedBuckets.map(_._1).toArray)
+      val hist = LongHistogram(buckets, sortedBuckets.map(_._2).toArray)
+      builder.startNewRecord(otelDeltaHistogram)
+      builder.addLong(timestamp)
+      builder.addDouble(sum)
+      builder.addDouble(count)
+      builder.addBlob(hist.serialize())
+      builder.addDouble(min)
+      builder.addDouble(max)
+      builder.addString(metric)
+      builder.encodeMapFrom(tags)
+      builder.endRecord()
+    }
+  }
+
+  //scalastyle:off method.length
+  def writeOtelExponentialHistRecord(builder: RecordBuilder,
+                                     metric: String,
+                                     tags: java.util.TreeMap[String, String],
+                                     timestamp: Long,
+                                     kvs: Seq[(String, Double)],
+                                     isDelta: Boolean): Unit = {
+    require(isDelta, "Cumulative exponential histograms not supported")
+    var sum = Double.NaN
+    var count = Double.NaN
+    var min = Double.NaN
+    var max = Double.NaN
+    var posBucketOffset = Double.NaN
+    var scale = Double.NaN
+    val sortedBuckets = kvs.filter {
+      case ("sum", v) => sum = v; false
+      case ("count", v) => count = v; false
+      case ("min", v) => min = v; false
+      case ("max", v) => max = v; false
+      case ("posBucketOffset", v) => posBucketOffset = v; false
+      case ("scale", v) => scale = v; false
+      case _ => true
+    }.map { case (k, v) => (k.toInt, v.toLong) }.sorted
+    if (sortedBuckets.nonEmpty) {
+      val buckets = Base2ExpHistogramBuckets(scale.toInt, posBucketOffset.toInt, sortedBuckets.length - 1)
+      val hist = LongHistogram(buckets, sortedBuckets.map(_._2).toArray)
+      builder.startNewRecord(otelExpDeltaHistogram)
+      builder.addLong(timestamp)
+      builder.addDouble(sum)
+      builder.addDouble(count)
+      builder.addBlob(hist.serialize())
+      builder.addDouble(min)
+      builder.addDouble(max)
+      builder.addString(metric)
+      builder.encodeMapFrom(tags)
+      builder.endRecord()
+    }
+  }
+  //scalastyle:on method.length
+
+  // ── Shared helpers for histogram bucket extraction ─────────────────
+
+  private def extractSumCountBuckets(kvs: Seq[(String, Double)])
+    : (Double, Double, Seq[(Double, Long)]) = {
+    var sum = Double.NaN
+    var count = Double.NaN
+    val sortedBuckets = kvs.filter {
+      case ("sum", v) => sum = v; false
+      case ("count", v) => count = v; false
+      case _ => true
+    }.map {
+      case ("+Inf", v) => (Double.PositiveInfinity, v.toLong)
+      case (k, v) => (k.toDouble, v.toLong)
+    }.sorted
+    (sum, count, sortedBuckets)
+  }
+
+  private def extractSumCountMinMaxBuckets(kvs: Seq[(String, Double)])
+    : (Double, Double, Double, Double, Seq[(Double, Long)]) = {
+    var sum = Double.NaN
+    var count = Double.NaN
+    var min = Double.NaN
+    var max = Double.NaN
+    val sortedBuckets = kvs.filter {
+      case ("sum", v) => sum = v; false
+      case ("count", v) => count = v; false
+      case ("min", v) => min = v; false
+      case ("max", v) => max = v; false
+      case _ => true
+    }.map {
+      case ("+Inf", v) => (Double.PositiveInfinity, v.toLong)
+      case (k, v) => (k.toDouble, v.toLong)
+    }.sorted
+    (sum, count, min, max, sortedBuckets)
+  }
+
+  // ── Original Scala Map overloads (unchanged) ───────────────────────
+
   /**
    * Writes a BinaryRecord for the built-in gauge schema.  Note that tags are NOT manipulated at all.
    */

--- a/gateway/src/test/scala/filodb/gateway/conversion/InputRecordBuilderSpec.scala
+++ b/gateway/src/test/scala/filodb/gateway/conversion/InputRecordBuilderSpec.scala
@@ -141,4 +141,172 @@ class InputRecordBuilderSpec extends AnyFunSpec with Matchers {
     // The empty histogram should have been skipped, so we should have only one record
     builder.allContainers.head.countRecords() shouldEqual 1
   }
+
+  // ── Java TreeMap overload compatibility tests ──────────────────────
+  // Verifies that TreeMap overloads produce byte-for-byte identical records
+  // to the original Scala Map overloads.
+
+  import filodb.memory.format.UnsafeUtils
+  import filodb.core.binaryrecord2.RecordBuilder.ContainerHeaderLen
+
+  val treeTags = {
+    val t = new java.util.TreeMap[String, String]()
+    baseTags.foreach { case (k, v) => t.put(k, v) }
+    t
+  }
+
+  /** Extract full record bytes from a builder's first container, first record */
+  private def firstRecordBytes(b: RecordBuilder, schema: filodb.core.metadata.Schema): Array[Byte] = {
+    val container = b.allContainers.head
+    val base = container.base
+    val off = container.offset + ContainerHeaderLen
+    val len = UnsafeUtils.getInt(base, off) + 4
+    val recBytes = new Array[Byte](len)
+    UnsafeUtils.unsafe.copyMemory(base, off, recBytes, UnsafeUtils.arayOffset, len)
+    recBytes
+  }
+
+  it("TreeMap writeGaugeRecord should match Scala Map version") {
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+
+    InputRecord.writeGaugeRecord(b1, metric, baseTags, 100000L, 42.5)
+    InputRecord.writeGaugeRecord(b2, metric, treeTags, 100000L, 42.5)
+
+    firstRecordBytes(b1, Schemas.gauge) shouldEqual
+      firstRecordBytes(b2, Schemas.gauge)
+  }
+
+  it("TreeMap writePromCounterRecord should match Scala Map version") {
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+
+    InputRecord.writePromCounterRecord(b1, metric, baseTags, 100000L, 99.0)
+    InputRecord.writePromCounterRecord(b2, metric, treeTags, 100000L, 99.0)
+
+    firstRecordBytes(b1, Schemas.promCounter) shouldEqual
+      firstRecordBytes(b2, Schemas.promCounter)
+  }
+
+  it("TreeMap writeDeltaCounterRecord should match Scala Map version") {
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+
+    InputRecord.writeDeltaCounterRecord(b1, metric, baseTags, 100000L, 7.0)
+    InputRecord.writeDeltaCounterRecord(b2, metric, treeTags, 100000L, 7.0)
+
+    firstRecordBytes(b1, Schemas.deltaCounter) shouldEqual
+      firstRecordBytes(b2, Schemas.deltaCounter)
+  }
+
+  it("TreeMap writeUntypedRecord should match Scala Map version") {
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+
+    InputRecord.writeUntypedRecord(b1, metric, baseTags, 100000L, 3.14)
+    InputRecord.writeUntypedRecord(b2, metric, treeTags, 100000L, 3.14)
+
+    firstRecordBytes(b1, Schemas.untyped) shouldEqual
+      firstRecordBytes(b2, Schemas.untyped)
+  }
+
+  it("TreeMap writePromHistRecord should match Scala Map version") {
+    val buckets = Array(0.5, 1, 2.5, 5, 10, Double.PositiveInfinity)
+    val bucketKVs = buckets.zip(counts).map {
+      case (Double.PositiveInfinity, c) => "+Inf" -> c.toDouble
+      case (b, c) => b.toString -> c.toDouble
+    }.toSeq ++ sumCountKVs
+
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+
+    InputRecord.writePromHistRecord(b1, metric, baseTags, 100000L, bucketKVs)
+    InputRecord.writePromHistRecord(b2, metric, treeTags, 100000L, bucketKVs)
+
+    firstRecordBytes(b1, Schemas.promHistogram) shouldEqual
+      firstRecordBytes(b2, Schemas.promHistogram)
+  }
+
+  it("TreeMap writeDeltaHistRecord should match Scala Map version") {
+    val buckets = Array(0.5, 1, 2.5, 5, 10, Double.PositiveInfinity)
+    val bucketKVs = buckets.zip(counts).map {
+      case (Double.PositiveInfinity, c) => "+Inf" -> c.toDouble
+      case (b, c) => b.toString -> c.toDouble
+    }.toSeq ++ sumCountKVs
+
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+
+    InputRecord.writeDeltaHistRecord(b1, metric, baseTags, 100000L, bucketKVs)
+    InputRecord.writeDeltaHistRecord(b2, metric, treeTags, 100000L, bucketKVs)
+
+    firstRecordBytes(b1, Schemas.deltaHistogram) shouldEqual
+      firstRecordBytes(b2, Schemas.deltaHistogram)
+  }
+
+  it("TreeMap writeOtelCumulativeHistRecord should match Scala Map version") {
+    val buckets = Array(0.5, 1, 2.5, 5, 10, Double.PositiveInfinity)
+    val bucketKVs = buckets.zip(counts).map {
+      case (Double.PositiveInfinity, c) => "+Inf" -> c.toDouble
+      case (b, c) => b.toString -> c.toDouble
+    }.toSeq ++ sumCountMinMaxKVs
+
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+
+    InputRecord.writeOtelCumulativeHistRecord(b1, metric, baseTags, 100000L, bucketKVs)
+    InputRecord.writeOtelCumulativeHistRecord(b2, metric, treeTags, 100000L, bucketKVs)
+
+    firstRecordBytes(b1, Schemas.otelCumulativeHistogram) shouldEqual
+      firstRecordBytes(b2, Schemas.otelCumulativeHistogram)
+  }
+
+  it("TreeMap writeOtelDeltaHistRecord should match Scala Map version") {
+    val buckets = Array(0.5, 1, 2.5, 5, 10, Double.PositiveInfinity)
+    val bucketKVs = buckets.zip(counts).map {
+      case (Double.PositiveInfinity, c) => "+Inf" -> c.toDouble
+      case (b, c) => b.toString -> c.toDouble
+    }.toSeq ++ sumCountMinMaxKVs
+
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+
+    InputRecord.writeOtelDeltaHistRecord(b1, metric, baseTags, 100000L, bucketKVs)
+    InputRecord.writeOtelDeltaHistRecord(b2, metric, treeTags, 100000L, bucketKVs)
+
+    firstRecordBytes(b1, Schemas.otelDeltaHistogram) shouldEqual
+      firstRecordBytes(b2, Schemas.otelDeltaHistogram)
+  }
+
+  it("TreeMap overloads should handle many tags identically") {
+    val manyTags = baseTags ++ (0 until 15).map(i => f"label_$i%02d" -> s"value_$i").toMap
+    val manyTreeTags = {
+      val t = new java.util.TreeMap[String, String]()
+      manyTags.foreach { case (k, v) => t.put(k, v) }
+      t
+    }
+
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+
+    InputRecord.writeGaugeRecord(b1, metric, manyTags, 100000L, 1.0)
+    InputRecord.writeGaugeRecord(b2, metric, manyTreeTags, 100000L, 1.0)
+
+    firstRecordBytes(b1, Schemas.gauge) shouldEqual
+      firstRecordBytes(b2, Schemas.gauge)
+  }
+
+  it("TreeMap overloads should handle empty tags identically") {
+    val emptyTags = Map.empty[String, String]
+    val emptyTreeTags = new java.util.TreeMap[String, String]()
+
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+
+    InputRecord.writeGaugeRecord(b1, metric, emptyTags, 100000L, 1.0)
+    InputRecord.writeGaugeRecord(b2, metric, emptyTreeTags, 100000L, 1.0)
+
+    firstRecordBytes(b1, Schemas.gauge) shouldEqual
+      firstRecordBytes(b2, Schemas.gauge)
+  }
 }

--- a/jmh/src/main/scala/filodb.jmh/HistVectorBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistVectorBenchmark.scala
@@ -8,7 +8,6 @@ import org.openjdk.jmh.infra.Blackhole
 
 import filodb.memory.NativeMemoryManager
 import filodb.memory.format._
-import filodb.memory.format.vectors.BinaryHistogram
 
 @State(Scope.Thread)
 class HistVectorBenchmark {
@@ -93,54 +92,6 @@ class HistVectorBenchmark {
       val h = r2(i)
       blackhole.consume(h)
     }
-  }
-
-  // ── sum() benchmark: simulates rate(delta_hist[5m]) hot path ───────
-  // 20-bucket geometric histograms, 30 samples (5m window @ 10s interval)
-  val scheme20 = GeometricBuckets(1.0, 2.0, 20)
-  final val numSamplesInWindow = 30
-  val sumAppender20: BinaryAppendableVector[org.agrona.DirectBuffer] = {
-    val app = HistogramVector.appending(memFactory, 15000)
-    val rng = new java.util.Random(42)
-    (0 until numSamplesInWindow).foreach { _ =>
-      val raw = new Array[Long](20)
-      (0 until 20).foreach { i => raw(i) = rng.nextInt(1000).toLong }
-      (1 until 20).foreach { i => raw(i) += raw(i - 1) }
-      BinaryHistogram.writeDelta(scheme20, raw, buffer)
-      if (app.addData(buffer) != Ack) {
-        throw new RuntimeException("Failed to add 20-bucket histogram")
-      }
-    }
-    app
-  }
-
-  @Benchmark
-  @BenchmarkMode(Array(Mode.Throughput, Mode.AverageTime))
-  @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  def sumDeltaHist20Buckets(blackhole: Blackhole): Unit = {
-    val r = sumAppender20.reader.asHistReader
-    blackhole.consume(r.sum(0, numSamplesInWindow - 1))
-  }
-
-  // 127-bucket OTel exp histograms, 30 samples
-  val sumAppender127: BinaryAppendableVector[org.agrona.DirectBuffer] = {
-    val app = HistogramVector.appending(memFactory, 15000)
-    (0 until numSamplesInWindow).foreach { _ =>
-      val hist = LongHistogram(bucketScheme, counts)
-      hist.serialize(Some(buffer))
-      if (app.addData(buffer) != Ack) {
-        throw new RuntimeException("Failed to add 127-bucket histogram")
-      }
-    }
-    app
-  }
-
-  @Benchmark
-  @BenchmarkMode(Array(Mode.Throughput, Mode.AverageTime))
-  @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  def sumDeltaHist127Buckets(blackhole: Blackhole): Unit = {
-    val r = sumAppender127.reader.asHistReader
-    blackhole.consume(r.sum(0, numSamplesInWindow - 1))
   }
 
 }

--- a/jmh/src/main/scala/filodb.jmh/HistVectorBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistVectorBenchmark.scala
@@ -8,6 +8,7 @@ import org.openjdk.jmh.infra.Blackhole
 
 import filodb.memory.NativeMemoryManager
 import filodb.memory.format._
+import filodb.memory.format.vectors.BinaryHistogram
 
 @State(Scope.Thread)
 class HistVectorBenchmark {
@@ -92,6 +93,54 @@ class HistVectorBenchmark {
       val h = r2(i)
       blackhole.consume(h)
     }
+  }
+
+  // ── sum() benchmark: simulates rate(delta_hist[5m]) hot path ───────
+  // 20-bucket geometric histograms, 30 samples (5m window @ 10s interval)
+  val scheme20 = GeometricBuckets(1.0, 2.0, 20)
+  final val numSamplesInWindow = 30
+  val sumAppender20: BinaryAppendableVector[org.agrona.DirectBuffer] = {
+    val app = HistogramVector.appending(memFactory, 15000)
+    val rng = new java.util.Random(42)
+    (0 until numSamplesInWindow).foreach { _ =>
+      val raw = new Array[Long](20)
+      (0 until 20).foreach { i => raw(i) = rng.nextInt(1000).toLong }
+      (1 until 20).foreach { i => raw(i) += raw(i - 1) }
+      BinaryHistogram.writeDelta(scheme20, raw, buffer)
+      if (app.addData(buffer) != Ack) {
+        throw new RuntimeException("Failed to add 20-bucket histogram")
+      }
+    }
+    app
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput, Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  def sumDeltaHist20Buckets(blackhole: Blackhole): Unit = {
+    val r = sumAppender20.reader.asHistReader
+    blackhole.consume(r.sum(0, numSamplesInWindow - 1))
+  }
+
+  // 127-bucket OTel exp histograms, 30 samples
+  val sumAppender127: BinaryAppendableVector[org.agrona.DirectBuffer] = {
+    val app = HistogramVector.appending(memFactory, 15000)
+    (0 until numSamplesInWindow).foreach { _ =>
+      val hist = LongHistogram(bucketScheme, counts)
+      hist.serialize(Some(buffer))
+      if (app.addData(buffer) != Ack) {
+        throw new RuntimeException("Failed to add 127-bucket histogram")
+      }
+    }
+    app
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput, Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  def sumDeltaHist127Buckets(blackhole: Blackhole): Unit = {
+    val r = sumAppender127.reader.asHistReader
+    blackhole.consume(r.sum(0, numSamplesInWindow - 1))
   }
 
 }


### PR DESCRIPTION
## **Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

## **New behavior :**

This PR adds a Java-friendly ingestion path for tag maps stored as java.util.TreeMap[String, String], enabling callers to avoid Scala collection conversion while preserving the existing BinaryRecord wire format and partition hashing behavior.

### Changes:

Added RecordBuilder.encodeMapFrom(TreeMap[String,String]) plus InputRecord.write* overloads that accept java.util.TreeMap.
Added byte-for-byte compatibility tests to ensure TreeMap overloads match the existing Scala Map overloads.
Extended histogram JMH benchmarks with sum() hot-path scenarios.
