### PR TITLE
misc(record): Adding TreeMap support for writeLastDeltaHistRecord

### DIFF
--- a/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
+++ b/gateway/src/main/scala/filodb/gateway/conversion/InputRecord.scala
@@ -215,6 +215,44 @@ object InputRecord {
   }
   //scalastyle:on method.length
 
+  def writeLastDeltaHistRecord(builder: RecordBuilder,
+                               metric: String,
+                               tags: java.util.TreeMap[String, String],
+                               timestamp: Long,
+                               kvs: Seq[(String, Double)]): Unit = {
+    var sum = Double.NaN
+    var count = Double.NaN
+    var min = Double.NaN
+    var max = Double.NaN
+    var sumLast = Double.NaN
+    val sortedBuckets = kvs.filter {
+      case ("sum", v) => sum = v; false
+      case ("count", v) => count = v; false
+      case ("min", v) => min = v; false
+      case ("max", v) => max = v; false
+      case ("sumLast", v) => sumLast = v; false
+      case _ => true
+    }.map {
+      case ("+Inf", v) => (Double.PositiveInfinity, v.toLong)
+      case (k, v) => (k.toDouble, v.toLong)
+    }.sorted
+    if (sortedBuckets.nonEmpty) {
+      val buckets = CustomBuckets(sortedBuckets.map(_._1).toArray)
+      val hist = LongHistogram(buckets, sortedBuckets.map(_._2).toArray)
+      builder.startNewRecord(deltaHistogramV2)
+      builder.addLong(timestamp)
+      builder.addDouble(sum)
+      builder.addDouble(count)
+      builder.addBlob(hist.serialize())
+      builder.addDouble(min)
+      builder.addDouble(max)
+      builder.addDouble(sumLast)
+      builder.addString(metric)
+      builder.encodeMapFrom(tags)
+      builder.endRecord()
+    }
+  }
+
   // ── Shared helpers for histogram bucket extraction ─────────────────
 
   private def extractSumCountBuckets(kvs: Seq[(String, Double)])

--- a/gateway/src/test/scala/filodb/gateway/conversion/InputRecordBuilderSpec.scala
+++ b/gateway/src/test/scala/filodb/gateway/conversion/InputRecordBuilderSpec.scala
@@ -309,4 +309,372 @@ class InputRecordBuilderSpec extends AnyFunSpec with Matchers {
     firstRecordBytes(b1, Schemas.gauge) shouldEqual
       firstRecordBytes(b2, Schemas.gauge)
   }
