### PR TITLE
fix(coord): When flight is enabled, SLF non-leaf plans should correctly use Flight Dispatcher

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
@@ -7,8 +7,8 @@ import akka.actor.ActorRef
 import akka.serialization.SerializationExtension
 import com.typesafe.scalalogging.StrictLogging
 
-import filodb.coordinator.flight.{FiloDBFlightProducer, SingleClusterFlightPlanDispatcher}
 import filodb.coordinator.{ActorPlanDispatcher, ActorSystemHolder, GrpcPlanDispatcher, RemoteActorPlanDispatcher}
+import filodb.coordinator.flight.{FiloDBFlightProducer, SingleClusterFlightPlanDispatcher}
 import filodb.core.metadata.{Dataset, DatasetOptions, Schemas}
 import filodb.core.query._
 import filodb.core.query.Filter.Equals
@@ -770,9 +770,6 @@ object PlannerUtil extends StrictLogging {
         val path = localShardMapper.shards(randomActiveShard).address
         val serialization = SerializationExtension(ActorSystemHolder.system)
         val deserializedActorRef = serialization.system.provider.resolveActorRef(path)
-        logger.warn(s"Using Actor Plan Dispatcher for SLF non leaf plan since no child plans have local dispatchers. " +
-          s"Cluster: $clusterName, Active Shards: ${activeShards.size}, " +
-          s"Randomly picked active shard: $randomActiveShard, Actor Path: $path")
         getAkkaOrFlightDispatcher(deserializedActorRef, clusterName, flightEnabled)
       } else {
         localDispatchers.iterator.drop(rnd.nextInt(localDispatchers.size)).next

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/DefaultPlanner.scala
@@ -3,9 +3,11 @@ package filodb.coordinator.queryplanner
 
 import java.util.concurrent.ThreadLocalRandom
 
+import akka.actor.ActorRef
 import akka.serialization.SerializationExtension
 import com.typesafe.scalalogging.StrictLogging
 
+import filodb.coordinator.flight.{FiloDBFlightProducer, SingleClusterFlightPlanDispatcher}
 import filodb.coordinator.{ActorPlanDispatcher, ActorSystemHolder, GrpcPlanDispatcher, RemoteActorPlanDispatcher}
 import filodb.core.metadata.{Dataset, DatasetOptions, Schemas}
 import filodb.core.query._
@@ -15,6 +17,7 @@ import filodb.prometheus.ast.Vectors.PromMetricLabel
 import filodb.query._
 import filodb.query.InstantFunctionId.HistogramBucket
 import filodb.query.LogicalPlan._
+import filodb.query.Query.qLogger
 import filodb.query.exec._
 import filodb.query.exec.InternalRangeFunction.Last
 
@@ -28,6 +31,7 @@ import filodb.query.exec.InternalRangeFunction.Last
 case class PlanResult(plans: Seq[ExecPlan], needsStitch: Boolean = false)
 
 trait  DefaultPlanner {
+    def flightEnabled: Boolean
     def queryConfig: QueryConfig
     def dataset: Dataset
     def schemas: Schemas
@@ -271,7 +275,7 @@ trait  DefaultPlanner {
                                      forceInProcess: Boolean = false): PlanResult = {
       val vectors = walkLogicalPlanTree(lp.vectors, qContext, forceInProcess)
       if (vectors.plans.length > 1) {
-        val targetActor = PlannerUtil.pickDispatcher(vectors.plans)
+        val targetActor = PlannerUtil.pickDispatcher(vectors.plans, flightEnabled)
         val topPlan = LocalPartitionDistConcatExec(qContext, targetActor, vectors.plans)
         topPlan.addRangeVectorTransformer(SortFunctionMapper(lp.function))
         PlanResult(Seq(topPlan), vectors.needsStitch)
@@ -286,7 +290,7 @@ trait  DefaultPlanner {
                               forceInProcess: Boolean = false): PlanResult = {
       val vectors = walkLogicalPlanTree(lp.vectors, qContext, forceInProcess)
       if (vectors.plans.length > 1) {
-        val targetActor = PlannerUtil.pickDispatcher(vectors.plans)
+        val targetActor = PlannerUtil.pickDispatcher(vectors.plans, flightEnabled)
         val topPlan = LocalPartitionDistConcatExec(qContext, targetActor, vectors.plans)
         topPlan.addRangeVectorTransformer(ScalarFunctionMapper(lp.function,
           RangeParams(lp.startMs, lp.stepMs, lp.endMs)))
@@ -348,7 +352,7 @@ trait  DefaultPlanner {
         // If number of children is above a threshold, parallelize aggregation
         val groupSize = Math.sqrt(toReduceLevel.plans.size).ceil.toInt
         toReduceLevel.plans.grouped(groupSize).map { nodePlans =>
-          val reduceDispatcher = PlannerUtil.pickDispatcher(nodePlans)
+          val reduceDispatcher = PlannerUtil.pickDispatcher(nodePlans, flightEnabled)
           LocalPartitionReduceAggregateExec(qContext, reduceDispatcher, nodePlans, lp.operator, lp.params)
         }.toList
       } else toReduceLevel.plans
@@ -361,7 +365,7 @@ trait  DefaultPlanner {
     *   Given that the work required to allow dispatcher updates and/or rework pushdown logic is nontrivial
     *   and the QueryStats bloat given by unnecessary aggregation plans is likely small, the fix is skipped for now.
     */
-    val reduceDispatcher = forceRootDispatcher.getOrElse(PlannerUtil.pickDispatcher(toReduceLevel2))
+    val reduceDispatcher = forceRootDispatcher.getOrElse(PlannerUtil.pickDispatcher(toReduceLevel2, flightEnabled))
     val reducer = LocalPartitionReduceAggregateExec(qContext, reduceDispatcher, toReduceLevel2, lp.operator, lp.params)
 
     if (!qContext.plannerParams.skipAggregatePresent)
@@ -391,7 +395,7 @@ trait  DefaultPlanner {
                                forceInProcess: Boolean = false): PlanResult = {
     val vectors = walkLogicalPlanTree(lp.vectors, qContext, forceInProcess)
     if (vectors.plans.length > 1) {
-      val targetActor = PlannerUtil.pickDispatcher(vectors.plans)
+      val targetActor = PlannerUtil.pickDispatcher(vectors.plans, flightEnabled)
       val topPlan = LocalPartitionDistConcatExec(qContext, targetActor, vectors.plans)
       topPlan.addRangeVectorTransformer(LimitFunctionMapper(lp.limit))
       PlanResult(Seq(topPlan), vectors.needsStitch)
@@ -609,7 +613,7 @@ trait  DefaultPlanner {
       val dispatcher = if (!lhs.plans.head.dispatcher.isLocalCall && !rhs.plans.head.dispatcher.isLocalCall) {
         val lhsCluster = lhs.plans.head.dispatcher.clusterName
         val rhsCluster = rhs.plans.head.dispatcher.clusterName
-        if (rhsCluster.equals(lhsCluster)) PlannerUtil.pickDispatcher(lhs.plans ++ rhs.plans)
+        if (rhsCluster.equals(lhsCluster)) PlannerUtil.pickDispatcher(lhs.plans ++ rhs.plans, flightEnabled)
         else inProcessPlanDispatcher
       } else inProcessPlanDispatcher
 
@@ -689,7 +693,7 @@ object PlannerUtil extends StrictLogging {
   /**
    * Picks one dispatcher randomly from child exec plans passed in as parameter
    */
-  def pickDispatcher(children: Seq[ExecPlan]): PlanDispatcher = {
+  def pickDispatcher(children: Seq[ExecPlan], flightEnabled: Boolean): PlanDispatcher = {
     val plannerParams = children.iterator.next().queryContext.plannerParams
     // there is a very subtle point on how to decide how we need to pick up the dispatcher
     // HA planner would inject the children that are created with HA planner with the active shard map
@@ -710,7 +714,7 @@ object PlannerUtil extends StrictLogging {
       if (!localActiveShardMapper.allShardsActive && buddyActiveShardMapper.allShardsActive) {
         pickDispatcherNormal(children)
       } else {
-        pickDispatcherShardLevelFailover(children, plannerParams)
+        pickDispatcherShardLevelFailover(children, flightEnabled)
       }
     } else {
       // this case is used for both:
@@ -739,7 +743,7 @@ object PlannerUtil extends StrictLogging {
    * Picks one dispatcher randomly from child exec plans passed in as parameter
    */
   def pickDispatcherShardLevelFailover(
-    children: Seq[ExecPlan], plannerParams: PlannerParams
+    children: Seq[ExecPlan], flightEnabled: Boolean
   ): PlanDispatcher = {
 
     children.find(_.dispatcher.isLocalCall).map(_.dispatcher).getOrElse {
@@ -766,17 +770,28 @@ object PlannerUtil extends StrictLogging {
         val path = localShardMapper.shards(randomActiveShard).address
         val serialization = SerializationExtension(ActorSystemHolder.system)
         val deserializedActorRef = serialization.system.provider.resolveActorRef(path)
-        val dispatcher = ActorPlanDispatcher(
-          deserializedActorRef, clusterName
-        )
-        dispatcher
+        logger.warn(s"Using Actor Plan Dispatcher for SLF non leaf plan since no child plans have local dispatchers. " +
+          s"Cluster: $clusterName, Active Shards: ${activeShards.size}, " +
+          s"Randomly picked active shard: $randomActiveShard, Actor Path: $path")
+        getAkkaOrFlightDispatcher(deserializedActorRef, clusterName, flightEnabled)
       } else {
-        val dispatcher =
-          localDispatchers.iterator.drop(rnd.nextInt(localDispatchers.size)).next
-        dispatcher
+        localDispatchers.iterator.drop(rnd.nextInt(localDispatchers.size)).next
       }
    }
   }
+
+  def getAkkaOrFlightDispatcher(targetActor: ActorRef,
+                                clusterName: String,
+                                flightEnabled: Boolean): PlanDispatcher = {
+    if (flightEnabled) {
+      qLogger.debug(s"Converting $targetActor to Flight ... ")
+      val location = FiloDBFlightProducer.akkaActorToFlightLocation(targetActor)
+      SingleClusterFlightPlanDispatcher(location, clusterName)
+    } else {
+      ActorPlanDispatcher(targetActor, clusterName)
+    }
+  }
+
 
   def isScheduledLocally(d : PlanDispatcher): Boolean = {
     val scheduledLocally = (!d.isInstanceOf[RemoteActorPlanDispatcher]) && (!d.isInstanceOf[GrpcPlanDispatcher])

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LongTimeRangePlanner.scala
@@ -29,6 +29,7 @@ import filodb.query.exec._
   */
   class LongTimeRangePlanner(rawClusterPlanner: QueryPlanner,
                              downsampleClusterPlanner: QueryPlanner,
+                             val flightEnabled: Boolean,
                              earliestRawTimestampFn: => Long,
                              latestDownsampleTimestampFn: => Long,
                              stitchDispatcher: => PlanDispatcher,

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/MultiPartitionPlanner.scala
@@ -90,6 +90,7 @@ class MultiPartitionPlanner(val partitionLocationProvider: PartitionLocationProv
                             localPartitionName: String,
                             val dataset: Dataset,
                             val queryConfig: QueryConfig,
+                            val flightEnabled: Boolean,
                             remoteExecHttpClient: RemoteExecHttpClient = RemoteHttpClient.defaultClient,
                             channels: ConcurrentMap[String, ManagedChannel] =
                             new ConcurrentHashMap[String, ManagedChannel]().asScala,
@@ -452,7 +453,7 @@ class MultiPartitionPlanner(val partitionLocationProvider: PartitionLocationProv
       queryParams.copy(promQl = LogicalPlanParser.convertToQuery(binaryJoin.rhs)))
     val rhsPlan = materializeForAssignment(binaryJoin.rhs, assignment, rightContext, timeRangeOverride)
 
-    val dispatcher = PlannerUtil.pickDispatcher(Seq(lhsPlan, rhsPlan))
+    val dispatcher = PlannerUtil.pickDispatcher(Seq(lhsPlan, rhsPlan), flightEnabled)
     if (binaryJoin.operator.isInstanceOf[SetOperator])
       exec.SetOperatorExec(queryContext, dispatcher, Seq(lhsPlan), Seq(rhsPlan), binaryJoin.operator,
         binaryJoin.on.map(LogicalPlanUtils.renameLabels(_, dsOptions.metricColumn)),
@@ -493,7 +494,7 @@ class MultiPartitionPlanner(val partitionLocationProvider: PartitionLocationProv
         plans.filter(_.isInstanceOf[PromQlRemoteExec]).foreach(
           _.addRangeVectorTransformer(AggregateMapReduce(aggregate.operator, aggregate.params, aggregate.clauseOpt))
         )
-        val dispatcher = PlannerUtil.pickDispatcher(plans)
+        val dispatcher = PlannerUtil.pickDispatcher(plans, flightEnabled)
         val reducer = MultiPartitionReduceAggregateExec(queryContext, dispatcher,
           PlannerUtil.localPlansFirst(plans), aggregate.operator, aggregate.params)
         if (!queryContext.plannerParams.skipAggregatePresent) {
@@ -797,7 +798,7 @@ class MultiPartitionPlanner(val partitionLocationProvider: PartitionLocationProv
         partitionDetails.grpcEndPoint, partitionDetails.httpEndPoint, queryContext, timeRangeOverride,
         partitionDetails.workUnit)
     }).toSeq
-    val dispatcher = PlannerUtil.pickDispatcher(plans)
+    val dispatcher = PlannerUtil.pickDispatcher(plans, flightEnabled)
     MultiPartitionDistConcatExec(queryContext, dispatcher, plans)
   }
 

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlanner.scala
@@ -33,6 +33,7 @@ class ShardKeyRegexPlanner(val dataset: Dataset,
                            shardKeyMatcher: Seq[ColumnFilter] => Seq[Seq[ColumnFilter]],
                            partitionLocationProvider: PartitionLocationProvider,
                            config: QueryConfig,
+                           val flightEnabled: Boolean,
                            _targetSchemaProvider: TargetSchemaProvider = StaticTargetSchemaProvider())
   extends PartitionLocationPlanner(dataset, partitionLocationProvider) {
 
@@ -110,7 +111,7 @@ class ShardKeyRegexPlanner(val dataset: Dataset,
     } else {
       val result = walkLogicalPlanTree(logicalPlan, qContext)
       if (result.plans.size > 1) {
-        val dispatcher = PlannerUtil.pickDispatcher(result.plans)
+        val dispatcher = PlannerUtil.pickDispatcher(result.plans, flightEnabled)
         MultiPartitionDistConcatExec(qContext, dispatcher, result.plans)
       } else result.plans.head
     }

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SingleClusterPlanner.scala
@@ -58,7 +58,7 @@ class SingleClusterPlanner(val dataset: Dataset,
                            earliestRetainedTimestampFn: => Long,
                            val queryConfig: QueryConfig,
                            clusterName: String,
-                           flightEnabled: Boolean = false,
+                           val flightEnabled: Boolean = false,
                            spreadProvider: SpreadProvider = StaticSpreadProvider(),
                            _targetSchemaProvider: TargetSchemaProvider = StaticTargetSchemaProvider(),
                            timeSplitEnabled: Boolean = false,
@@ -211,17 +211,7 @@ class SingleClusterPlanner(val dataset: Dataset,
       else
         throw new RuntimeException(s"Shard: $shard is not available")
     }
-    getAkkaOrFlightDispatcher(targetActor)
-  }
-
-  private def getAkkaOrFlightDispatcher(targetActor: ActorRef): PlanDispatcher = {
-    if (flightEnabled) {
-      qLogger.debug(s"Converting $targetActor to Flight ... ")
-      val location = FiloDBFlightProducer.akkaActorToFlightLocation(targetActor)
-      SingleClusterFlightPlanDispatcher(location, clusterName)
-    } else {
-      ActorPlanDispatcher(targetActor, clusterName)
-    }
+    PlannerUtil.getAkkaOrFlightDispatcher(targetActor, clusterName, flightEnabled)
   }
 
   private def shardLevelFailoverDispatcherForShard(shard: Int, queryContext: QueryContext): PlanDispatcher = {
@@ -243,7 +233,7 @@ class SingleClusterPlanner(val dataset: Dataset,
       if (targetActor == ActorRef.noSender) {
         getRemoteDispatcherForShard(shard, queryContext)
       } else {
-        getAkkaOrFlightDispatcher(targetActor)
+        PlannerUtil.getAkkaOrFlightDispatcher(targetActor, clusterName, flightEnabled)
       }
     } else {
       getRemoteDispatcherForShard(shard, queryContext)
@@ -337,7 +327,7 @@ class SingleClusterPlanner(val dataset: Dataset,
         case Seq(one) => materializeTimeSplitPlan(one, qContext, false)
         case many =>
           val materializedPlans = many.map(materializeTimeSplitPlan(_, qContext, false))
-          val targetActor = PlannerUtil.pickDispatcher(materializedPlans)
+          val targetActor = PlannerUtil.pickDispatcher(materializedPlans, flightEnabled)
 
           // create SplitLocalPartitionDistConcatExec that will execute child execplanss sequentially and stitches
           // results back with StitchRvsMapper transformer.
@@ -361,7 +351,7 @@ class SingleClusterPlanner(val dataset: Dataset,
         if (stitch) justOne.addRangeVectorTransformer(StitchRvsMapper(rvRangeFromPlan(logicalPlan)))
         justOne
       case PlanResult(many, stitch) =>
-        val targetActor = PlannerUtil.pickDispatcher(many)
+        val targetActor = PlannerUtil.pickDispatcher(many, flightEnabled)
         many.head match {
           case _: LabelValuesExec => LabelValuesDistConcatExec(qContext, targetActor, many)
           case _: LabelNamesExec => LabelNamesDistConcatExec(qContext, targetActor, many)
@@ -617,11 +607,11 @@ class SingleClusterPlanner(val dataset: Dataset,
                                               forceDispatcher: Option[PlanDispatcher]): PlanResult = {
     val lhs = walkLogicalPlanTree(lp.lhs, qContext, forceInProcess)
     val stitchedLhs = if (lhs.needsStitch) Seq(StitchRvsExec(qContext,
-      PlannerUtil.pickDispatcher(lhs.plans), rvRangeFromPlan(lp), lhs.plans))
+      PlannerUtil.pickDispatcher(lhs.plans, flightEnabled), rvRangeFromPlan(lp), lhs.plans))
     else lhs.plans
     val rhs = walkLogicalPlanTree(lp.rhs, qContext, forceInProcess)
     val stitchedRhs = if (rhs.needsStitch) Seq(StitchRvsExec(qContext,
-      PlannerUtil.pickDispatcher(rhs.plans), rvRangeFromPlan(lp), rhs.plans))
+      PlannerUtil.pickDispatcher(rhs.plans, flightEnabled), rvRangeFromPlan(lp), rhs.plans))
     else rhs.plans
 
     // TODO Currently we create separate exec plan node for stitching.
@@ -630,7 +620,7 @@ class SingleClusterPlanner(val dataset: Dataset,
     // In theory, more efficient to use transformer than to have separate exec plan node to avoid IO.
     // In the interest of keeping it simple, deferring decorations to the ExecPlan. Add only if needed after measuring.
 
-    val targetActor = forceDispatcher.getOrElse(PlannerUtil.pickDispatcher(stitchedLhs ++ stitchedRhs))
+    val targetActor = forceDispatcher.getOrElse(PlannerUtil.pickDispatcher(stitchedLhs ++ stitchedRhs, flightEnabled))
     val joined = if (lp.operator.isInstanceOf[SetOperator])
       Seq(exec.SetOperatorExec(qContext, targetActor, stitchedLhs, stitchedRhs, lp.operator,
         lp.on.map(LogicalPlanUtils.renameLabels(_, dsOptions.metricColumn)),
@@ -1160,7 +1150,7 @@ class SingleClusterPlanner(val dataset: Dataset,
     var toReduceLevel1 = walkLogicalPlanTree(lp.vectors,
       qContext.copy(plannerParams = qContext.plannerParams.copy(skipAggregatePresent = false)), forceInProcess)
     if (!canPushdownInner) {
-      val dispatcher = PlannerUtil.pickDispatcher(toReduceLevel1.plans)
+      val dispatcher = PlannerUtil.pickDispatcher(toReduceLevel1.plans, flightEnabled)
       val plan = if (toReduceLevel1.needsStitch) {
         StitchRvsExec(qContext, dispatcher, outputRvRange = None, children = toReduceLevel1.plans)
       } else if (toReduceLevel1.plans.size > 1) {

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/SinglePartitionPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/SinglePartitionPlanner.scala
@@ -17,7 +17,8 @@ import filodb.query.exec._
 class SinglePartitionPlanner(planners: Map[String, QueryPlanner],
                              plannerSelector: String => String,
                              val dataset: Dataset,
-                             val queryConfig: QueryConfig)
+                             val queryConfig: QueryConfig,
+                             val flightEnabled: Boolean)
   extends QueryPlanner with DefaultPlanner {
 
   override val schemas: Schemas = Schemas(dataset.schema)

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LongTimeRangePlannerSpec.scala
@@ -57,7 +57,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
   val dataset = MetricsTestData.timeseriesDataset
   val datasetMetricColumn = dataset.options.metricColumn
 
-  val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+  val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
     earliestRawTime, latestDownsampleTime, disp,
     queryConfig, dataset)
   implicit val system: akka.actor.ActorSystem = ActorSystem()
@@ -399,7 +399,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
 
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
@@ -447,7 +447,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       queryConfigWithGrpcEndpoint,
       workUnit = "", buddyWorkUnit = "", clusterName = "", useShardLevelFailover = false)
 
-    val longTimeRangePlanner = new LongTimeRangePlanner(highAvailabilityPlannerRaw, downsamplePlanner,
+    val longTimeRangePlanner = new LongTimeRangePlanner(highAvailabilityPlannerRaw, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfigWithGrpcEndpoint, dataset)
 
     val execPlan = longTimeRangePlanner.materialize(lp, QueryContext(origQueryParams = promQlParams))
@@ -482,7 +482,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
 
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
@@ -517,7 +517,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
 
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
@@ -564,7 +564,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
 
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
@@ -594,7 +594,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
 
@@ -626,7 +626,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
     ep.asInstanceOf[LocalPartitionReduceAggregateExec].dispatcher.isInstanceOf[ActorPlanDispatcher] shouldEqual true
@@ -652,7 +652,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
     ep.asInstanceOf[LocalPartitionReduceAggregateExec].dispatcher.isInstanceOf[ActorPlanDispatcher] shouldEqual true
@@ -678,7 +678,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
     ep.isInstanceOf[StitchRvsExec] shouldEqual true
@@ -706,7 +706,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
 
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
@@ -766,7 +766,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
 
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
@@ -829,7 +829,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
 
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
@@ -932,7 +932,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
                                               queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
 
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
@@ -1019,7 +1019,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
 
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
@@ -1128,7 +1128,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
 
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
@@ -1228,7 +1228,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
 
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
@@ -1327,7 +1327,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
 
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
@@ -1440,7 +1440,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
 
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
@@ -1489,7 +1489,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       earliestRetainedTimestampFn = earliestRawTime, queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
 
     val ep1 = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
@@ -1574,7 +1574,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
       earliestRetainedTimestampFn = earliestRawTime, queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
       earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
 
     val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))
@@ -1643,7 +1643,7 @@ class LongTimeRangePlannerSpec extends AnyFunSpec with Matchers with PlanValidat
         earliestRetainedTimestampFn = earliestRawTime, queryConfig, "raw")
       val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
         earliestRetainedTimestampFn = earliestDownSampleTime, queryConfig, "downsample")
-      val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
+      val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
         earliestRawTime, latestDownsampleTime, disp, queryConfig, dataset)
 
       val ep = longTermPlanner.materialize(logicalPlan, QueryContext(origQueryParams = promQlQueryParams))

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
@@ -84,7 +84,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
         List(PartitionAssignment("local", "local-url", TimeRange(timeRange.startMs, timeRange.endMs), workUnit = "testWorkUnit"))
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("test{job = \"app\"}", TimeStepParams(1000, 100, 2000))
 
     val promQlQueryParams = PromQlQueryParams("test{job = \"app\"}", 1000, 100, 2000)
@@ -118,7 +118,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = twoPartitions(timeRange)
 
     }
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("test{job = \"app\"}", TimeStepParams(startSeconds, step, endSeconds))
 
     val promQlQueryParams = PromQlQueryParams("test{job = \"app\"}", startSeconds, step, endSeconds)
@@ -157,7 +157,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = Nil
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("""absent_over_time(test{job = "app1"}[10m])""",
       TimeStepParams(1000, 100, 10000))
 
@@ -234,7 +234,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = Nil
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("""absent_over_time(test{job = "app1"}[10m])""",
       TimeStepParams(1000, 100, 10000))
 
@@ -270,7 +270,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
         List(PartitionAssignment("local", "local-url", TimeRange(timeRange.startMs, timeRange.endMs), workUnit = "testWorkUnit"))
     }
     val engine = new MultiPartitionPlanner(
-      partitionLocationProvider, localPlanner, "local", dataset, queryConfig
+      partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false
     )
     val lp = Parser.queryRangeToLogicalPlan(
       """test{job = "app"}[9000s:100s]""", TimeStepParams(queryStartSecs, 0, queryStartSecs)
@@ -320,7 +320,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
   //      override def getAuthorizedPartitions(timeRange: TimeRange): List[PartitionAssignment] = twoPartitions()
   //    }
   //    val engine = new MultiPartitionPlanner(
-  //      partitionLocationProvider, localPlanner, "local", dataset, queryConfig
+  //      partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false
   //    )
   //    val lp = Parser.queryRangeToLogicalPlan(
   //      """test{job = "app"}[9000s:100s]""", TimeStepParams(queryStartSecs, 0, queryStartSecs)
@@ -382,7 +382,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
   //      override def getAuthorizedPartitions(timeRange: TimeRange): List[PartitionAssignment] = twoPartitions()
   //    }
   //    val engine = new MultiPartitionPlanner(
-  //      partitionLocationProvider, localPlanner, "local", dataset, queryConfig
+  //      partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false
   //    )
   //    val lp = Parser.queryRangeToLogicalPlan(
   //      """test{job = "app"}[9000s:100s]""", TimeStepParams(queryStartSecs, 0, queryStartSecs)
@@ -434,7 +434,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
     }
 
     val engine = new MultiPartitionPlanner(
-      partitionLocationProvider, localPlanner, "local", dataset, queryConfig
+      partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false
     )
     val query = """(test{job = "app1"} + test{job = "app2"})[9000s:100s]"""
     val lp = Parser.queryRangeToLogicalPlan(
@@ -482,7 +482,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
     }
 
     val engine = new MultiPartitionPlanner(
-      partitionLocationProvider, localPlanner, "local", dataset, queryConfig
+      partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false
     )
     val query = """(test{job = "app1"} + test{job = "app2"})[9000s:100s]"""
     val lp = Parser.queryRangeToLogicalPlan(
@@ -528,7 +528,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
     }
 
     val engine = new MultiPartitionPlanner(
-      partitionLocationProvider, localPlanner, "local", dataset, queryConfig
+      partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false
     )
     val query = """sum((test{job = "app1"} + test{job = "app2"}))[9000s:100s]"""
     val lp = Parser.queryRangeToLogicalPlan(
@@ -579,7 +579,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = onePartition(timeRange)
     }
     val query = "avg_over_time(test{job = \"app\"}[10m:1m])"
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan(query, TimeStepParams(queryStartSecs, step, queryEndSecs), Parser.Antlr)
     val promQlQueryParams = PromQlQueryParams(query, queryStartSecs, step, queryEndSecs)
     val execPlan = engine.materialize(
@@ -613,7 +613,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = onePartition(timeRange)
     }
     val query = "avg_over_time(test{job = \"app\"}[10m:1m])"
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan(query, TimeStepParams(queryStartSecs, stepSecs, queryEndSecs), Parser.Antlr)
     val promQlQueryParams = PromQlQueryParams(query, queryStartSecs, stepSecs, queryEndSecs)
     val execPlan = engine.materialize(
@@ -653,7 +653,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
     }
 
     val query = """avg_over_time((test{job = "app1"} + test{job = "app2"})[10m:1m])"""
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan(query, TimeStepParams(queryStartSecs, stepSecs, queryEndSecs), Parser.Antlr)
     val promQlQueryParams = PromQlQueryParams(query, queryStartSecs, stepSecs, queryEndSecs)
     val execPlan = engine.materialize(
@@ -693,7 +693,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
     }
 
     val query = """min_over_time((sum_over_time(sum(test{job = "app1"})[10m:1m]) + sum_over_time(sum(test{job = "app2"})[10m:1m]))[10m:1m])"""
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan(query, TimeStepParams(queryStartSecs, stepSecs, queryEndSecs), Parser.Antlr)
     val promQlQueryParams = PromQlQueryParams(query, queryStartSecs, stepSecs, queryEndSecs)
     val execPlan = engine.materialize(
@@ -725,7 +725,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
         partitions(timeRange)
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("time()", TimeStepParams(1000, 100, 2000))
 
     val promQlQueryParams = PromQlQueryParams("time()", 1000, 100, 2000)
@@ -745,7 +745,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
         partitions(timeRange)
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("test1{job = \"app\"} + test2{job = \"app\"}",
       TimeStepParams(1000, 100, 2000))
 
@@ -770,7 +770,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = ???
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("test1{job = \"app\"} + test2{job = \"app\"}",
       TimeStepParams(1000, 100, 2000))
 
@@ -796,7 +796,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = ???
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("test1{job = \"app\"} + test2{job = \"app\"}",
       TimeStepParams(1000, 100, 2000))
 
@@ -822,7 +822,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = ???
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("test1{job = \"app\"} + test2{job = \"app\"}",
       TimeStepParams(1000, 100, 2000))
 
@@ -850,7 +850,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = ???
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("test1{job = \"app\"} ",
       TimeStepParams(1000, 100, 2000))
 
@@ -880,7 +880,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = ???
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("test1{job = \"app\"}",
       TimeStepParams(1000, 100, 2000))
 
@@ -912,7 +912,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = ???
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("""absent_over_time(test{job = "app"}[10m])""",
       TimeStepParams(1000, 100, 2000))
 
@@ -966,7 +966,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = ???
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("""sum(absent_over_time(test{job = "app"}[10m])) + 1""",
       TimeStepParams(1000, 100, 2000))
 
@@ -1029,7 +1029,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = ???
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("""test1{job = "app"} + test2{job = "app"}""",
       TimeStepParams(1000, 100, 2000))
 
@@ -1110,7 +1110,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = ???
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("""scalar(test{job = "app"}) + 5""",
       TimeStepParams(1000, 100, 2000))
 
@@ -1170,7 +1170,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = ???
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("""5 + test{job = "app"}""",
       TimeStepParams(1000, 100, 2000))
 
@@ -1228,7 +1228,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = ???
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("""sum(test{job = "app"}) or vector(5)""",
       TimeStepParams(1000, 100, 2000))
 
@@ -1300,7 +1300,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = ???
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("""abs(test{job = "app"})""",
       TimeStepParams(1000, 100, 2000))
 
@@ -1355,7 +1355,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = ???
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("""histogram_quantile(0.9, test{job = "app"})""",
       TimeStepParams(1000, 100, 2000))
 
@@ -1413,7 +1413,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = ???
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("""sort(test{job = "app"})""",
       TimeStepParams(1000, 100, 2000))
 
@@ -1485,7 +1485,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
         partitions(timeRange)
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("test1{job = \"app\"} + test2{job = \"app\"}",
       TimeStepParams(1000, 100, 10000))
 
@@ -1513,7 +1513,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
         partitions(timeRange)
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("test1{job = \"app\"} + test2{job = \"app\"}",
       TimeStepParams(1000, 100, 10000))
 
@@ -1548,7 +1548,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
     val schemas = Schemas(dataset.schema)
     val localPlanner = new SingleClusterPlanner(dataset, schemas, mapperRef, earliestRetainedTimestampFn = 0,
       queryConfig, "raw")
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.metadataQueryToLogicalPlan("http_requests_total{method=\"GET\"}",
       TimeStepParams(startSeconds, step, endSeconds))
 
@@ -1591,7 +1591,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
     val schemas = Schemas(dataset.schema)
     val localPlanner = new SingleClusterPlanner(dataset, schemas, mapperRef, earliestRetainedTimestampFn = 0,
       queryConfig, "raw")
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.metadataQueryToLogicalPlan("http_requests_total{_ws_=\"demo\", method=\"GET\"}",
       TimeStepParams(startSeconds, step, endSeconds))
 
@@ -1630,7 +1630,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
         partitions(timeRange)
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.metadataQueryToLogicalPlan("http_requests_total{job=\"prometheus\", method=\"GET\"}",
       TimeStepParams(startSeconds, step, endSeconds))
 
@@ -1679,7 +1679,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
             thirdPartitionStart * 1000 - 1), workUnit = "testWorkUnit"),
           PartitionAssignment("local", "local-url", TimeRange(thirdPartitionStart * 1000, endSeconds * 1000), workUnit = "testWorkUnit"))
     }
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("test{job = \"app\"}", TimeStepParams(startSeconds, step, endSeconds))
     val promQlQueryParams = PromQlQueryParams("test{job = \"app\"}", startSeconds, step, endSeconds)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams,  plannerParams =
@@ -1723,7 +1723,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
           localPartitionStartSec * 1000 - 1), workUnit = "testWorkUnit"), PartitionAssignment("local", "local-url",
           TimeRange(localPartitionStartSec * 1000, endSeconds * 1000), workUnit = "testWorkUnit"))
     }
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("test{job = \"app\"}[100s]", TimeStepParams(startSeconds, step, endSeconds))
 
     val promQlQueryParams = PromQlQueryParams("test{job = \"app\"}[100s]", startSeconds, step, endSeconds)
@@ -1769,7 +1769,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
   //          TimeRange(localPartitionStartMs, endSeconds * 1000)))
   //
   //    }
-  //    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+  //    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
   //    val lp = Parser.queryRangeToLogicalPlan("test{job = \"app\"}", TimeStepParams(startSeconds, step, endSeconds))
   //
   //    val promQlQueryParams = PromQlQueryParams("test{job = \"app\"}", startSeconds, step, endSeconds)
@@ -1816,7 +1816,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
         partitions(timeRange)
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
 
     val lp = Parser.labelValuesQueryToLogicalPlan(Seq("""__metric__"""), Some("""_ws_="demo""""), TimeStepParams(startSeconds, step, endSeconds) )
 
@@ -1856,7 +1856,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
     }
 
     val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local",
-      dataset, queryConfig)
+      dataset, queryConfig, false)
     val lp = TsCardinalities(Seq("a", "b"), 3, Seq("longtime-prometheus","recordingrules-prometheus_rules_1m")
       , "raw,recordingrules")
     val promQlQueryParams = PromQlQueryParams("", startSeconds, step, endSeconds,
@@ -1891,7 +1891,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
         partitions(timeRange)
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("""test1{job = "app1"} + test2{job = "app2"}""",
       TimeStepParams(1000, 100, 10000))
 
@@ -1920,7 +1920,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
         List.empty
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("test{job = \"app\"}", TimeStepParams(1000, 100, 2000))
 
     val promQlQueryParams = PromQlQueryParams("test{job = \"app\"}", 1000, 100, 2000)
@@ -1944,7 +1944,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
         List.empty
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
 
     val lp = Parser.labelValuesQueryToLogicalPlan(Seq("""__metric__"""), Some("""_ws_="demo""""), TimeStepParams(startSeconds, step, endSeconds) )
 
@@ -1964,7 +1964,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = List.empty
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.metadataQueryToLogicalPlan("http_requests_total{job=\"prometheus\", method=\"GET\"}",
       TimeStepParams(startSeconds, step, endSeconds))
 
@@ -2000,7 +2000,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
           TimeRange(localPartitionStartMs, endSeconds * 1000), workUnit = "testWorkUnit"))
 
     }
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("test{job = \"app\"}", TimeStepParams(startSeconds, step, endSeconds))
 
     val promQlQueryParams = PromQlQueryParams("test{job = \"app\"}", startSeconds, step, endSeconds)
@@ -2027,7 +2027,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
         partitions(timeRange)
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     (startSeconds, endSeconds, engine)
   }
 
@@ -2140,7 +2140,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
         partitions(timeRange)
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("""ln(test1{job = "app1"} + test2{job = "app2"})""",
       TimeStepParams(1000, 100, 10000))
 
@@ -2193,7 +2193,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
         partitions(timeRange)
     }
 
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("""absent(test1{job = "app1"} and test2{job = "app2"})""",
       TimeStepParams(1000, 100, 10000))
 
@@ -2243,7 +2243,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
     val query =
       """sum(test1{job = "app1"}) * sum(test2{job = "app1"}) +
         |ln(sum(test3{job = "app2"}) + sum(test4{job = "app3"}))""".stripMargin
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan(query, TimeStepParams(1000, 100, 10000))
 
     val promQlQueryParams = PromQlQueryParams(query, 1000, 100, 10000)
@@ -2308,7 +2308,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
     val query =
       """sum(test1{job = "app1"}) * sum(test2{job = "app1"}) +
         |ln(sum(test3{job = "app2"}) + sum(test4{job = "app2"}))""".stripMargin
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan(query, TimeStepParams(1000, 100, 10000))
 
     val promQlQueryParams = PromQlQueryParams(query, 1000, 100, 10000)
@@ -2367,7 +2367,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
     val query =
       """sum(test1{job = "app2"}) * sum(test2{job = "app2"}) +
         |ln(sum(test3{job = "app2"}) + sum(test4{job = "app2"}))""".stripMargin.replaceAll("\n", "")
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan(query, TimeStepParams(1000, 100, 10000))
 
     val promQlQueryParams = PromQlQueryParams(query, 1000, 100, 10000)
@@ -2402,7 +2402,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
         partitions(timeRange)
     }
 
-    val mpPlanner = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val mpPlanner = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
 
     val localPlan = LabelCardinality(Seq(ColumnFilter("job", Equals("app1")), ColumnFilter("__name__", Equals("test"))),
       startSeconds * 1000, endSeconds * 1000)
@@ -2484,7 +2484,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
          |-----E~MultiSchemaPartitionsExec(dataset=timeseries, shard=19, chunkMethod=TimeRangeChunkScan(7300000,10000000), filters=List(ColumnFilter(job,Equals(app)), ColumnFilter(__name__,Equals(test))), colName=None, schema=None) on ActorPlanDispatcher(Actor[akka://default/system/testProbe-1#885676802],raw)""".stripMargin
 
     val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local",
-      dataset, queryConfig.copy(routingConfig = queryConfig.routingConfig.copy(supportRemoteRawExport = true)))
+      dataset, queryConfig.copy(routingConfig = queryConfig.routingConfig.copy(supportRemoteRawExport = true)), false)
     val query1 = "sum(rate(test{job = \"app\"}[10m]))"
     val lp1 = Parser.queryRangeToLogicalPlan(query1, TimeStepParams(1000, stepSecs, 10000))
 
@@ -2571,7 +2571,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
     val engine1 = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local",
       dataset, queryConfig.copy(routingConfig = queryConfig.routingConfig.copy(
         supportRemoteRawExport = true,
-        periodOfUncertaintyMs = 3000)))
+        periodOfUncertaintyMs = 3000)), false)
     val lp5 = Parser.queryRangeToLogicalPlan(query1, TimeStepParams(1000, 400, 10000))
     val promQlQueryParam5 = PromQlQueryParams(query1, 1000, 400, 10000)
 
@@ -2587,7 +2587,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getPartitions(routingKey: Map[String, String], timeRange: TimeRange): List[PartitionAssignment] = ???
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = ???
     }
-    val mpp = new MultiPartitionPlanner(dummyPartitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val mpp = new MultiPartitionPlanner(dummyPartitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
     val lp = Parser.queryRangeToLogicalPlan("""foo{job=~"abc|def"} + foo{job="ghi"}""", TimeStepParams(1000, 100, 2000))
     val expected = Set(Map("job" -> "abc"), Map("job" -> "def"), Map("job" -> "ghi"))
     mpp.getRoutingKeys(lp) shouldEqual expected
@@ -2606,7 +2606,8 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
         localPlanner,
         "local",
         dataset,
-        qc
+        qc,
+        false
       )
     }
 
@@ -2701,7 +2702,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       }
       override def getMetadataPartitions(nonMetricShardKeyFilters: scala.Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = ???
     }
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
 
     for (query <- queries) {
       val lp = Parser.queryRangeToLogicalPlan(query, TimeStepParams(1000, 100, 10000))
@@ -2728,7 +2729,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
         List(PartitionAssignment("remote", "remote-url", TimeRange(1000 * 1000, 10000 * 1000), None, "testWorkUnit"))
       }
     }
-    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig, false)
 
     for (query <- queries) {
       val lp = Parser.metadataQueryToLogicalPlan(query, TimeStepParams(1000, 100, 10000))

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/PlannerHierarchySpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/PlannerHierarchySpec.scala
@@ -59,14 +59,13 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
       earliestRetainedTimestampFn = now - rawRetention, queryConfig, "raw")
     val downsamplePlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = now - downsampleRetention, queryConfig, "downsample")
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner,
-      earliestRawTimestampFn = now - rawRetention, latestDownsampleTimestampFn = now - timeToDownsample,
-      inProcessDispatcher, queryConfig, dataset)
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false,
+      now - rawRetention, now - timeToDownsample, inProcessDispatcher, queryConfig, dataset)
     val recordingRulesPlanner = new SingleClusterPlanner(dataset, schemas, mapperRef,
       earliestRetainedTimestampFn = now - rrRetention,
       queryConfig, "recordingRules")
     val planners = Map("longTerm" -> longTermPlanner, "recordingRules" -> recordingRulesPlanner)
