### PR TITLE
fix(query) Div by zero when the steps go before earliest retention timestamp for an instant query

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -917,9 +917,15 @@ class SingleClusterPlanner(val dataset: Dataset,
       // We calculate below number of steps/instants to drop. We drop instant if data required for that instant
       // doesnt fully fall into the retention period. Data required for that instant involves
       // going backwards from that instant up to windowMs + offsetMs milli-seconds.
-      val numStepsBeforeRetention = (earliestRetainedTimestamp - startMs + windowMs + offsetMs) / stepMs
-      val lastInstantBeforeRetention = startMs + numStepsBeforeRetention * stepMs
-      lastInstantBeforeRetention + stepMs
+      if (stepMs == 0L) {
+        // Instant query: single data point is outside retention period.
+        // Return startMs + 1 so caller sees newStartMs > endMs and returns EmptyResultExec.
+        startMs + 1
+      } else {
+        val numStepsBeforeRetention = (earliestRetainedTimestamp - startMs + windowMs + offsetMs) / stepMs
+        val lastInstantBeforeRetention = startMs + numStepsBeforeRetention * stepMs
+        lastInstantBeforeRetention + stepMs
+      }
     } else {
       startMs
     }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -2100,6 +2100,40 @@ class SingleClusterPlannerSpec extends AnyFunSpec
     res.result.isEmpty shouldEqual true
   }
 
+  it("should not throw div by zero for instant queries with window and offset outside retention") {
+    val nowSeconds = System.currentTimeMillis() / 1000
+    val planner = new SingleClusterPlanner(dataset, schemas, mapperRef,
+      earliestRetainedTimestampFn = nowSeconds * 1000 - 3.days.toMillis, queryConfig, "raw")
+
+    // Instant query with window and offset that pushes data need before retention boundary.
+    // This is the query pattern from the original bug: max_over_time(...[5m] offset 5m)
+    // For an instant query step=0, so boundToStartTimeToEarliestRetained must not divide by zero.
+    val logicalPlan = Parser.queryRangeToLogicalPlan(
+      """max_over_time(foo{job="bar"}[5m] offset 5m)""",
+      TimeStepParams(nowSeconds - 4.days.toSeconds, 0, nowSeconds - 4.days.toSeconds))
+
+    val ep = planner.materialize(logicalPlan, QueryContext())
+    // The instant is outside retention, so we should get an empty result
+    ep.isInstanceOf[EmptyResultExec] shouldEqual true
+  }
+
+  it("should not throw div by zero for instant query within retention with window and offset") {
+    val nowSeconds = System.currentTimeMillis() / 1000
+    val planner = new SingleClusterPlanner(dataset, schemas, mapperRef,
+      earliestRetainedTimestampFn = nowSeconds * 1000 - 3.days.toMillis, queryConfig, "raw")
+
+    // Instant query where the timestamp is recent enough that data window is within retention.
+    // step=0 but the guard condition in boundToStartTimeToEarliestRetained should be false,
+    // so it returns startMs as-is.
+    val logicalPlan = Parser.queryRangeToLogicalPlan(
+      """max_over_time(foo{job="bar"}[5m] offset 5m)""",
+      TimeStepParams(nowSeconds, 0, nowSeconds))
+
+    val ep = planner.materialize(logicalPlan, QueryContext())
+    // Should materialize successfully, not throw or return empty
+    ep.isInstanceOf[EmptyResultExec] shouldEqual false
+  }
+
   it("should materialize instant queries with lookback == retention correctly") {
     val nowSeconds = System.currentTimeMillis() / 1000
     val planner = new SingleClusterPlanner(dataset, schemas, mapperRef,

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -2105,15 +2105,18 @@ class SingleClusterPlannerSpec extends AnyFunSpec
     val planner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = nowSeconds * 1000 - 3.days.toMillis, queryConfig, "raw")
 
-    // Instant query with window and offset that pushes data need before retention boundary.
-    // This is the query pattern from the original bug: max_over_time(...[5m] offset 5m)
+    // Place the instant timestamp just inside the retention boundary (retention - 2 min).
+    // The 5m window + 5m offset pushes the data need 10 minutes before startMs, which crosses
+    // the retention boundary. This matches the real-world bug: startMs is within retention
+    // but startMs - windowMs - offsetMs is before earliestRetainedTimestamp.
     // For an instant query step=0, so boundToStartTimeToEarliestRetained must not divide by zero.
+    val queryTimestamp = nowSeconds - 3.days.toSeconds + 2.minutes.toSeconds
     val logicalPlan = Parser.queryRangeToLogicalPlan(
       """max_over_time(foo{job="bar"}[5m] offset 5m)""",
-      TimeStepParams(nowSeconds - 4.days.toSeconds, 0, nowSeconds - 4.days.toSeconds))
+      TimeStepParams(queryTimestamp, 0, queryTimestamp))
 
     val ep = planner.materialize(logicalPlan, QueryContext())