+
+  // ── Deserialization tests for scalar TreeMap overloads ─────────────
+
+  it("TreeMap writeGaugeRecord data should deserialize correctly") {
+    val b = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeGaugeRecord(b, metric, treeTags, 100000L, 42.5)
+    b.allContainers.head.iterate(Schemas.gauge.ingestionSchema).foreach { row =>
+      row.getLong(0) shouldEqual 100000L
+      row.getDouble(1) shouldEqual 42.5
+    }
+  }
+
+  it("TreeMap writePromCounterRecord data should deserialize correctly") {
+    val b = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writePromCounterRecord(b, metric, treeTags, 100000L, 99.0)
+    b.allContainers.head.iterate(Schemas.promCounter.ingestionSchema).foreach { row =>
+      row.getLong(0) shouldEqual 100000L
+      row.getDouble(1) shouldEqual 99.0
+    }
+  }
+
+  it("TreeMap writeDeltaCounterRecord data should deserialize correctly") {
+    val b = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeDeltaCounterRecord(b, metric, treeTags, 100000L, 7.0)
+    b.allContainers.head.iterate(Schemas.deltaCounter.ingestionSchema).foreach { row =>
+      row.getLong(0) shouldEqual 100000L
+      row.getDouble(1) shouldEqual 7.0
+    }
+  }
+
+  it("TreeMap writeUntypedRecord data should deserialize correctly") {
+    val b = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeUntypedRecord(b, metric, treeTags, 100000L, 3.14)
+    b.allContainers.head.iterate(Schemas.untyped.ingestionSchema).foreach { row =>
+      row.getLong(0) shouldEqual 100000L
+      row.getDouble(1) shouldEqual 3.14
+    }
+  }
+
+  // ── Many tags tests for scalar TreeMap overloads ───────────────────
+
+  it("TreeMap writePromCounterRecord with many tags should match") {
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writePromCounterRecord(b1, metric, manyTags, 100000L, 99.0)
+    InputRecord.writePromCounterRecord(b2, metric, manyTreeTags, 100000L, 99.0)
+    firstRecordBytes(b1, Schemas.promCounter) shouldEqual
+      firstRecordBytes(b2, Schemas.promCounter)
+  }
+
+  it("TreeMap writeDeltaCounterRecord with many tags should match") {
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeDeltaCounterRecord(b1, metric, manyTags, 100000L, 7.0)
+    InputRecord.writeDeltaCounterRecord(b2, metric, manyTreeTags, 100000L, 7.0)
+    firstRecordBytes(b1, Schemas.deltaCounter) shouldEqual
+      firstRecordBytes(b2, Schemas.deltaCounter)
+  }
+
+  it("TreeMap writeUntypedRecord with many tags should match") {
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeUntypedRecord(b1, metric, manyTags, 100000L, 3.14)
+    InputRecord.writeUntypedRecord(b2, metric, manyTreeTags, 100000L, 3.14)
+    firstRecordBytes(b1, Schemas.untyped) shouldEqual
+      firstRecordBytes(b2, Schemas.untyped)
+  }
+
+  // ── No-bucket skip tests for all histogram TreeMap overloads ───────
+
+  it("TreeMap writePromHistRecord should skip when no buckets") {
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writePromHistRecord(b1, metric, baseTags, 100000L, sumCountKVs)
+    InputRecord.writePromHistRecord(b2, metric, treeTags, 100000L, sumCountKVs)
+    b1.allContainers shouldBe empty
+    b2.allContainers shouldBe empty
+  }
+
+  it("TreeMap writeDeltaHistRecord should skip when no buckets") {
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeDeltaHistRecord(b1, metric, baseTags, 100000L, sumCountKVs)
+    InputRecord.writeDeltaHistRecord(b2, metric, treeTags, 100000L, sumCountKVs)
+    b1.allContainers shouldBe empty
+    b2.allContainers shouldBe empty
+  }
+
+  it("TreeMap writeOtelDeltaHistRecord should skip when no buckets") {
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeOtelDeltaHistRecord(b1, metric, baseTags, 100000L, sumCountMinMaxKVs)
+    InputRecord.writeOtelDeltaHistRecord(b2, metric, treeTags, 100000L, sumCountMinMaxKVs)
+    b1.allContainers shouldBe empty
+    b2.allContainers shouldBe empty
+  }
+
+  it("TreeMap writeOtelCumulativeHistRecord should skip when no buckets") {
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeOtelCumulativeHistRecord(b1, metric, baseTags, 100000L, sumCountMinMaxKVs)
+    InputRecord.writeOtelCumulativeHistRecord(b2, metric, treeTags, 100000L, sumCountMinMaxKVs)
+    b1.allContainers shouldBe empty
+    b2.allContainers shouldBe empty
+  }
+
+  // ── Deserialization tests for histogram TreeMap overloads ──────────
+
+  private val histBuckets = Array(0.5, 1, 2.5, 5, 10, Double.PositiveInfinity)
+  private val expectedHist = LongHistogram(CustomBuckets(histBuckets), counts)
+  private def histBucketKVs: Seq[(String, Double)] = histBuckets.zip(counts).map {
+    case (Double.PositiveInfinity, c) => "+Inf" -> c.toDouble
+    case (b, c) => b.toString -> c.toDouble
+  }.toSeq
+
+  it("TreeMap writePromHistRecord data should deserialize correctly") {
+    val b = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writePromHistRecord(b, metric, treeTags, 100000L,
+      histBucketKVs ++ sumCountKVs)
+    b.allContainers.head.iterate(Schemas.promHistogram.ingestionSchema).foreach { row =>
+      row.getDouble(1) shouldEqual sum
+      row.getDouble(2) shouldEqual count
+      row.getHistogram(3) shouldEqual expectedHist
+    }
+  }
+
+  it("TreeMap writeDeltaHistRecord data should deserialize correctly") {
+    val b = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeDeltaHistRecord(b, metric, treeTags, 100000L,
+      histBucketKVs ++ sumCountKVs)
+    b.allContainers.head.iterate(Schemas.deltaHistogram.ingestionSchema).foreach { row =>
+      row.getDouble(1) shouldEqual sum
+      row.getDouble(2) shouldEqual count
+      row.getHistogram(3) shouldEqual expectedHist
+    }
+  }
+
+  it("TreeMap writeOtelDeltaHistRecord data should deserialize correctly") {
+    val b = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeOtelDeltaHistRecord(b, metric, treeTags, 100000L,
+      histBucketKVs ++ sumCountMinMaxKVs)
+    b.allContainers.head.iterate(Schemas.otelDeltaHistogram.ingestionSchema).foreach { row =>
+      row.getDouble(1) shouldEqual sum
+      row.getDouble(2) shouldEqual count
+      row.getHistogram(3) shouldEqual expectedHist
+      row.getDouble(4) shouldEqual min
+      row.getDouble(5) shouldEqual max
+    }
+  }
+
+  it("TreeMap writeOtelCumulativeHistRecord data should deserialize correctly") {
+    val b = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeOtelCumulativeHistRecord(b, metric, treeTags, 100000L,
+      histBucketKVs ++ sumCountMinMaxKVs)
+    b.allContainers.head.iterate(Schemas.otelCumulativeHistogram.ingestionSchema).foreach { row =>
+      row.getDouble(1) shouldEqual sum
+      row.getDouble(2) shouldEqual count
+      row.getHistogram(3) shouldEqual expectedHist
+      row.getDouble(4) shouldEqual min
+      row.getDouble(5) shouldEqual max
+    }
+  }
+
+  // ── Many tags tests for histogram TreeMap overloads ────────────────
+
+  private val manyTags = baseTags ++ (0 until 10).map(i => f"label_$i%02d" -> s"val_$i").toMap
+  private val manyTreeTags = {
+    val t = new java.util.TreeMap[String, String]()
+    manyTags.foreach { case (k, v) => t.put(k, v) }
+    t
+  }
+
+  it("TreeMap writePromHistRecord with many tags should match") {
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writePromHistRecord(b1, metric, manyTags, 100000L, histBucketKVs ++ sumCountKVs)
+    InputRecord.writePromHistRecord(b2, metric, manyTreeTags, 100000L, histBucketKVs ++ sumCountKVs)
+    firstRecordBytes(b1, Schemas.promHistogram) shouldEqual firstRecordBytes(b2, Schemas.promHistogram)
+  }
+
+  it("TreeMap writeDeltaHistRecord with many tags should match") {
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeDeltaHistRecord(b1, metric, manyTags, 100000L, histBucketKVs ++ sumCountKVs)
+    InputRecord.writeDeltaHistRecord(b2, metric, manyTreeTags, 100000L, histBucketKVs ++ sumCountKVs)
+    firstRecordBytes(b1, Schemas.deltaHistogram) shouldEqual firstRecordBytes(b2, Schemas.deltaHistogram)
+  }
+
+  it("TreeMap writeOtelDeltaHistRecord with many tags should match") {
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeOtelDeltaHistRecord(b1, metric, manyTags, 100000L, histBucketKVs ++ sumCountMinMaxKVs)
+    InputRecord.writeOtelDeltaHistRecord(b2, metric, manyTreeTags, 100000L, histBucketKVs ++ sumCountMinMaxKVs)
+    firstRecordBytes(b1, Schemas.otelDeltaHistogram) shouldEqual firstRecordBytes(b2, Schemas.otelDeltaHistogram)
+  }
+
+  it("TreeMap writeOtelCumulativeHistRecord with many tags should match") {
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeOtelCumulativeHistRecord(b1, metric, manyTags, 100000L, histBucketKVs ++ sumCountMinMaxKVs)
+    InputRecord.writeOtelCumulativeHistRecord(b2, metric, manyTreeTags, 100000L, histBucketKVs ++ sumCountMinMaxKVs)
+    firstRecordBytes(b1, Schemas.otelCumulativeHistogram) shouldEqual
+      firstRecordBytes(b2, Schemas.otelCumulativeHistogram)
+  }
+
+  // ── OTel Exponential Histogram TreeMap tests ──────────────────────
+
+  private val expBucketScheme = Base2ExpHistogramBuckets(3, -5, 10)
+  private val expBucketCounts = Array(1L, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+  private val expBucketKVs: Seq[(String, Double)] = expBucketCounts.zipWithIndex.map {
+    case (c, i) => i.toString -> c.toDouble
+  }.toSeq
+  private val expExtra = Seq(
+    "posBucketOffset" -> expBucketScheme.startIndexPositiveBuckets.toDouble,
+    "scale" -> expBucketScheme.scale.toDouble)
+
+  it("TreeMap writeOtelExponentialHistRecord should match Scala Map version") {
+    val kvs = expBucketKVs ++ sumCountMinMaxKVs ++ expExtra
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeOtelExponentialHistRecord(b1, metric, baseTags, 100000L, kvs, isDelta = true)
+    InputRecord.writeOtelExponentialHistRecord(b2, metric, treeTags, 100000L, kvs, isDelta = true)
+    firstRecordBytes(b1, Schemas.otelExpDeltaHistogram) shouldEqual
+      firstRecordBytes(b2, Schemas.otelExpDeltaHistogram)
+  }
+
+  it("TreeMap writeOtelExponentialHistRecord data should deserialize correctly") {
+    val kvs = expBucketKVs ++ sumCountMinMaxKVs ++ expExtra
+    val b = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeOtelExponentialHistRecord(b, metric, treeTags, 100000L, kvs, isDelta = true)
+    val expectedHist = LongHistogram(expBucketScheme, expBucketCounts)
+    b.allContainers.head.iterate(Schemas.otelExpDeltaHistogram.ingestionSchema).foreach { row =>
+      row.getLong(0) shouldEqual 100000L
+      row.getDouble(1) shouldEqual sum
+      row.getDouble(2) shouldEqual count
+      val hist = row.getHistogram(3).asInstanceOf[LongHistogram]
+      hist.buckets shouldEqual expectedHist.buckets
+      hist.values shouldEqual expBucketCounts
+      row.getDouble(4) shouldEqual min
+      row.getDouble(5) shouldEqual max
+    }
+  }
+
+  it("TreeMap writeOtelExponentialHistRecord should skip when no buckets") {
+    val kvs = sumCountMinMaxKVs ++ expExtra
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeOtelExponentialHistRecord(b1, metric, baseTags, 100000L, kvs, isDelta = true)
+    InputRecord.writeOtelExponentialHistRecord(b2, metric, treeTags, 100000L, kvs, isDelta = true)
+    b1.allContainers shouldBe empty
+    b2.allContainers shouldBe empty
+  }
+
+  it("TreeMap writeOtelExponentialHistRecord with many tags should match") {
+    val kvs = expBucketKVs ++ sumCountMinMaxKVs ++ expExtra
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeOtelExponentialHistRecord(b1, metric, manyTags, 100000L, kvs, isDelta = true)
+    InputRecord.writeOtelExponentialHistRecord(b2, metric, manyTreeTags, 100000L, kvs, isDelta = true)
+    firstRecordBytes(b1, Schemas.otelExpDeltaHistogram) shouldEqual
+      firstRecordBytes(b2, Schemas.otelExpDeltaHistogram)
+  }
+
+  it("TreeMap writeLastDeltaHistRecord should match Scala Map version") {
+    val buckets = Array(0.5, 1, 2.5, 5, 10, Double.PositiveInfinity)
+    val sumLast = 99.0
+    val bucketKVs = buckets.zip(counts).map {
+      case (Double.PositiveInfinity, c) => "+Inf" -> c.toDouble
+      case (b, c) => b.toString -> c.toDouble
+    }.toSeq ++ sumCountMinMaxKVs :+ ("sumLast" -> sumLast)
+
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+
+    InputRecord.writeLastDeltaHistRecord(b1, metric, baseTags, 100000L, bucketKVs)
+    InputRecord.writeLastDeltaHistRecord(b2, metric, treeTags, 100000L, bucketKVs)
+
+    firstRecordBytes(b1, Schemas.deltaHistogramV2) shouldEqual
+      firstRecordBytes(b2, Schemas.deltaHistogramV2)
+  }
+
+  it("TreeMap writeLastDeltaHistRecord with many tags should match") {
+    val manyTags = baseTags ++ (0 until 10).map(i => f"label_$i%02d" -> s"value_$i").toMap
+    val manyTreeTags = {
+      val t = new java.util.TreeMap[String, String]()
+      manyTags.foreach { case (k, v) => t.put(k, v) }
+      t
+    }
+    val buckets = Array(0.5, 1, 2.5, 5, 10, Double.PositiveInfinity)
+    val bucketKVs = buckets.zip(counts).map {
+      case (Double.PositiveInfinity, c) => "+Inf" -> c.toDouble
+      case (b, c) => b.toString -> c.toDouble
+    }.toSeq ++ sumCountMinMaxKVs :+ ("sumLast" -> 42.0)
+
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+
+    InputRecord.writeLastDeltaHistRecord(b1, metric, manyTags, 100000L, bucketKVs)
+    InputRecord.writeLastDeltaHistRecord(b2, metric, manyTreeTags, 100000L, bucketKVs)
+
+    firstRecordBytes(b1, Schemas.deltaHistogramV2) shouldEqual
+      firstRecordBytes(b2, Schemas.deltaHistogramV2)
+  }
+
+  it("TreeMap writeLastDeltaHistRecord with shuffled kvs should match") {
+    // Verify that sum/count/min/max/sumLast extraction works regardless of position
+    val buckets = Array(0.5, 1, 2.5, 5, 10, Double.PositiveInfinity)
+    val shuffledKVs = Seq(
+      "sumLast" -> 77.0,
+      "count" -> count,
+      "+Inf" -> counts(5).toDouble,
+      "0.5" -> counts(0).toDouble,
+      "min" -> min,
+      "1.0" -> counts(1).toDouble,
+      "sum" -> sum,
+      "2.5" -> counts(2).toDouble,
+      "max" -> max,
+      "5.0" -> counts(3).toDouble,
+      "10.0" -> counts(4).toDouble
+    )
+
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+
+    InputRecord.writeLastDeltaHistRecord(b1, metric, baseTags, 100000L, shuffledKVs)
+    InputRecord.writeLastDeltaHistRecord(b2, metric, treeTags, 100000L, shuffledKVs)
+
+    firstRecordBytes(b1, Schemas.deltaHistogramV2) shouldEqual
+      firstRecordBytes(b2, Schemas.deltaHistogramV2)
+  }
+
+  it("TreeMap writeLastDeltaHistRecord should skip when no buckets") {
+    // Only sum/count/min/max/sumLast, no actual bucket data → should be skipped
+    val noBucketKVs = sumCountMinMaxKVs :+ ("sumLast" -> 55.0)
+
+    val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+    val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+
+    InputRecord.writeLastDeltaHistRecord(b1, metric, baseTags, 100000L, noBucketKVs)
+    InputRecord.writeLastDeltaHistRecord(b2, metric, treeTags, 100000L, noBucketKVs)
+
+    // Both should skip — no record written
+    b1.allContainers shouldBe empty
+    b2.allContainers shouldBe empty
+  }
+
+  it("TreeMap writeLastDeltaHistRecord data should deserialize correctly") {
+    val buckets = Array(0.5, 1, 2.5, 5, 10, Double.PositiveInfinity)
+    val sumLast = 123.456
+    val bucketKVs = buckets.zip(counts).map {
+      case (Double.PositiveInfinity, c) => "+Inf" -> c.toDouble
+      case (b, c) => b.toString -> c.toDouble
+    }.toSeq ++ sumCountMinMaxKVs :+ ("sumLast" -> sumLast)
+
+    val b = new RecordBuilder(MemFactory.onHeapFactory)
+    InputRecord.writeLastDeltaHistRecord(b, metric, treeTags, 100000L, bucketKVs)
+
+    val expectedHist = LongHistogram(CustomBuckets(buckets), counts)
+    b.allContainers.head.iterate(Schemas.deltaHistogramV2.ingestionSchema).foreach { row =>
+      row.getLong(0) shouldEqual 100000L  // timestamp
+      row.getDouble(1) shouldEqual sum    // sum
+      row.getDouble(2) shouldEqual count  // count
+      row.getHistogram(3) shouldEqual expectedHist  // histogram
+      row.getDouble(4) shouldEqual min    // min
+      row.getDouble(5) shouldEqual max    // max
+      row.getDouble(6) shouldEqual sumLast // sumLast
+    }
+  }
 }