-    val singlePartitionPlanner = new SinglePartitionPlanner(planners, plannerSelector, dataset, queryConfig)
+    val singlePartitionPlanner = new SinglePartitionPlanner(planners, plannerSelector, dataset, queryConfig, false)
     Planners(singlePartitionPlanner, longTermPlanner, rawPlanner, downsamplePlanner, recordingRulesPlanner)
   }
 
@@ -113,9 +112,9 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
   }
 
   val oneRemoteMultiPartitionPlanner = new MultiPartitionPlanner(oneRemotePartitionLocationProvider, singlePartitionPlanner,
-    "localPartition", dataset, queryConfig)
+    "localPartition", dataset, queryConfig, false)
   val twoRemoteMultiPartitionPlanner = new MultiPartitionPlanner(twoRemotePartitionLocationProvider, singlePartitionPlanner,
-    "localPartition", dataset, queryConfig)
+    "localPartition", dataset, queryConfig, false)
 
   private val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
     // we may have mixed of a regex filter and a non-regex filter.
@@ -177,9 +176,9 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
 
   private val targetSchemaProvider = StaticTargetSchemaProvider()
 
-  val rootPlanner = new ShardKeyRegexPlanner(dataset, oneRemoteMultiPartitionPlanner, shardKeyMatcherFn, oneRemotePartitionLocationProvider, queryConfig)
-  val oneRemoteRootPlanner = new ShardKeyRegexPlanner(dataset, oneRemoteMultiPartitionPlanner, oneRemoteShardKeyMatcherFn, oneRemotePartitionLocationProvider, queryConfig)
-  val twoRemoteRootPlanner = new ShardKeyRegexPlanner(dataset, twoRemoteMultiPartitionPlanner, twoRemoteShardKeyMatcherFn, twoRemotePartitionLocationProvider, queryConfig)
+  val rootPlanner = new ShardKeyRegexPlanner(dataset, oneRemoteMultiPartitionPlanner, shardKeyMatcherFn, oneRemotePartitionLocationProvider, queryConfig, false)
+  val oneRemoteRootPlanner = new ShardKeyRegexPlanner(dataset, oneRemoteMultiPartitionPlanner, oneRemoteShardKeyMatcherFn, oneRemotePartitionLocationProvider, queryConfig, false)
+  val twoRemoteRootPlanner = new ShardKeyRegexPlanner(dataset, twoRemoteMultiPartitionPlanner, twoRemoteShardKeyMatcherFn, twoRemotePartitionLocationProvider, queryConfig, false)
 
 
   private val startSeconds = now / 1000 - 10.days.toSeconds