-    // The instant is outside retention, so we should get an empty result
+    // The single instant's data window is outside retention, so we should get an empty result
     ep.isInstanceOf[EmptyResultExec] shouldEqual true
   }
 


### PR DESCRIPTION

**Pull Request checklist**
                                                                                                                                                                                                           
- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
                                                                                                                                                                                                           
**Current behavior :** :                                        

  When an instant query (``step=0``) with a window and offset (e.g. ``max_over_time(metric[5m] offset 5m``)) has its data window extending before the earliest retained timestamp,                                 
  ``boundToStartTimeToEarliestRetained`` in ``SingleClusterPlanner`` divides by ``stepMs`` on line 920 to calculate how many steps to skip forward. Since ``stepMs=0`` for instant queries, this results in a
  ``java.lang.ArithmeticException: / by zero``, returning a 500 Internal Server Error.                                                                                                                         
                                                            
  The bug is only triggered when all of the following are true:                                                                                                                                            
  - The query is an instant query (``start == end``,`` step == 0``)
  - The query uses a range function with a window and/or offset (e.g. ``max_over_time(...[5m] offset 5m``)) 
  - ``startMs - windowMs - offsetMs < earliestRetainedTimestamp`` (the data window extends before the retention boundary)
                                                                                                                                                                                                           
**New behavior :** :                                                                                                                                                                                           
                                                                                                                                                                                                           
  When ``stepMs == 0`` (instant query) and the data window falls before the retention boundary, ``boundToStartTimeToEarliestRetained`` now returns ``startMs + 1`` instead of performing the division. Since ``startMs ==
   endMs`` for instant queries, the caller ``updateStartTime`` sees ``newStartMs > endMs`` and returns ``None``, which materialize converts to an ``EmptyResultExec``. This is the correct behavior — the single instant's
  data requirement falls outside the retention period, so an empty result should be returned.                                                                                                              
                                                            
  Other information:

  The fix is in ``SingleClusterPlanner.boundToStartTimeToEarliestRetained``. A guard for ``stepMs == 0L`` is added inside the retention check block:                                                               
  ``` 
  if (stepMs == 0L) {                                                                                                                                                                                      
    startMs + 1                                             
  } else {
    val numStepsBeforeRetention = (earliestRetainedTimestamp - startMs + windowMs + offsetMs) / stepMs
    val lastInstantBeforeRetention = startMs + numStepsBeforeRetention * stepMs                                                                                                                            
    lastInstantBeforeRetention + stepMs                                                                                                                                                                    
  }                                                                                                                                                                                                        
```
                                                                                                                                                                                                           
  Two test cases are added to ``SingleClusterPlannerSpec``:                                                                                                                                                    
  - Instant query with window and offset outside retention period — verifies ``EmptyResultExec`` is returned instead of throwing
  - Instant query with window and offset within retention period — verifies normal materialization is unaffected            