--- a/jmh/src/main/scala/filodb.jmh/HistVectorBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistVectorBenchmark.scala
@@ -8,7 +8,6 @@ import org.openjdk.jmh.infra.Blackhole
 
 import filodb.memory.NativeMemoryManager
 import filodb.memory.format._
-import filodb.memory.format.vectors.BinaryHistogram
 
 @State(Scope.Thread)
 class HistVectorBenchmark {
@@ -93,54 +92,6 @@ class HistVectorBenchmark {
       val h = r2(i)
       blackhole.consume(h)
     }
-  }
-
-  // ── sum() benchmark: simulates rate(delta_hist[5m]) hot path ───────
-  // 20-bucket geometric histograms, 30 samples (5m window @ 10s interval)
-  val scheme20 = GeometricBuckets(1.0, 2.0, 20)
-  final val numSamplesInWindow = 30
-  val sumAppender20: BinaryAppendableVector[org.agrona.DirectBuffer] = {
-    val app = HistogramVector.appending(memFactory, 15000)
-    val rng = new java.util.Random(42)
-    (0 until numSamplesInWindow).foreach { _ =>
-      val raw = new Array[Long](20)
-      (0 until 20).foreach { i => raw(i) = rng.nextInt(1000).toLong }
-      (1 until 20).foreach { i => raw(i) += raw(i - 1) }
-      BinaryHistogram.writeDelta(scheme20, raw, buffer)
-      if (app.addData(buffer) != Ack) {
-        throw new RuntimeException("Failed to add 20-bucket histogram")
-      }
-    }
-    app
-  }
-
-  @Benchmark
-  @BenchmarkMode(Array(Mode.Throughput, Mode.AverageTime))
-  @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  def sumDeltaHist20Buckets(blackhole: Blackhole): Unit = {
-    val r = sumAppender20.reader.asHistReader
-    blackhole.consume(r.sum(0, numSamplesInWindow - 1))
-  }
-
-  // 127-bucket OTel exp histograms, 30 samples
-  val sumAppender127: BinaryAppendableVector[org.agrona.DirectBuffer] = {
-    val app = HistogramVector.appending(memFactory, 15000)
-    (0 until numSamplesInWindow).foreach { _ =>
-      val hist = LongHistogram(bucketScheme, counts)
-      hist.serialize(Some(buffer))
-      if (app.addData(buffer) != Ack) {
-        throw new RuntimeException("Failed to add 127-bucket histogram")
-      }
-    }
-    app
-  }
-
-  @Benchmark
-  @BenchmarkMode(Array(Mode.Throughput, Mode.AverageTime))
-  @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  def sumDeltaHist127Buckets(blackhole: Blackhole): Unit = {
-    val r = sumAppender127.reader.asHistReader
-    blackhole.consume(r.sum(0, numSamplesInWindow - 1))
   }
 
 }

