### PR TITLE
fix(query) Non numeric value or +Inf in le filter throws NumberFormatException and HTTP 500 to user

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
@@ -152,6 +152,12 @@ trait  DefaultPlanner {
     } else series
   }
 
+  private[queryplanner] def parsePromLeValue(le: String): Option[Double] = le match {
+    case "+Inf" | "Inf" => Some(Double.PositiveInfinity)
+    case "-Inf"         => Some(Double.NegativeInfinity)
+    case other          => scala.util.Try(other.toDouble).toOption
+  }
+
   private[queryplanner] def removeBucket(lp: Either[PeriodicSeries, PeriodicSeriesWithWindowing]):
               (Option[String], Option[String], Either[PeriodicSeries, PeriodicSeriesWithWindowing])= {
     val rawSeries = lp match {
@@ -164,7 +170,8 @@ trait  DefaultPlanner {
 
         val nameFilter = rawSeriesLp.filters.find(_.column.equals(PromMetricLabel)).
           map(_.filter.valuesStrings.head.toString)
-        val leFilter = rawSeriesLp.filters.find(_.column == "le").map(_.filter.valuesStrings.head.toString)
+        val leEqualsFilter = rawSeriesLp.filters.find(f => f.column == "le" && f.filter.isInstanceOf[Equals])
+        val leFilter = leEqualsFilter.map(_.filter.valuesStrings.head.toString)
 
         if (nameFilter.isEmpty) (nameFilter, leFilter, lp)
         else {
@@ -172,9 +179,9 @@ trait  DefaultPlanner {
           if (!nameFilter.get.endsWith("_bucket")) {
             (nameFilter, leFilter, lp)
           }
-          else {
+          else if (leFilter.isDefined && parsePromLeValue(leFilter.get).isDefined) {
             val filtersWithoutBucket = rawSeriesLp.filters.filterNot(_.column.equals(PromMetricLabel)).
-              filterNot(_.column == "le") :+ ColumnFilter(PromMetricLabel,
+              filterNot(f => f.column == "le" && f.filter.isInstanceOf[Equals]) :+ ColumnFilter(PromMetricLabel,
               Equals(PlannerUtil.replaceLastBucketOccurenceStringFromMetricName(nameFilter.get)))
             val newLp =
               if (lp.isLeft)
@@ -182,6 +189,9 @@ trait  DefaultPlanner {
               else
                 Right(lp.toOption.get.copy(series = rawSeriesLp.copy(filters = filtersWithoutBucket)))
             (nameFilter, leFilter, newLp)
+          }
+          else {
+            (nameFilter, None, lp)
           }
         }
       case _ => (None, None, lp)
@@ -213,10 +223,12 @@ trait  DefaultPlanner {
       lp.offsetMs, rawSource = rawSource)))
 
     if (nameFilter.isDefined && nameFilter.head.endsWith("_bucket") && leFilter.isDefined) {
-      val paramsExec = StaticFuncArgs(leFilter.head.toDouble, RangeParams(lp.startMs / 1000, lp.stepMs / 1000,
-        lp.endMs / 1000))
-      rawSeries.plans.foreach(_.addRangeVectorTransformer(InstantVectorFunctionMapper(HistogramBucket,
-        Seq(paramsExec))))
+      parsePromLeValue(leFilter.head).foreach { doubleVal =>
+        val paramsExec = StaticFuncArgs(doubleVal, RangeParams(lp.startMs / 1000, lp.stepMs / 1000,
+          lp.endMs / 1000))
+        rawSeries.plans.foreach(_.addRangeVectorTransformer(InstantVectorFunctionMapper(HistogramBucket,
+          Seq(paramsExec))))
+      }
     }
     rawSeries
   }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -834,12 +834,6 @@ class SingleClusterPlanner(val dataset: Dataset,
   }
   // scalastyle:on method.length
 
-  private def parsePromLeValue(le: String): Option[Double] = le match {
-    case "+Inf" | "Inf" => Some(Double.PositiveInfinity)
-    case "-Inf"         => Some(Double.NegativeInfinity)
-    case other          => scala.util.Try(other.toDouble).toOption
-  }
-
   override private[queryplanner] def removeBucket(lp: Either[PeriodicSeries, PeriodicSeriesWithWindowing]) = {
     val rawSeries = lp match {
       case Right(value) => value.series
@@ -860,7 +854,7 @@ class SingleClusterPlanner(val dataset: Dataset,
           if (!nameFilter.get.endsWith("_bucket")) {
             (nameFilter, leFilter, lp)
           }
-          else {
+          else if (leFilter.isDefined && parsePromLeValue(leFilter.get).isDefined) {
             val filtersWithoutBucket = rawSeriesLp.filters.filterNot(_.column.equals(PromMetricLabel)).
               filterNot(f => f.column == "le" && f.filter.isInstanceOf[Equals]) :+ ColumnFilter(PromMetricLabel,
               Equals(PlannerUtil.replaceLastBucketOccurenceStringFromMetricName(nameFilter.get)))
@@ -870,6 +864,9 @@ class SingleClusterPlanner(val dataset: Dataset,
               else
                 Right(lp.toOption.get.copy(series = rawSeriesLp.copy(filters = filtersWithoutBucket)))
             (nameFilter, leFilter, newLp)
+          }
+          else {
+            (nameFilter, None, lp)
           }
         }
       case _ => (None, None, lp)

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -803,16 +803,12 @@ class SingleClusterPlanner(val dataset: Dataset,
     // Add the le filter transformer to select the required bucket
     (nameFilter, leFilter) match {
       case (Some(filter), Some (le)) if filter.endsWith("_bucket") => {
-        // if le filter matches for Inf or +Inf, set the double value to PositiveInfinity
-        val doubleVal = le match {
-          case "+Inf" => Double.PositiveInfinity
-          case "Inf" => Double.PositiveInfinity
-          case _ => le.toDouble
+        parsePromLeValue(le).foreach { doubleVal =>
+          val paramsExec = StaticFuncArgs(doubleVal, RangeParams(realScanStartMs / 1000,
+            realScanStepMs / 1000, realScanEndMs / 1000))
+          series.plans.foreach(_.addRangeVectorTransformer(InstantVectorFunctionMapper(HistogramBucket,
+            Seq(paramsExec))))
         }
-        val paramsExec = StaticFuncArgs(doubleVal, RangeParams(realScanStartMs / 1000,
-          realScanStepMs / 1000, realScanEndMs / 1000))
-        series.plans.foreach(_.addRangeVectorTransformer(InstantVectorFunctionMapper(HistogramBucket,
-          Seq(paramsExec))))
       }
       case _ => //NOP
     }
@@ -838,6 +834,12 @@ class SingleClusterPlanner(val dataset: Dataset,
   }
   // scalastyle:on method.length
 
+  private def parsePromLeValue(le: String): Option[Double] = le match {
+    case "+Inf" | "Inf" => Some(Double.PositiveInfinity)
+    case "-Inf"         => Some(Double.NegativeInfinity)
+    case other          => scala.util.Try(other.toDouble).toOption
+  }
+
   override private[queryplanner] def removeBucket(lp: Either[PeriodicSeries, PeriodicSeriesWithWindowing]) = {
     val rawSeries = lp match {
       case Right(value) => value.series
@@ -849,7 +851,8 @@ class SingleClusterPlanner(val dataset: Dataset,
 
         val nameFilter = rawSeriesLp.filters.find(_.column.equals(PromMetricLabel)).
           map(_.filter.valuesStrings.head.toString)
-        val leFilter = rawSeriesLp.filters.find(_.column == "le").map(_.filter.valuesStrings.head.toString)
+        val leEqualsFilter = rawSeriesLp.filters.find(f => f.column == "le" && f.filter.isInstanceOf[Equals])
+        val leFilter = leEqualsFilter.map(_.filter.valuesStrings.head.toString)
 
         if (nameFilter.isEmpty) (nameFilter, leFilter, lp)
         else {
@@ -859,7 +862,7 @@ class SingleClusterPlanner(val dataset: Dataset,
           }
           else {
             val filtersWithoutBucket = rawSeriesLp.filters.filterNot(_.column.equals(PromMetricLabel)).
-              filterNot(_.column == "le") :+ ColumnFilter(PromMetricLabel,
+              filterNot(f => f.column == "le" && f.filter.isInstanceOf[Equals]) :+ ColumnFilter(PromMetricLabel,
               Equals(PlannerUtil.replaceLastBucketOccurenceStringFromMetricName(nameFilter.get)))
             val newLp =
               if (lp.isLeft)
@@ -895,10 +898,12 @@ class SingleClusterPlanner(val dataset: Dataset,
       realScanEndMs, None, None, stepMultipleNotationUsed = false, Nil, lp.offsetMs)))
 
     if (nameFilter.isDefined && nameFilter.head.endsWith("_bucket") && leFilter.isDefined) {
-      val paramsExec = StaticFuncArgs(leFilter.head.toDouble, RangeParams(realScanStartMs/1000, realScanStepMs/1000,
-        realScanEndMs/1000))
-      rawSeries.plans.foreach(_.addRangeVectorTransformer(InstantVectorFunctionMapper(HistogramBucket,
-        Seq(paramsExec))))
+      parsePromLeValue(leFilter.head).foreach { doubleVal =>
+        val paramsExec = StaticFuncArgs(doubleVal, RangeParams(realScanStartMs/1000, realScanStepMs/1000,
+          realScanEndMs/1000))
+        rawSeries.plans.foreach(_.addRangeVectorTransformer(InstantVectorFunctionMapper(HistogramBucket,
+          Seq(paramsExec))))
+      }
     }
     // repeat the same value for each step if '@' is specified
     if (lp.atMs.nonEmpty) {

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -834,44 +834,6 @@ class SingleClusterPlanner(val dataset: Dataset,
   }
   // scalastyle:on method.length
 
-  override private[queryplanner] def removeBucket(lp: Either[PeriodicSeries, PeriodicSeriesWithWindowing]) = {
-    val rawSeries = lp match {
-      case Right(value) => value.series
-      case Left(value)  => value.rawSeries
-    }
-
-    rawSeries match {
-      case rawSeriesLp: RawSeries =>
-
-        val nameFilter = rawSeriesLp.filters.find(_.column.equals(PromMetricLabel)).
-          map(_.filter.valuesStrings.head.toString)
-        val leEqualsFilter = rawSeriesLp.filters.find(f => f.column == "le" && f.filter.isInstanceOf[Equals])
-        val leFilter = leEqualsFilter.map(_.filter.valuesStrings.head.toString)
-
-        if (nameFilter.isEmpty) (nameFilter, leFilter, lp)
-        else {
-          // the convention for histogram bucket queries is to have the "_bucket" string in the suffix
-          if (!nameFilter.get.endsWith("_bucket")) {
-            (nameFilter, leFilter, lp)
-          }
-          else if (leFilter.isDefined && parsePromLeValue(leFilter.get).isDefined) {
-            val filtersWithoutBucket = rawSeriesLp.filters.filterNot(_.column.equals(PromMetricLabel)).
-              filterNot(f => f.column == "le" && f.filter.isInstanceOf[Equals]) :+ ColumnFilter(PromMetricLabel,
-              Equals(PlannerUtil.replaceLastBucketOccurenceStringFromMetricName(nameFilter.get)))
-            val newLp =
-              if (lp.isLeft)
-                Left(lp.swap.toOption.get.copy(rawSeries = rawSeriesLp.copy(filters = filtersWithoutBucket)))
-              else
-                Right(lp.toOption.get.copy(series = rawSeriesLp.copy(filters = filtersWithoutBucket)))
-            (nameFilter, leFilter, newLp)
-          }
-          else {
-            (nameFilter, None, lp)
-          }
-        }
-      case _ => (None, None, lp)
-    }
-  }
   override private[queryplanner] def materializePeriodicSeries(qContext: QueryContext,
                                         lp: PeriodicSeries,
                                         forceInProcess: Boolean): PlanResult = {

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -2479,6 +2479,9 @@ class SingleClusterPlannerSpec extends AnyFunSpec
 
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     val multiSchemaPartitionsExec = execPlan.children.head.asInstanceOf[MultiSchemaPartitionsExec]
+    // metric name should NOT be rewritten when le is not an Equals filter
+    multiSchemaPartitionsExec.filters.filter(_.column == "__name__").head.filter.valuesStrings.
+      head.equals("my_hist_bucket") shouldEqual true
     // le NotEquals filter should be retained since this is not a specific bucket selection
     multiSchemaPartitionsExec.filters.exists(_.column == "le") shouldEqual true
     // HistogramBucket transformer should NOT be added for NotEquals le filter
@@ -2493,6 +2496,9 @@ class SingleClusterPlannerSpec extends AnyFunSpec
 
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     val multiSchemaPartitionsExec = execPlan.children.head.asInstanceOf[MultiSchemaPartitionsExec]
+    // metric name should NOT be rewritten when le is not an Equals filter
+    multiSchemaPartitionsExec.filters.filter(_.column == "__name__").head.filter.valuesStrings.
+      head.equals("my_hist_bucket") shouldEqual true
     // le NotEquals filter should be retained
     multiSchemaPartitionsExec.filters.exists(_.column == "le") shouldEqual true
     // HistogramBucket transformer should NOT be added for NotEquals le filter
@@ -2507,6 +2513,11 @@ class SingleClusterPlannerSpec extends AnyFunSpec
 
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     val multiSchemaPartitionsExec = execPlan.children.head.asInstanceOf[MultiSchemaPartitionsExec]
+    // metric name should NOT be rewritten when le value is not a valid number
+    multiSchemaPartitionsExec.filters.filter(_.column == "__name__").head.filter.valuesStrings.
+      head.equals("my_hist_bucket") shouldEqual true
+    // le filter should be retained since the value is not a valid number
+    multiSchemaPartitionsExec.filters.exists(_.column == "le") shouldEqual true
     // HistogramBucket transformer should NOT be added for unparseable le value
     multiSchemaPartitionsExec.rangeVectorTransformers.exists(
       _.isInstanceOf[InstantVectorFunctionMapper]) shouldEqual false
@@ -2519,6 +2530,11 @@ class SingleClusterPlannerSpec extends AnyFunSpec
 
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     val multiSchemaPartitionsExec = execPlan.children.head.asInstanceOf[MultiSchemaPartitionsExec]
+    // metric name should NOT be rewritten when le value is not a valid number
+    multiSchemaPartitionsExec.filters.filter(_.column == "__name__").head.filter.valuesStrings.
+      head.equals("my_hist_bucket") shouldEqual true
+    // le filter should be retained since the value is not a valid number
+    multiSchemaPartitionsExec.filters.exists(_.column == "le") shouldEqual true
     // HistogramBucket transformer should NOT be added for unparseable le value
     multiSchemaPartitionsExec.rangeVectorTransformers.exists(
       _.isInstanceOf[InstantVectorFunctionMapper]) shouldEqual false

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -2472,6 +2472,58 @@ class SingleClusterPlannerSpec extends AnyFunSpec
     validatePlan(execPlan, expected)
   }
 
+  it("should not throw NumberFormatException for histogram bucket query with le!=\"+Inf\" NotEquals filter") {
+    val t = TimeStepParams(700, 1000, 10000)
+    val lp = Parser.queryRangeToLogicalPlan(
+      """my_hist_bucket{job="prometheus",le!="+Inf"}""", t)
+
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    val multiSchemaPartitionsExec = execPlan.children.head.asInstanceOf[MultiSchemaPartitionsExec]
+    // le NotEquals filter should be retained since this is not a specific bucket selection
+    multiSchemaPartitionsExec.filters.exists(_.column == "le") shouldEqual true
+    // HistogramBucket transformer should NOT be added for NotEquals le filter
+    multiSchemaPartitionsExec.rangeVectorTransformers.exists(
+      _.isInstanceOf[InstantVectorFunctionMapper]) shouldEqual false
+  }
+
+  it("should not throw NumberFormatException for rate histogram bucket query with le!=\"+Inf\" NotEquals filter") {
+    val t = TimeStepParams(700, 1000, 10000)
+    val lp = Parser.queryRangeToLogicalPlan(
+      """sum(rate(my_hist_bucket{job="prometheus",le!="+Inf"}[2m])) by (job)""", t)
+
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    val multiSchemaPartitionsExec = execPlan.children.head.asInstanceOf[MultiSchemaPartitionsExec]
+    // le NotEquals filter should be retained
+    multiSchemaPartitionsExec.filters.exists(_.column == "le") shouldEqual true
+    // HistogramBucket transformer should NOT be added for NotEquals le filter
+    multiSchemaPartitionsExec.rangeVectorTransformers.exists(
+      _.isInstanceOf[InstantVectorFunctionMapper]) shouldEqual false
+  }
+
+  it("should not throw NumberFormatException for histogram bucket query with non-numeric le value") {
+    val t = TimeStepParams(700, 1000, 10000)
+    val lp = Parser.queryRangeToLogicalPlan(
+      """my_hist_bucket{job="prometheus",le="notanumber"}""", t)
+
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    val multiSchemaPartitionsExec = execPlan.children.head.asInstanceOf[MultiSchemaPartitionsExec]
+    // HistogramBucket transformer should NOT be added for unparseable le value
+    multiSchemaPartitionsExec.rangeVectorTransformers.exists(
+      _.isInstanceOf[InstantVectorFunctionMapper]) shouldEqual false
+  }
+
+  it("should not throw NumberFormatException for rate histogram bucket query with non-numeric le value") {
+    val t = TimeStepParams(700, 1000, 10000)
+    val lp = Parser.queryRangeToLogicalPlan(
+      """sum(rate(my_hist_bucket{job="prometheus",le="notanumber"}[2m])) by (job)""", t)
+
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    val multiSchemaPartitionsExec = execPlan.children.head.asInstanceOf[MultiSchemaPartitionsExec]
+    // HistogramBucket transformer should NOT be added for unparseable le value
+    multiSchemaPartitionsExec.rangeVectorTransformers.exists(
+      _.isInstanceOf[InstantVectorFunctionMapper]) shouldEqual false
+  }
+
   it("should NOT convert to histogram bucket query when _bucket is not a suffix") {
     val t = TimeStepParams(700, 1000, 10000)
     val lp = Parser.queryRangeToLogicalPlan("""my_bucket_counter{job="prometheus"}""", t)

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -2472,6 +2472,26 @@ class SingleClusterPlannerSpec extends AnyFunSpec
     validatePlan(execPlan, expected)
   }
 
+  it("should handle le=\"+Inf\" correctly for non-windowed histogram bucket query") {
+    val t = TimeStepParams(700, 1000, 10000)
+    val lp = Parser.queryRangeToLogicalPlan(
+      """my_hist_bucket{job="prometheus",le="+Inf"}""", t)
+
+    val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
+    val multiSchemaPartitionsExec = execPlan.children.head.asInstanceOf[MultiSchemaPartitionsExec]
+    // _bucket should be removed from name
+    multiSchemaPartitionsExec.filters.filter(_.column == "__name__").head.filter.valuesStrings.
+      head.equals("my_hist") shouldEqual true
+    // le filter should be removed
+    multiSchemaPartitionsExec.filters.exists(_.column == "le") shouldEqual false
+    // HistogramBucket transformer should be added with PositiveInfinity
+    val histBucketMapper = multiSchemaPartitionsExec.rangeVectorTransformers.collectFirst {
+      case t: InstantVectorFunctionMapper if t.function == InstantFunctionId.HistogramBucket => t
+    }
+    histBucketMapper shouldBe defined
+    histBucketMapper.get.funcParams.head.asInstanceOf[StaticFuncArgs].scalar shouldEqual Double.PositiveInfinity
+  }
+
   it("should not throw NumberFormatException for histogram bucket query with le!=\"+Inf\" NotEquals filter") {
     val t = TimeStepParams(700, 1000, 10000)
     val lp = Parser.queryRangeToLogicalPlan(

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SingleClusterPlannerSpec.scala
@@ -2485,8 +2485,10 @@ class SingleClusterPlannerSpec extends AnyFunSpec
     // le NotEquals filter should be retained since this is not a specific bucket selection
     multiSchemaPartitionsExec.filters.exists(_.column == "le") shouldEqual true
     // HistogramBucket transformer should NOT be added for NotEquals le filter
-    multiSchemaPartitionsExec.rangeVectorTransformers.exists(
-      _.isInstanceOf[InstantVectorFunctionMapper]) shouldEqual false
+    multiSchemaPartitionsExec.rangeVectorTransformers.exists {
+      case t: InstantVectorFunctionMapper => t.function == InstantFunctionId.HistogramBucket
+      case _ => false
+    } shouldEqual false
   }
 
   it("should not throw NumberFormatException for rate histogram bucket query with le!=\"+Inf\" NotEquals filter") {
@@ -2502,8 +2504,10 @@ class SingleClusterPlannerSpec extends AnyFunSpec
     // le NotEquals filter should be retained
     multiSchemaPartitionsExec.filters.exists(_.column == "le") shouldEqual true
     // HistogramBucket transformer should NOT be added for NotEquals le filter
-    multiSchemaPartitionsExec.rangeVectorTransformers.exists(
-      _.isInstanceOf[InstantVectorFunctionMapper]) shouldEqual false
+    multiSchemaPartitionsExec.rangeVectorTransformers.exists {
+      case t: InstantVectorFunctionMapper => t.function == InstantFunctionId.HistogramBucket
+      case _ => false
+    } shouldEqual false
   }
 
   it("should not throw NumberFormatException for histogram bucket query with non-numeric le value") {
@@ -2519,8 +2523,10 @@ class SingleClusterPlannerSpec extends AnyFunSpec
     // le filter should be retained since the value is not a valid number
     multiSchemaPartitionsExec.filters.exists(_.column == "le") shouldEqual true
     // HistogramBucket transformer should NOT be added for unparseable le value
-    multiSchemaPartitionsExec.rangeVectorTransformers.exists(
-      _.isInstanceOf[InstantVectorFunctionMapper]) shouldEqual false
+    multiSchemaPartitionsExec.rangeVectorTransformers.exists {
+      case t: InstantVectorFunctionMapper => t.function == InstantFunctionId.HistogramBucket
+      case _ => false
+    } shouldEqual false
   }
 
   it("should not throw NumberFormatException for rate histogram bucket query with non-numeric le value") {
@@ -2536,8 +2542,10 @@ class SingleClusterPlannerSpec extends AnyFunSpec
     // le filter should be retained since the value is not a valid number
     multiSchemaPartitionsExec.filters.exists(_.column == "le") shouldEqual true
     // HistogramBucket transformer should NOT be added for unparseable le value
-    multiSchemaPartitionsExec.rangeVectorTransformers.exists(
-      _.isInstanceOf[InstantVectorFunctionMapper]) shouldEqual false
+    multiSchemaPartitionsExec.rangeVectorTransformers.exists {
+      case t: InstantVectorFunctionMapper => t.function == InstantFunctionId.HistogramBucket
+      case _ => false
+    } shouldEqual false
   }
 
   it("should NOT convert to histogram bucket query when _bucket is not a suffix") {


### PR DESCRIPTION


**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

 
 **Current behavior :**                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                   
  Histogram bucket queries with a ``NotEquals`` filter on the ``le`` label (e.g. ``apiserver_request_duration_seconds_bucket{le!="+Inf"}``) throw a ``NumberFormatException: For input string: "+Inf"`` in ``SingleClusterPlanner.materializePeriodicSeries``. This is because ``removeBucket`` extracts the ``le`` filter value regardless of 
  filter type (``Equals``, ``NotEquals``, ``EqualsRegex``, etc.) and the downstream code calls ``.toDouble`` on the raw string "+Inf", which Java's ``Double.parseDouble``  does not recognize (it expects ``Infinity``).
                                                                                                                                                                                                                                                                                                                   
  Additionally, a garbage non-numeric le value (e.g. ``le="notanumber"``) in an ``Equals`` filter would also cause an unhandled ``NumberFormatException`` in both the ``materializePeriodicSeries`` and ``materializePeriodicSeriesWithWindowing`` code paths.                                                                         
   
 **New behavior :**
                                                                  
  1. ``removeBucket`` now only extracts and strips ``le`` filters that use the ``Equals`` filter type. ``NotEquals``, ``EqualsRegex``, and other filter types are left intact in the query plan and do not trigger the ``HistogramBucket`` transformer path.                                                                               
  2. Both ``materializePeriodicSeries`` and ``materializePeriodicSeriesWithWindowing`` now use a shared ``parsePromLeValue`` helper that:
    - Maps Prometheus infinity conventions (``+Inf``,`` Inf``, ``-Inf``) to their Java Double equivalents                                                                                                                                                                                                                      
    - Wraps the fallback ``.toDouble`` in ``Try(...).toOption`` so unparseable values are silently skipped rather than throwing an exception                                                                                                                                                                               
  3. Four new test cases added in SingleClusterPlannerSpec:                                                                                                                                                                                                                                                        
    - ``le!="+Inf"`` on ``PeriodicSeries`` (the original production crash)                                                                                                                                                                                                                                                 
    - ``le!="+Inf"`` on ``PeriodicSeriesWithWindowing`` (via sum(rate(...)))                                                                                                                                                                                                                                               
    - ``le="notanumber"`` on both paths (garbage-string hardening)                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                   
  BREAKING CHANGES                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                   
  None. This is a defensive bug fix. Valid histogram bucket queries (``le="0.5"``, ``le="+Inf"``) continue to work identically. Queries that previously crashed now execute without the HistogramBucket transformer, which is the correct behavior for non-exact or non-numeric ``le`` filters.                                