@@ -2487,7 +2486,7 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
     }
     val engine = new MultiPartitionPlanner(
       partitionLocationProvider, singlePartitionPlanner, "local",
-      MetricsTestData.timeseriesDataset, queryConfig
+      MetricsTestData.timeseriesDataset, queryConfig, false
     )
     for (test <- tests) {
       val lp = Parser.queryRangeToLogicalPlan(test.query, TimeStepParams(startSec, stepSec, endSec))
@@ -2701,7 +2700,7 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
     }
     val engine = new MultiPartitionPlanner(
       partitionLocationProvider, singlePartitionPlanner, "local",
-      MetricsTestData.timeseriesDataset, queryConfig
+      MetricsTestData.timeseriesDataset, queryConfig, false
     )
     for (test <- tests) {
       val lp = Parser.queryRangeToLogicalPlan(test.query, TimeStepParams(startSec, stepSec, endSec))
@@ -2766,7 +2765,7 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
       MetricsTestData.timeseriesDataset, queryConfig.copy(routingConfig = queryConfig.routingConfig.copy(
         supportRemoteRawExport = true,
         maxRemoteRawExportTimeRange = Duration(3, TimeUnit.DAYS),
-        periodOfUncertaintyMs = 3000)))
+        periodOfUncertaintyMs = 3000)), false)
 
     val lp = Parser.queryRangeToLogicalPlan(query, TimeStepParams(startSec, stepSec, endSec))
     val promQlQueryParams = PromQlQueryParams(query, startSec, stepSec, endSec)