--- a/jmh/src/main/scala/filodb.jmh/HistVectorBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/HistVectorBenchmark.scala
@@ -8,6 +8,7 @@ import org.openjdk.jmh.infra.Blackhole
 
 import filodb.memory.NativeMemoryManager
 import filodb.memory.format._
+import filodb.memory.format.vectors.BinaryHistogram
 
 @State(Scope.Thread)
 class HistVectorBenchmark {
@@ -92,6 +93,54 @@ class HistVectorBenchmark {
       val h = r2(i)
       blackhole.consume(h)
     }
+  }
+
+  // ── sum() benchmark: simulates rate(delta_hist[5m]) hot path ───────
+  // 20-bucket geometric histograms, 30 samples (5m window @ 10s interval)
+  val scheme20 = GeometricBuckets(1.0, 2.0, 20)
+  final val numSamplesInWindow = 30
+  val sumAppender20: BinaryAppendableVector[org.agrona.DirectBuffer] = {
+    val app = HistogramVector.appending(memFactory, 15000)
+    val rng = new java.util.Random(42)
+    (0 until numSamplesInWindow).foreach { _ =>
+      val raw = new Array[Long](20)
+      (0 until 20).foreach { i => raw(i) = rng.nextInt(1000).toLong }
+      (1 until 20).foreach { i => raw(i) += raw(i - 1) }
+      BinaryHistogram.writeDelta(scheme20, raw, buffer)
+      if (app.addData(buffer) != Ack) {
+        throw new RuntimeException("Failed to add 20-bucket histogram")
+      }
+    }
+    app
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput, Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  def sumDeltaHist20Buckets(blackhole: Blackhole): Unit = {
+    val r = sumAppender20.reader.asHistReader
+    blackhole.consume(r.sum(0, numSamplesInWindow - 1))
+  }
+
+  // 127-bucket OTel exp histograms, 30 samples
+  val sumAppender127: BinaryAppendableVector[org.agrona.DirectBuffer] = {
+    val app = HistogramVector.appending(memFactory, 15000)
+    (0 until numSamplesInWindow).foreach { _ =>
+      val hist = LongHistogram(bucketScheme, counts)
+      hist.serialize(Some(buffer))
+      if (app.addData(buffer) != Ack) {
+        throw new RuntimeException("Failed to add 127-bucket histogram")
+      }
+    }
+    app
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput, Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  def sumDeltaHist127Buckets(blackhole: Blackhole): Unit = {
+    val r = sumAppender127.reader.asHistReader
+    blackhole.consume(r.sum(0, numSamplesInWindow - 1))
   }
 
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?

**New behavior :**

Adds Java TreeMap support for InputRecord.writeLastDeltaHistRecord, aligning it with the other low-allocation TreeMap-based record writers used by gateway ingestion/conversion.

Changes:

- Added writeLastDeltaHistRecord overload that accepts java.util.TreeMap[String, String] and encodes tags via RecordBuilder.encodeMapFrom.
- Expanded InputRecordBuilderSpec to cover deserialization and byte-for-byte equivalence for TreeMap overloads, including new coverage for writeLastDeltaHistRecord.