### PR TITLE
fix(query) java.util.NoSuchElementException: next on empty iterator

### DIFF
--- a/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
+++ b/query/src/main/scala/filodb/query/exec/AggrOverRangeVectors.scala
@@ -297,8 +297,10 @@ object RangeVectorAggregator extends StrictLogging {
           acc.resetToZero()
           queryContext.checkQueryTimeout(this.getClass.getName)
           itsAndKeys.foreach { case (rowIter, rvk) =>
-            val mapped = if (skipMapPhase) rowIter.next() else rowAgg.map(rvk, rowIter.next(), mapInto)
-            acc = if (skipMapPhase) rowAgg.reduceAggregate(acc, mapped) else rowAgg.reduceMappedRow(acc, mapped)
+            if (rowIter.hasNext) {
+              val mapped = if (skipMapPhase) rowIter.next() else rowAgg.map(rvk, rowIter.next(), mapInto)
+              acc = if (skipMapPhase) rowAgg.reduceAggregate(acc, mapped) else rowAgg.reduceMappedRow(acc, mapped)
+            }
           }
           acc
         }
@@ -328,12 +330,14 @@ object RangeVectorAggregator extends StrictLogging {
     // NOTE: ChunkedWindowIterator automatically releases locks after last window.  So it should all just work.  :)
     val aggObs = if (skipMapPhase) {
       source.foldLeft(accs) { case (_, rv) =>
-        count += 1
         val rowIter = rv.rows
         if (period.isEmpty) period = rv.outputRange
         try {
-          cforRange { 0 until outputLen } { i =>
-            accs(i) = rowAgg.reduceAggregate(accs(i), rowIter.next())
+          if (rowIter.hasNext) {
+            count += 1
+            cforRange { 0 until outputLen } { i =>
+              accs(i) = rowAgg.reduceAggregate(accs(i), rowIter.next())
+            }
           }
         } finally {
           rowIter.close()
@@ -343,13 +347,15 @@ object RangeVectorAggregator extends StrictLogging {
     } else {
       val mapIntos = Array.fill(outputLen)(rowAgg.newRowToMapInto)
       source.foldLeft(accs) { case (_, rv) =>
-        count += 1
         val rowIter = rv.rows
         if (period.isEmpty) period = rv.outputRange
         try {
-          cforRange { 0 until outputLen } { i =>
-            val mapped = rowAgg.map(rv.key, rowIter.next(), mapIntos(i))
-            accs(i) = rowAgg.reduceMappedRow(accs(i), mapped)
+          if (rowIter.hasNext) {
+            count += 1
+            cforRange { 0 until outputLen } { i =>
+              val mapped = rowAgg.map(rv.key, rowIter.next(), mapIntos(i))
+              accs(i) = rowAgg.reduceMappedRow(accs(i), mapped)
+            }
           }
         } finally {
           rowIter.close()

--- a/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/AggrOverRangeVectorsSpec.scala
@@ -1043,6 +1043,42 @@ class AggrOverRangeVectorsSpec extends RawDataWindowingSpec with ScalaFutures {
     resultRows.foreach { case (_, q) => q.isNaN shouldEqual false }
   }
 
+  it("should handle empty RangeVectors in fastReduce without NoSuchElementException") {
+    val emptyRv = toRv(Seq.empty)
+
+    val agg = RowAggregator(AggregationOperator.Sum, Nil, tvSchema)
+    val resultObs = RangeVectorAggregator.fastReduce(agg, skipMapPhase = false, Observable.fromIterable(Seq(emptyRv)), outputLen = 1)
+
+    val result = resultObs.toListL.runToFuture.futureValue
+    result.size shouldEqual 0
+  }
+
+  it("should handle empty RangeVectors in fastReduce skipMapPhase without NoSuchElementException") {
+    val emptyRv = toRv(Seq.empty)
+
+    val agg = RowAggregator(AggregationOperator.Sum, Nil, tvSchema)
+    val resultObs = RangeVectorAggregator.fastReduce(agg, skipMapPhase = true, Observable.fromIterable(Seq(emptyRv)), outputLen = 1)
+
+    val result = resultObs.toListL.runToFuture.futureValue
+    result.size shouldEqual 0
+  }
+
+  it("should handle mismatched row counts in mapReduceInternal without NoSuchElementException") {
+    val samples: Array[RangeVector] = Array(
+      toRv(Seq((1000L, 1.0)), noKey),
+      toRv(Seq.empty, noKey)
+    )
+
+    val agg = RowAggregator(AggregationOperator.Sum, Nil, tvSchema)
+    val resultObs = RangeVectorAggregator.mapReduce(
+      agg, skipMapPhase = false, Observable.fromIterable(samples), noGrouping, queryContext = qc, QueryWarnings()
+    )
+
+    val result = resultObs.toListL.runToFuture.futureValue
+    result.size shouldEqual 1
+    compareIter(result(0).rows().map(_.getDouble(1)), Seq(1.0d).iterator)
+  }
+
   @tailrec
   final private def compareIter2(it1: Iterator[Set[Double]], it2: Iterator[Set[Double]]) : Unit = {
     (it1.hasNext, it2.hasNext) match{

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -137,8 +137,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
     val samplesRhs2 = scala.util.Random.shuffle(sampleNodeRole.toList) // they may come out of order
 
     val execPlan = BinaryJoinExec(QueryContext(), dummyDispatcher,
-      Array(dummyPlan), // cannot be empty as some compose's rely on the schema
-      new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
+      Seq(dummyPlan), // cannot be empty as some compose's rely on the schema
+      Seq(null: ExecPlan), // empty since we test compose, not execute or doExecute
       BinaryOperator.MUL,
       Cardinality.ManyToOne,
       Some(Seq("instance")), Nil, Seq("role"), "__name__", None)
@@ -176,8 +176,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
     val samplesRhs2 = scala.util.Random.shuffle(sampleNodeRole.toList) // they may come out of order
 
     val execPlan = BinaryJoinExec(QueryContext(), dummyDispatcher,
-      Array(dummyPlan),
-      new Array[ExecPlan](1),
+      Seq(dummyPlan),
+      Seq(null: ExecPlan),
       BinaryOperator.MUL,
       Cardinality.ManyToOne,
       None, Seq("role", "mode"), Seq("role"), "__name__", None)
@@ -221,8 +221,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
     val samplesRhs = resultObs4.toListL.runToFuture.futureValue
 
     val execPlan = BinaryJoinExec(QueryContext(), dummyDispatcher,
-      Array(dummyPlan),
-      new Array[ExecPlan](1),
+      Seq(dummyPlan),
+      Seq(null: ExecPlan),
       BinaryOperator.DIV,
       Cardinality.ManyToOne,
       Some(Seq("instance")), Nil, Nil, "__name__", None)
@@ -271,8 +271,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
     val samplesRhs2 = scala.util.Random.shuffle(sampleNodeVar.toList) // they may come out of order
 
     val execPlan = BinaryJoinExec(QueryContext(), dummyDispatcher,
-      Array(dummyPlan),
-      new Array[ExecPlan](1),
+      Seq(dummyPlan),
+      Seq(null: ExecPlan),
       BinaryOperator.MUL,
       Cardinality.OneToMany,
       None, Seq("role"),
@@ -309,8 +309,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
     val samplesRhs = resultObs4.toListL.runToFuture.futureValue
 
     val execPlan = BinaryJoinExec(QueryContext(), dummyDispatcher,
-      Array(dummyPlan),
-      new Array[ExecPlan](1),
+      Seq(dummyPlan),
+      Seq(null: ExecPlan),
       BinaryOperator.DIV,
       Cardinality.ManyToOne, None,
       Seq("mode"), Seq("dummy"), "__name__", None)
@@ -401,8 +401,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
     )
 
     val execPlan = BinaryJoinExec(QueryContext(), dummyDispatcher,
-      Array(dummyPlan), // cannot be empty as some compose's rely on the schema
-      new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
+      Seq(dummyPlan), // cannot be empty as some compose's rely on the schema
+      Seq(null: ExecPlan), // empty since we test compose, not execute or doExecute
       BinaryOperator.GTR,
       Cardinality.ManyToOne,
       Some(Seq("instance")), Nil, Seq("role"), "metric", None)
@@ -440,8 +440,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
     val samplesRhs2 = scala.util.Random.shuffle(sampleNodeRole.toList) // they may come out of order
 
     val execPlan = BinaryJoinExec(queryContext, dummyDispatcher,
-      Array(dummyPlan), // cannot be empty as some compose's rely on the schema
-      new Array[ExecPlan](1), // empty since we test compose, not execute or doExecute
+      Seq(dummyPlan), // cannot be empty as some compose's rely on the schema
+      Seq(null: ExecPlan), // empty since we test compose, not execute or doExecute
       BinaryOperator.MUL,
       Cardinality.ManyToOne,
       Some(Seq("instance")), Nil, Seq("role"), "__name__", None)
@@ -471,8 +471,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
     val samplesRhs2 = scala.util.Random.shuffle(sampleNodeRole.toList) // they may come out of order
 
     val execPlan = BinaryJoinExec(queryContext, dummyDispatcher,
-      Array(dummyPlan),
-      new Array[ExecPlan](1),
+      Seq(dummyPlan),
+      Seq(null: ExecPlan),
       BinaryOperator.MUL,
       Cardinality.ManyToOne,
       None, Seq("role", "mode"), Seq("role"), "__name__", None)
@@ -508,8 +508,8 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
     val samplesRhs = resultObs4.toListL.runToFuture.futureValue
 
     val execPlan = BinaryJoinExec(queryContext, dummyDispatcher,
-      Array(dummyPlan),
-      new Array[ExecPlan](1),
+      Seq(dummyPlan),
+      Seq(null: ExecPlan),
       BinaryOperator.DIV,
       Cardinality.ManyToOne,
       Some(Seq("instance")), Nil, Nil, "__name__", None)


### PR DESCRIPTION
***Pull Request checklist***
                                                                                                                                                                                                                                                                                                                   
  - [x] The commit(s) message(s) follows the contribution CONTRIBUTING.md ?
  - [x] Tests for the changes have been added (for bug fixes / features) ?                                                                                                                                                                                                                                             
  - [ ] Docs have been added / updated (for bug fixes / features) ?
                                                                                                                                                                                                                                                                                                                   
  **Current behavior :**

  When aggregating ``RangeVectors`` where some partitions produce zero rows (e.g., a partition exists in memory but has no data points in the queried time range), the query engine throws ``java.util.NoSuchElementException: next on empty iterator``. This crashes the query with a 500 Internal Server Error.          
   
  The root cause is three unguarded ``.next()`` calls in ``AggrOverRangeVectors.scala``
                                                                  
  1. ``mapReduceInternal: hasNext()`` returns true if any iterator in the aggregation group has data, but ``next()`` calls ``.next()`` on all iterators — including empty ones.                                                                                                                                                
  2. ``fastReduce`` (``skipMapPhase``): Iterates ``cforRange { 0 until outputLen } calling .next()`` without checking if the iterator has any rows.
  3. ``fastReduce`` (non-``skipMapPhase``): Same pattern as above.                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                   
  **New behavior :**
                                                                                                                                                                                                                                                                                                                   
  All three call sites now check ``hasNext`` before calling ``.next()``
   
  - ``mapReduceInternal``: Each individual iterator is guarded — empty iterators are skipped and don't contribute to the accumulator, which stays at its ``NaN``-initialized zero. This matches Prometheus semantics where all aggregators (Sum, Avg, Count, Min, Max, etc.) initialize to ``NaN`` and skip ``NaN`` inputs during  
  reduction.                                                      
  - ``fastReduce`` (both paths): Empty ``RangeVectors`` are skipped entirely. The count is only incremented for ``RangeVectors`` that actually have data, so if all inputs are empty, the result is ``Observable.empty`` rather than NaN-filled output.                                                                            
                                                                                                                                                                                                                                                                                                                   
  Three new tests verify the fix:                                                                                                                                                                                                                                                                                  
  - ``fastReduce`` with empty RV (non-``skipMapPhase``) → returns empty result                                                                                                                                                                                                                                             
  - ``fastReduce`` with empty RV (``skipMapPhase``) → returns empty result                                                                                                                                                                                                                                                 
  - ``mapReduceInternal`` with mismatched row counts → aggregates only the non-empty RV
                                                                                                                                                                                                                                                                                                                   
  Additionally, fixed Scala 2.13 deprecation warnings in ``BinaryJoinGroupingSpec.scala`` (``Array`` → ``Seq`` to avoid implicit ``copyArrayToImmutableIndexedSeq`` conversion).
                                                                                                                                                                                                                                                                                                                   
  Other information:                                              
                                                                                                                                                                                                                                                                                                                   
  This is a recurring pattern in the codebase — similar fixes were previously applied to ``TopBottomKRowAggregator`` (commit 64c49a3b5) and ``ScalarFunctionMapper`` (commit b31e93612).    