@@ -2803,7 +2802,7 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
       MetricsTestData.timeseriesDataset, queryConfig.copy(routingConfig = queryConfig.routingConfig.copy(
         supportRemoteRawExport = true,
         maxRemoteRawExportTimeRange = Duration(3, TimeUnit.DAYS),
-        periodOfUncertaintyMs = 3000)))
+        periodOfUncertaintyMs = 3000)), false)
 
     val lp = Parser.queryRangeToLogicalPlan(query, TimeStepParams(startSec, stepSec, endSec))
     val promQlQueryParams = PromQlQueryParams(query, startSec, stepSec, endSec)
@@ -2838,7 +2837,7 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
       MetricsTestData.timeseriesDataset, queryConfig.copy(routingConfig = queryConfig.routingConfig.copy(
         supportRemoteRawExport = true,
         maxRemoteRawExportTimeRange = Duration(3, TimeUnit.DAYS),
-        periodOfUncertaintyMs = 3000)))
+        periodOfUncertaintyMs = 3000)), false)
 
     val lp = Parser.queryRangeToLogicalPlan(query, TimeStepParams(startSec, stepSec, endSec))
     val promQlQueryParams = PromQlQueryParams(query, startSec, stepSec, endSec)
@@ -2955,7 +2954,7 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
       MetricsTestData.timeseriesDataset, queryConfig.copy(routingConfig = queryConfig.routingConfig.copy(
         supportRemoteRawExport = true,
         maxRemoteRawExportTimeRange = Duration(3, TimeUnit.DAYS),
-        periodOfUncertaintyMs = 3000)))
+        periodOfUncertaintyMs = 3000)), false)
 
     for (test <- tests) {
       val lp = Parser.queryRangeToLogicalPlan(test.query, TimeStepParams(startSec, stepSec, endSec))
@@ -3032,8 +3031,8 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
       override def getMetadataPartitions(nonMetricShardKeyFilters: Seq[ColumnFilter], timeRange:  TimeRange): List[PartitionAssignment] = ???
 }
     val grpcRemoteMultiPartitionPlanner = new MultiPartitionPlanner(gRpcRemotePartitionLocationProvider, singlePartitionPlanner,
-      "localPartition", dataset, queryConfig)
-    val gRpcRemoteRootPlanner = new ShardKeyRegexPlanner(dataset, grpcRemoteMultiPartitionPlanner, shardKeyMatcherFn, gRpcRemotePartitionLocationProvider, queryConfig)
+      "localPartition", dataset, queryConfig, false)
+    val gRpcRemoteRootPlanner = new ShardKeyRegexPlanner(dataset, grpcRemoteMultiPartitionPlanner, shardKeyMatcherFn, gRpcRemotePartitionLocationProvider, queryConfig, false)
 
     val query4 = """topk(2, test{_ws_ = "demo", _ns_ =~ ".*Ns", instance = "Inst-1"})"""
     val lp4 = Parser.queryRangeToLogicalPlan(query4, TimeStepParams(startSeconds, step, endSeconds), Antlr)
