### PR TITLE
feat(query): add histogram_max_quantile_even instant function

### DIFF
--- a/coordinator/src/main/scala/filodb/coordinator/ProtoConverters.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/ProtoConverters.scala
@@ -913,6 +913,7 @@ object ProtoConverters {
         case filodb.query.InstantFunctionId.Floor => GrpcMultiPartitionQueryService.InstantFunctionId.FLOOR
         case filodb.query.InstantFunctionId.HistogramQuantile => GrpcMultiPartitionQueryService.InstantFunctionId.HISTOGRAM_QUANTILE
         case filodb.query.InstantFunctionId.HistogramMaxQuantile => GrpcMultiPartitionQueryService.InstantFunctionId.HISTOGRAM_MAX_QUANTILE
+        case filodb.query.InstantFunctionId.HistogramMaxQuantileEven => GrpcMultiPartitionQueryService.InstantFunctionId.HISTOGRAM_MAX_QUANTILE_EVEN
         case filodb.query.InstantFunctionId.HistogramBucket => GrpcMultiPartitionQueryService.InstantFunctionId.HISTOGRAM_BUCKET
         case filodb.query.InstantFunctionId.HistogramFraction => GrpcMultiPartitionQueryService.InstantFunctionId.HISTOGRAM_FRACTION
         case filodb.query.InstantFunctionId.Ln => GrpcMultiPartitionQueryService.InstantFunctionId.LN
@@ -945,6 +946,7 @@ object ProtoConverters {
         case GrpcMultiPartitionQueryService.InstantFunctionId.FLOOR => filodb.query.InstantFunctionId.Floor
         case GrpcMultiPartitionQueryService.InstantFunctionId.HISTOGRAM_QUANTILE => filodb.query.InstantFunctionId.HistogramQuantile
         case GrpcMultiPartitionQueryService.InstantFunctionId.HISTOGRAM_MAX_QUANTILE => filodb.query.InstantFunctionId.HistogramMaxQuantile
+        case GrpcMultiPartitionQueryService.InstantFunctionId.HISTOGRAM_MAX_QUANTILE_EVEN => filodb.query.InstantFunctionId.HistogramMaxQuantileEven
         case GrpcMultiPartitionQueryService.InstantFunctionId.HISTOGRAM_BUCKET => filodb.query.InstantFunctionId.HistogramBucket
         case GrpcMultiPartitionQueryService.InstantFunctionId.HISTOGRAM_FRACTION => filodb.query.InstantFunctionId.HistogramFraction
         case GrpcMultiPartitionQueryService.InstantFunctionId.LN => filodb.query.InstantFunctionId.Ln

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -2509,6 +2509,7 @@ class SingleClusterPlannerSpec extends AnyFunSpec
       ("""floor(metric{job="app"})""", InstantFunctionId.Floor),
       ("""histogram_quantile(0.9, metric{job="app"})""", InstantFunctionId.HistogramQuantile),
       ("""histogram_max_quantile(0.9, metric{job="app"})""", InstantFunctionId.HistogramMaxQuantile),
+      ("""histogram_max_quantile_even(0.9, 1, metric{job="app"})""", InstantFunctionId.HistogramMaxQuantileEven),
       ("""histogram_bucket(0.1, metric{job="app"})""", InstantFunctionId.HistogramBucket),
       ("""ln(metric{job="app"})""", InstantFunctionId.Ln),
       ("""log10(metric{job="app"})""", InstantFunctionId.Log10),

--- a/core/src/main/scala/filodb.memory/format/vectors/Histogram.scala
+++ b/core/src/main/scala/filodb.memory/format/vectors/Histogram.scala
@@ -64,7 +64,8 @@ trait Histogram extends Ordered[Histogram] {
    */
   def quantile(q: Double,
                min: Double = 0, // negative observations not supported yet
-               max: Double = Double.PositiveInfinity): Double = {
+               max: Double = Double.PositiveInfinity,
+               evenDistribution: Boolean = false): Double = {
     val result = if (q < 0) Double.NegativeInfinity
     else if (q > 1) Double.PositiveInfinity
     else if (numBuckets < 2 || topBucketValue <= 0) Double.NaN
@@ -92,7 +93,7 @@ trait Histogram extends Ordered[Histogram] {
         // interpolate quantile within boundaries of "bucket"
         val count = if (bucket == 0) bucketValue(bucket) else bucketValue(bucket) - bucketValue(bucket-1)
         rank -= (if (bucket == 0) 0 else bucketValue(bucket-1))
-        val fraction = rank/count
+        val fraction = if (evenDistribution) rank / (count + 1) else rank / count
         if (!hasExponentialBuckets || bucketStart == 0) {
           bucketStart + (bucketEnd-bucketStart) * fraction
         } else {

--- a/grpc/src/main/protobuf/query_service.proto
+++ b/grpc/src/main/protobuf/query_service.proto
@@ -608,6 +608,7 @@ enum InstantFunctionId {
   YEAR                    = 21;
   OR_VECTOR_DOUBLE        = 22;
   HISTOGRAM_FRACTION      = 23;
+  HISTOGRAM_MAX_QUANTILE_EVEN = 24;
 }
 
 enum ScalarFunctionId {

--- a/query/src/main/scala/filodb/query/PlanEnums.scala
+++ b/query/src/main/scala/filodb/query/PlanEnums.scala
@@ -17,6 +17,7 @@ object InstantFunctionId extends Enum[InstantFunctionId] {
   case object HistogramQuantile extends InstantFunctionId("histogram_quantile")
   case object HistogramFraction extends InstantFunctionId("histogram_fraction")
   case object HistogramMaxQuantile extends InstantFunctionId("histogram_max_quantile")
+  case object HistogramMaxQuantileEven extends InstantFunctionId("histogram_max_quantile_even")
   case object HistogramBucket extends InstantFunctionId("histogram_bucket")
   case object Ln extends InstantFunctionId("ln")
   case object Log10 extends InstantFunctionId("log10")

--- a/query/src/main/scala/filodb/query/exec/rangefn/InstantFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/InstantFunction.scala
@@ -113,6 +113,7 @@ object InstantFunction {
     case HistogramQuantile =>
       if (sourceSchema.isHistMaxMin) HistogramQuantileWithMaxMinImpl() else HistogramQuantileImpl()
     case HistogramMaxQuantile => HistogramMaxQuantileImpl()
+    case HistogramMaxQuantileEven => HistogramMaxQuantileEvenImpl()
     case HistogramBucket => HistogramBucketImpl()
     case HistogramFraction =>
       if (sourceSchema.isHistMaxMin) HistogramFractionWithMaxMinImpl() else HistogramFractionImpl()
@@ -409,6 +410,20 @@ final case class HistogramMaxQuantileImpl() extends HMaxMinToDoubleIFunction {
   final def apply(hist: Histogram, max: Double, min: Double = Double.NaN, scalarParams: Seq[Double]): Double = {
     require(scalarParams.length == 1, "Quantile (between 0 and 1) required for histogram quantile")
     hist.quantile(scalarParams(0), 0, max)
+  }
+}
+
+/**
+ * Histogram max quantile with even distribution mode for Histogram column + extra max (Double) column.
+ */
+final case class HistogramMaxQuantileEvenImpl() extends HMaxMinToDoubleIFunction {
+  /**
+    * @param scalarParams - two values: quantile (0 to 1) and mode (0=linear, 1=even distribution).
+    */
+  final def apply(hist: Histogram, max: Double, min: Double = Double.NaN, scalarParams: Seq[Double]): Double = {
+    require(scalarParams.length == 2, "Quantile (between 0 and 1) and mode (0=linear, 1=even) required")
+    val evenDistribution = scalarParams(1) == 1.0
+    hist.quantile(scalarParams(0), 0, max, evenDistribution)
   }
 }
 

--- a/query/src/test/scala/filodb/query/exec/rangefn/InstantFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/InstantFunctionSpec.scala
@@ -344,6 +344,36 @@ class InstantFunctionSpec extends RawDataWindowingSpec with ScalaFutures {
     outSchema.columns.map(_.colType) shouldEqual resultSchema.columns.map(_.colType)
   }
 
+  it("should compute histogram_max_quantile_even with mode=0 (linear) same as histogram_max_quantile") {
+    val (data, histRV) = MMD.histMaxMinRV(100000L, numSamples = 7)
+    val expected = data.map { row =>
+      val _hist = row(3).asInstanceOf[bv.LongHistogram]
+      val _max = row(5).asInstanceOf[Double]
+      _hist.quantile(0.9, 0, _max, evenDistribution = false)
+    }
+    applyFunctionAndAssertResult(Array(histRV), Array(expected.toIterator),
+                                 InstantFunctionId.HistogramMaxQuantileEven, Seq(0.9, 0.0), histMaxMinSchema)
+  }
+
+  it("should compute histogram_max_quantile_even with mode=1 (even distribution)") {
+    val (data, histRV) = MMD.histMaxMinRV(100000L, numSamples = 7)
+    val expected = data.map { row =>
+      val _hist = row(3).asInstanceOf[bv.LongHistogram]
+      val _max = row(5).asInstanceOf[Double]
+      _hist.quantile(0.9, 0, _max, evenDistribution = true)
+    }
+    applyFunctionAndAssertResult(Array(histRV), Array(expected.toIterator),
+                                 InstantFunctionId.HistogramMaxQuantileEven, Seq(0.9, 1.0), histMaxMinSchema)
+  }
+
+  it("should return proper schema after applying histogram_max_quantile_even") {
+    val instantVectorFnMapper = exec.InstantVectorFunctionMapper(InstantFunctionId.HistogramMaxQuantileEven,
+                                                                 Seq(StaticFuncArgs(0.99, rangeParams),
+                                                                     StaticFuncArgs(1.0, rangeParams)))
+    val outSchema = instantVectorFnMapper.schema(histMaxMinSchema)
+    outSchema.columns.map(_.colType) shouldEqual resultSchema.columns.map(_.colType)
+  }
+
   it("should compute histogram_bucket on Histogram RV") {
     val (data, histRV) = histogramRV(numSamples = 10, infBucket = true)
     val expected = Seq(1.0, 2.0, 3.0, 4.0, 4.0, 4.0, 4.0, 4.0)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Add a new PromQL instant function `histogram_max_quantile_even` that extends `histogram_max_quantile` with an interpolation mode parameter. When mode=0, uses standard linear interpolation (fraction = rank/count). When mode=1, uses even distribution (fraction = rank/(count+1)) which ensures the quantile value is always strictly within bucket bounds.

Changes:
- Histogram.scala: add `evenDistribution` parameter to `quantile()` method
- PlanEnums.scala: add `HistogramMaxQuantileEven` enum entry
- InstantFunction.scala: add `HistogramMaxQuantileEvenImpl` class
- query_service.proto: add `HISTOGRAM_MAX_QUANTILE_EVEN = 24` enum value
- ProtoConverters.scala: add bidirectional proto mappings
- InstantFunctionSpec.scala: tests for mode=0, mode=1, and schema output
- SingleClusterPlannerSpec.scala: add query parsing test