@@ -3138,8 +3137,8 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
     }
 
     val twoGrpcRemoteMpPlanner = new MultiPartitionPlanner(twoRemoteGrpcPartitionLocationProvider, singlePartitionPlanner,
-      "localPartition", dataset, queryConfig)
-    val twoGrpcRemoteShardKeyRegexPlanner = new ShardKeyRegexPlanner(dataset, twoGrpcRemoteMpPlanner, twoRemoteShardKeyMatcherFn, twoRemoteGrpcPartitionLocationProvider, queryConfig)
+      "localPartition", dataset, queryConfig, false)
+    val twoGrpcRemoteShardKeyRegexPlanner = new ShardKeyRegexPlanner(dataset, twoGrpcRemoteMpPlanner, twoRemoteShardKeyMatcherFn, twoRemoteGrpcPartitionLocationProvider, queryConfig, false)
 
     val query8 = """topk(2, test{_ws_ = "demo", _ns_ =~ "remoteNs.*", instance = "Inst-1"})"""
     val lp8 =
@@ -3172,8 +3171,8 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
     }
 
     val twoRemoteMpPlanner = new MultiPartitionPlanner(twoRemotePartitionLocationProvider, twoRemoteMultiPartitionPlanner,
-      "localPartition", dataset, queryConfig)
-    val oneRemoteShardKeyRegexPlanner = new ShardKeyRegexPlanner(dataset, twoRemoteMpPlanner, twoRemoteShardKeyMatcherFn, twoRemotePartitionLocationProvider, queryConfig)
+      "localPartition", dataset, queryConfig, false)
+    val oneRemoteShardKeyRegexPlanner = new ShardKeyRegexPlanner(dataset, twoRemoteMpPlanner, twoRemoteShardKeyMatcherFn, twoRemotePartitionLocationProvider, queryConfig, false)
     val query9 = """topk(2, test{_ws_ = "demo", _ns_ =~ "remoteNs.*", instance = "Inst-1"})"""
     val lp9 =
       Parser.queryRangeToLogicalPlan(query9, TimeStepParams(startSeconds, step, endSeconds), Antlr)
@@ -3195,9 +3194,9 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
 
     val twoGrpcRemoteMpPlannerNoGrpc = new MultiPartitionPlanner(twoRemoteGrpcPartitionLocationProvider, singlePartitionPlanner,
       "localPartition", dataset,
-      queryConfig.copy(grpcPartitionsDenyList = Set("remotepartition1")))
+      queryConfig.copy(grpcPartitionsDenyList = Set("remotepartition1")), false)
     val twoGrpcRemoteShardKeyRegexPlannerNoGrpc =
-      new ShardKeyRegexPlanner(dataset, twoGrpcRemoteMpPlannerNoGrpc, twoRemoteShardKeyMatcherFn, twoRemoteGrpcPartitionLocationProvider, queryConfig)
+      new ShardKeyRegexPlanner(dataset, twoGrpcRemoteMpPlannerNoGrpc, twoRemoteShardKeyMatcherFn, twoRemoteGrpcPartitionLocationProvider, queryConfig, false)
 
     val query10 = """sum(test{_ws_ = "demo", _ns_ =~ "remoteNs.*", instance = "Inst-1"})"""
     val lp10 =
@@ -3855,8 +3854,8 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
       }
 
       val spp = getPlanners(2, dataset).spp
-      val multiPartitionPlanner = new MultiPartitionPlanner(partitionLocationProvider, spp, "local", dataset, queryConfig)
-      val shardKeyRegexPlanner = new ShardKeyRegexPlanner(dataset, multiPartitionPlanner, shardKeyMatcherFunc, partitionLocationProvider, queryConfig, targetSchemaProvider)
+      val multiPartitionPlanner = new MultiPartitionPlanner(partitionLocationProvider, spp, "local", dataset, queryConfig, false)
+      val shardKeyRegexPlanner = new ShardKeyRegexPlanner(dataset, multiPartitionPlanner, shardKeyMatcherFunc, partitionLocationProvider, queryConfig, false, targetSchemaProvider)
 
       val tschema = FunctionalTargetSchemaProvider(tschemaProviderFunc)
 
@@ -3985,8 +3984,8 @@ class PlannerHierarchySpec extends AnyFunSpec with Matchers with PlanValidationS
                      |--E~PromQlRemoteExec(PromQlQueryParams(sum(my_cool_metric{_ws_="demo",_ns_=~"i-part2|j-part2"}),1633913330,300,1634777330,None,false), PlannerParams(filodb,None,None,None,None,60000,PerQueryLimits(1000000,1000000,18000000,100000,100000,300000000,1000000,200000000),PerQueryLimits(50000,1000000,15000000,50000,50000,150000000,500000,100000000),None,None,None,false,86400000,86400000,true,true,false,false,true,2,false,true,TreeSet(),LegacyFailoverMode,None,None,None,None), queryEndpoint=part2-url, requestTimeoutMs=10000) on InProcessPlanDispatcher(QueryConfig(10 seconds,300000,1,50,antlr,true,true,None,Some(10000),None,None,25,true,false,true,Set(),Some(plannerSelector),Map(filodb-query-exec-metadataexec -> 65536, filodb-query-exec-aggregate-large-container -> 65536),RoutingConfig(false,1800000 milliseconds,true,0)))""".stripMargin
 
     val spp = getPlanners(2, dataset).spp
-    val multiPartitionPlanner = new MultiPartitionPlanner(partitionLocationProvider, spp, "part1", dataset, queryConfig)
-    val shardKeyRegexPlanner = new ShardKeyRegexPlanner(dataset, multiPartitionPlanner, shardKeyMatcherFunc, partitionLocationProvider, queryConfig, targetSchemaProvider)
+    val multiPartitionPlanner = new MultiPartitionPlanner(partitionLocationProvider, spp, "part1", dataset, queryConfig, false)
+    val shardKeyRegexPlanner = new ShardKeyRegexPlanner(dataset, multiPartitionPlanner, shardKeyMatcherFunc, partitionLocationProvider, queryConfig, false, targetSchemaProvider)
 
     val lp = Parser.queryRangeToLogicalPlan(query, timeParams)
     val context = QueryContext(

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/ShardKeyRegexPlannerSpec.scala
@@ -65,7 +65,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
   }
   val c = QueryConfig(config).copy(plannerSelector = Some("plannerSelector"))
   val mpp = new MultiPartitionPlanner(
-    mppPartitionLocationProvider, localPlanner, "local", dataset, c
+    mppPartitionLocationProvider, localPlanner, "local", dataset, c, false
   )
   val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
     Seq(
@@ -79,14 +79,14 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       )
     )
   }
-  val skrp = new ShardKeyRegexPlanner(dataset, mpp, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+  val skrp = new ShardKeyRegexPlanner(dataset, mpp, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
 
   it("should generate Exec plan for simple query") {
     val lp = Parser.queryToLogicalPlan("test{_ws_ = \"demo\", _ns_ =~ \"App.*\", instance = \"Inst-1\" }", 1000, 1000)
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-2"))))}
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[MultiPartitionDistConcatExec] shouldEqual(true)
     execPlan.children(0).children.head.isInstanceOf[MultiSchemaPartitionsExec]
@@ -101,7 +101,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-2"))))}
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = PromQlQueryParams(
       """test{_ns_ =~ "App.*", instance = "Inst-1" }""", 100, 1, 1000)))
     println(execPlan.printTree())
@@ -121,7 +121,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-2"))))}
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
 
     val nonMetricShardColumns = dataset.options.nonMetricShardColumns
     val implicitLp = Parser.queryToLogicalPlan("test{_ns_ =~ \"App.*\", instance = \"Inst-1\" }", 1000, 1000)
@@ -149,7 +149,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       1000, 1000
     )
 
-    val engine = new ShardKeyRegexPlanner(dataset, mpp, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, mpp, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(
       lp,
       QueryContext(origQueryParams = promQlQueryParams, plannerParams = PlannerParams(processMultiPartition = true))
@@ -167,7 +167,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-2"))))}
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[MultiPartitionDistConcatExec] shouldEqual(true)
     execPlan.children(0).children.head.isInstanceOf[MultiSchemaPartitionsExec]
@@ -185,7 +185,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-2"))))}
-    val engine = new ShardKeyRegexPlanner( dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner( dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = PromQlQueryParams("sum(heap_usage)", 100, 1,
       1000)))
     execPlan.isInstanceOf[MultiPartitionReduceAggregateExec] shouldEqual(true)
@@ -221,7 +221,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-2"))))}
-    val engine = new ShardKeyRegexPlanner( dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner( dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = PromQlQueryParams("sum(heap_usage)", 100, 1,
       1000)))
     execPlan.isInstanceOf[MultiPartitionReduceAggregateExec] shouldEqual(true)
@@ -235,7 +235,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
   it("should generate Exec plan for time()") {
     val lp = Parser.queryToLogicalPlan("time()", 1000, 1000)
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq((Seq.empty)) }
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[TimeScalarGeneratorExec] shouldEqual(true)
   }
@@ -246,7 +246,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-2"))))}
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = PromQlQueryParams(
     """1 + test{_ws_ = \"demo\",_ns_ =~ \"App.*\", instance = \"Inst-1\" }""", 100, 1, 1000)))
     execPlan.isInstanceOf[MultiPartitionDistConcatExec] shouldEqual(true)
@@ -271,7 +271,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-2"))))}
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams =
       PromQlQueryParams("""test1{_ws_="demo",_ns_="App"} + test2{_ws_="demo",_ns_="App"}""".stripMargin, 100,1, 1000)))
     execPlan.isInstanceOf[BinaryJoinExec] shouldEqual(true)
@@ -285,7 +285,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-2"))))}
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[PartKeysDistConcatExec] shouldEqual (true)
   }
@@ -296,7 +296,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-2"))))}
-    val engine = new ShardKeyRegexPlanner( dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner( dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[MultiPartitionReduceAggregateExec] shouldEqual(true)
     execPlan.asInstanceOf[MultiPartitionReduceAggregateExec].rangeVectorTransformers(0).
@@ -330,7 +330,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-2"))))}
-    val engine = new ShardKeyRegexPlanner( dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner( dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[MultiPartitionReduceAggregateExec] shouldEqual(true)
     execPlan.asInstanceOf[MultiPartitionReduceAggregateExec].rangeVectorTransformers(0).
@@ -362,7 +362,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val lp = Parser.queryToLogicalPlan("""test{_ws_ = "demo", _ns_ = "App-1" }""", 1000, 1000)
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-1"))))}
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[LocalPartitionDistConcatExec] shouldEqual(true)
     execPlan.children(1).isInstanceOf[MultiSchemaPartitionsExec]
@@ -383,7 +383,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
               ColumnFilter("_ns_", Equals("App-2"))))
       } else Nil
     }
-    val engine = new ShardKeyRegexPlanner( dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner( dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[TimeScalarGeneratorExec] shouldEqual(true)
     execPlan.rangeVectorTransformers.head.isInstanceOf[ScalarOperationMapper] shouldEqual true
@@ -407,7 +407,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
 
   it ("should generate Exec plan for Metadata Label values query") {
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => Seq.empty
-    val engine = new ShardKeyRegexPlanner( dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner( dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val lp = Parser.labelValuesQueryToLogicalPlan(Seq("""__metric__"""), Some("""_ws_="demo", _ns_=~".*" """),
       TimeStepParams(1000, 20, 5000) )
 
@@ -422,7 +422,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
 
   it ("should generate ExecPlan for TsCardinalities") {
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => Nil
-    val engine = new ShardKeyRegexPlanner( dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner( dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val lp = TsCardinalities(Seq("ws_foo", "ns_bar"), 3)
     val promQlQueryParams = PromQlQueryParams(
       "", 1000, 20, 5000, Some("/api/v1/metering/cardinality/timeseries"))
@@ -439,7 +439,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-2"))))}
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[BinaryJoinExec] shouldEqual(true)
     execPlan.children(0).isInstanceOf[MultiPartitionDistConcatExec] shouldEqual(true)
@@ -468,7 +468,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => { Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-1"))), Seq(ColumnFilter("_ws_", Equals("demo")),
       ColumnFilter("_ns_", Equals("App-2"))))}
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[BinaryJoinExec] shouldEqual(true)
     execPlan.children(0).isInstanceOf[MultiPartitionDistConcatExec] shouldEqual(true)
@@ -500,7 +500,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
         Seq(shardColumnFilters)
       }
     }
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[BinaryJoinExec] shouldEqual (true)
     execPlan.children(0).isInstanceOf[LocalPartitionDistConcatExec] shouldEqual (true)
@@ -522,7 +522,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
         ColumnFilter("_ns_", Equals("App-1"))))
     }
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual (true)
   }
@@ -536,7 +536,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
           Seq(ColumnFilter("_ws_", Equals("demo")),
             ColumnFilter("_ns_", Equals("App-2"))))
       }
-      val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+      val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
       val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
       execPlan.isInstanceOf[MultiPartitionReduceAggregateExec] shouldEqual true
     }
@@ -549,7 +549,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
         ColumnFilter("_ns_", Equals("App-1"))))
     }
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual (true)
     execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].rangeVectorTransformers(0).
@@ -575,7 +575,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
         ColumnFilter("_ns_", Equals("App"))))
     }
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[BinaryJoinExec] shouldEqual (true)
     execPlan.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl shouldEqual
@@ -590,7 +590,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       Seq(Seq(ColumnFilter("_ws_", Equals("demo")),
         ColumnFilter("_ns_", Equals("App"))))
     }
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[BinaryJoinExec] shouldEqual (true)
     execPlan.queryContext.origQueryParams.asInstanceOf[PromQlQueryParams].promQl shouldEqual
@@ -609,7 +609,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
         )
       )
     }
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual true
     execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].aggrOp shouldEqual Sum
@@ -643,7 +643,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
         ColumnFilter("_ns_", Equals("App1")))
       )
     }
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     // Since we resolve to just one namespace, the entire plan should be materialized by the wrapped planner
     execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual true
@@ -665,7 +665,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
         ColumnFilter("_ns_", Equals("App1")))
       )
     }
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(
       origQueryParams = PromQlQueryParams("""test1{_ws_="demo",_ns_="App-1"} + test2{_ws_="demo",_ns_="App-1"}""",
         100, 1, 1000)))
@@ -688,7 +688,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => Seq(shardColumnFilters)
 
     // Top level plan to be done in-process, both left & right operations will be executed by the wrapped query planner
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[BinaryJoinExec] shouldEqual true
     val inJoin = execPlan.asInstanceOf[BinaryJoinExec]
@@ -716,7 +716,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       )
     }
 
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[MultiPartitionDistConcatExec] shouldEqual (true)
     // Since we get data from multiple partitions, the dispatcher will be in process
@@ -751,7 +751,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
         )
       )
     }
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[MultiPartitionDistConcatExec] shouldEqual (true)
     // Since the dispatcher is ActorDispatcher, its materialized by the underlying queryPlanner
@@ -776,7 +776,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       1000, 1000)
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => Seq(shardColumnFilters)
 
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams =
       PromQlQueryParams("""ln(test1{_ws_="demo",_ns_="App-1"})""", 100, 1, 1000)))
     execPlan.isInstanceOf[LocalPartitionDistConcatExec] shouldEqual (true)
@@ -797,7 +797,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       1000, 1000)
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => Seq(shardColumnFilters)
 
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams =
       PromQlQueryParams("""sum(ln(test1{_ws_="demo",_ns_="App-1"}))""", 100, 1, 1000)))
     execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual (true)
@@ -826,7 +826,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       )
     }
 
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     execPlan.isInstanceOf[MultiPartitionDistConcatExec] shouldEqual (true)
     execPlan.dispatcher.isInstanceOf[InProcessPlanDispatcher] shouldEqual (true)
@@ -863,7 +863,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       )
     }
 
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
 
     execPlan.isInstanceOf[MultiPartitionDistConcatExec] shouldEqual (true)
@@ -902,7 +902,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       )
     }
 
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     // val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
 
@@ -946,7 +946,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       )
     }
 
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
 
     execPlan.isInstanceOf[LocalPartitionReduceAggregateExec] shouldEqual (true)
@@ -984,7 +984,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
         ColumnFilter("_ns_", Equals("App-1"))))
     }
 
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams =
       PromQlQueryParams("""absent(foo{_ws_="Demo", _ns_ =~ "App-1"} , "foo", "," "instance", "job")""",
         100, 1, 1000)))
@@ -1003,7 +1003,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       1000, 1000)
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => Seq(shardColumnFilters)
 
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams =
       PromQlQueryParams("""vector(scalar(sum(foo{_ws_="demo",_ns_="App-1"})))""", 100, 1, 1000)))
 
@@ -1034,7 +1034,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       )
     }
 
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
     val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
 
     // Entre Plan should be materialized on the wrapped
@@ -1069,7 +1069,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
         Seq(Seq(ColumnFilter("_ns_", Equals("App-1")), ColumnFilter("_ws_", Equals("demo"))))
       }
-      val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+      val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
       val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
       execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].rangeVectorTransformers.head
         .asInstanceOf[AbsentFunctionMapper].columnFilter.isEmpty shouldEqual true
@@ -1081,7 +1081,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
         Seq(Seq(ColumnFilter("_ns_", Equals("App-1")), ColumnFilter("_ws_", Equals("demo"))))
       }
-      val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+      val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
       val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
       execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].rangeVectorTransformers.head
         .asInstanceOf[AbsentFunctionMapper].columnFilter.isEmpty shouldEqual true
@@ -1094,7 +1094,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
         Seq(Seq(ColumnFilter("_ns_", Equals("App-1")), ColumnFilter("_ws_", Equals("demo"))))
       }
-      val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+      val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
       val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
       execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].rangeVectorTransformers.head
         .asInstanceOf[AbsentFunctionMapper].columnFilter.size shouldEqual 4 // _ws_, _ns_, __name__ & instance
@@ -1106,7 +1106,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
         Seq(Seq(ColumnFilter("_ns_", Equals("App-1")), ColumnFilter("_ws_", Equals("demo"))))
       }
-      val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+      val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
       val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
       execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].rangeVectorTransformers.head
         .asInstanceOf[AbsentFunctionMapper].columnFilter.size shouldEqual 4 // _ws_, _ns_, __name__ & instance
@@ -1119,7 +1119,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
         Seq(Seq(ColumnFilter("_ns_", Equals("App-1")), ColumnFilter("_ws_", Equals("demo"))))
       }
-      val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+      val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
       val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
       execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].rangeVectorTransformers.head
         .asInstanceOf[AbsentFunctionMapper].columnFilter.size shouldEqual 4 // _ws_, _ns_, __name__ & instance
@@ -1131,7 +1131,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
       val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
         Seq(Seq(ColumnFilter("_ns_", Equals("App-1")), ColumnFilter("_ws_", Equals("demo"))))
       }
-      val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+      val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
       val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams))
       execPlan.asInstanceOf[LocalPartitionReduceAggregateExec].rangeVectorTransformers.head
         .asInstanceOf[AbsentFunctionMapper].columnFilter.size shouldEqual 4 // _ws_, _ns_, __name__ & instance
@@ -1170,7 +1170,7 @@ class ShardKeyRegexPlannerSpec extends AnyFunSpec with Matchers with ScalaFuture
     val shardKeyMatcherFn = (shardColumnFilters: Seq[ColumnFilter]) => {
       Seq(Seq(ColumnFilter("_ns_", Equals("App-1")), ColumnFilter("_ws_", Equals("demo"))))
     }
-    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig)
+    val engine = new ShardKeyRegexPlanner(dataset, localPlanner, shardKeyMatcherFn, simplePartitionLocationProvider, queryConfig, false)
 
     queryExpectedPairs.foreach{ case (query, expected) =>
       val lp = Parser.queryToLogicalPlan(query, 1000, 1000)

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/SinglePartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/SinglePartitionPlannerSpec.scala
@@ -87,7 +87,7 @@ class SinglePartitionPlannerSpec extends AnyFunSpec with Matchers {
     else if (metricName.equals("rr2")) "rules2" else "local"
   }
 
-  val engine = new SinglePartitionPlanner(planners, plannerSelector, dataset, queryConfig)
+  val engine = new SinglePartitionPlanner(planners, plannerSelector, dataset, queryConfig, false)
 
   it("should generate Exec plan for simple query") {
     val lp = Parser.queryToLogicalPlan("test{job = \"app\"}", 1000, 1000)
@@ -175,12 +175,12 @@ class SinglePartitionPlannerSpec extends AnyFunSpec with Matchers {
     val downsamplePlanner = new SingleClusterPlanner(
       dataset, schemas, localMapper, earliestRetainedTimestampFn = 0, queryConfig, "downsample")
 
-    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, 0, 0,
+    val longTermPlanner = new LongTimeRangePlanner(rawPlanner, downsamplePlanner, false, 0, 0,
       InProcessPlanDispatcher(QueryConfig.unitTestingQueryConfig), queryConfig, dataset)
 
     val planners = Map("longtime" -> longTermPlanner, "rules1" -> rrPlanner1, "rules2" -> rrPlanner2)
 
-    val engine = new SinglePartitionPlanner(planners, plannerSelector, dataset, queryConfig)
+    val engine = new SinglePartitionPlanner(planners, plannerSelector, dataset, queryConfig, false)
     val lp = TsCardinalities(Seq("a", "b"), 2, Seq("longtime", "rules1", "rules2"))
 
     // Plan should just contain a single root TsCardReduceExec and its TsCardExec children.


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Prior to this PR, non-leaf plans during shard level failover were still using Akka Dispatcher even when flight was enabled.

This PR wires the flightEnabled flag into PlannerUtil.pickDispatcherShardLevelFailover enabling correct choice of dispatcher  for non-leaf plans.

This was verified using functional/integration testing.