### PR TITLE
[0.9.32.4] cherry-pick: fix(core): support metric names with unicode characters (#2194)

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
@@ -51,7 +51,7 @@ object LogicalPlanParser {
         val metricNameNoQuotes = value.replaceAll("^\"|\"$", "")
         s"$metricNameNoQuotes$colSuffix"
       }.get
-    val metricCanPrefixBraces = PREPENDABLE_METRIC_NAME_REGEX.matches(fullMetricName)
+    val metricCanPrefixBraces = PREPENDABLE_METRIC_NAME_REGEX.pattern.matcher(fullMetricName).matches()
 
     val filterStringWithoutMetric = filters
       .filter { case (name, op, value) => name != PromMetricLabel }
@@ -76,7 +76,7 @@ object LogicalPlanParser {
     } else {  // Metric cannot prepend braces.
       // Add a metric filter inside the curly braces.
       val (filterName, filterOp, filterVal) = metricFilter.get
-      val metricFilterString = s"$filterName$filterOp\"${fullMetricName}\""
+      val metricFilterString = s"$filterName$filterOp$Quotes$fullMetricName$Quotes"
       if (filterStringWithoutMetric.nonEmpty) {
         s"$OpeningCurlyBraces$filterStringWithoutMetric,$metricFilterString$ClosingCurlyBraces"
       } else {

--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/LogicalPlanParser.scala
@@ -27,6 +27,12 @@ object QueryConstants {
 object LogicalPlanParser {
   import QueryConstants._
 
+  // Matched against metric names.
+  // If a metric name matches, it is valid to prefix a selector's curly braces, i.e. "foo{...}".
+  // Otherwise, it must be included as an explicit __name__ filter.
+  // Sourced from IDENTIFIER_EXTENDED in PromQL grammar.
+  private val PREPENDABLE_METRIC_NAME_REGEX = "[_:]*[a-zA-Z][a-zA-Z0-9_:\\-.]*".r
+
   private def getFiltersFromRawSeries(lp: RawSeries)= getFiltersFromColumnFilters(lp.filters)
 
   private def getFiltersFromColumnFilters(filters: Seq[ColumnFilter]) = {
@@ -36,20 +42,49 @@ object LogicalPlanParser {
 
   private def filtersToQuery(filters: Seq[(String, String, String)], columns: Seq[String],
                              lookback: Option[Long], offset: Option[Long], addWindow: Boolean): String = {
-    val columnString = if (columns.isEmpty) "" else s"::${columns.head}"
-    // Get metric name from filters and remove quotes from start and end
-    val name = s"${filters.find(x => x._1.equals(PromMetricLabel)).head._3.
-      replaceAll("^\"|\"$", "")}$columnString"
-    val window = if (lookback.isDefined) {
+    val metricFilter = filters.find { case (name, op, value) => name == PromMetricLabel }
+    require(metricFilter.nonEmpty, s"Missing metric filter! filters=$filters")
+
+    val fullMetricName = metricFilter
+      .map { case (name, op, value) =>
+        val colSuffix = columns.headOption.map("::" + _).getOrElse("")
+        val metricNameNoQuotes = value.replaceAll("^\"|\"$", "")
+        s"$metricNameNoQuotes$colSuffix"
+      }.get
+    val metricCanPrefixBraces = PREPENDABLE_METRIC_NAME_REGEX.matches(fullMetricName)
+
+    val filterStringWithoutMetric = filters
+      .filter { case (name, op, value) => name != PromMetricLabel }
+      .map { case (name, op, value) => s"$name$op$value" }
+      .mkString(Comma)
+
+    val windowString = if (lookback.isDefined) {
       // Window should not be added for queries like sum(foo) even though they have lookback
       if (lookback.get.equals(WindowConstants.staleDataLookbackMillis) && !addWindow) ""
       else s"$OpeningSquareBracket${lookback.get / 1000}s$ClosingSquareBracket"
     } else ""
+
     val offsetString = offset.map(o => s"$Space$Offset$Space${(o / 1000).toString}s").getOrElse("")
-    // When only metric name is present
-    if (filters.size == 1) name + window + offsetString
-    else s"$name$OpeningCurlyBraces${filters.filterNot(x => x._1.equals(PromMetricLabel)).
-      map(f => f._1 + f._2 + f._3).mkString(Comma)}$ClosingCurlyBraces" + window + offsetString
+
+    val selectorString = if (metricCanPrefixBraces) {
+      if (filterStringWithoutMetric.nonEmpty) {
+        s"${fullMetricName}$OpeningCurlyBraces$filterStringWithoutMetric$ClosingCurlyBraces"
+      } else {
+        // Nothing to include inside the curly braces, so the braces are excluded.
+        fullMetricName
+      }
+    } else {  // Metric cannot prepend braces.
+      // Add a metric filter inside the curly braces.
+      val (filterName, filterOp, filterVal) = metricFilter.get
+      val metricFilterString = s"$filterName$filterOp\"${fullMetricName}\""
+      if (filterStringWithoutMetric.nonEmpty) {
+        s"$OpeningCurlyBraces$filterStringWithoutMetric,$metricFilterString$ClosingCurlyBraces"
+      } else {
+        s"$OpeningCurlyBraces$metricFilterString$ClosingCurlyBraces"
+      }
+    }
+
+    s"$selectorString$windowString$offsetString"
   }
 
   private def rawSeriesLikeToQuery(lp: RawSeriesLikePlan, addWindow: Boolean): String = {

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/LogicalPlanParserSpec.scala
@@ -70,6 +70,13 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
     parseAndAssertResult("""test{_ws_="demo",_ns_="App1",instance="Inst-1"}[600s] offset 1000s""")("""test{_ws_="demo",_ns_="App1",instance="Inst-1"}[600s] offset 1000s""")
     parseAndAssertResult("""foo[5m:1m]""")("""foo[300s:60s]""")
     parseAndAssertResult("""last_over_time_is_mad_outlier(3.0,1.0,sum(rate(http_requests_total{job="app"}[300s]))[432000s:300s])""")()
+    parseAndAssertResult("""{__name__="foo"}""")("foo")
+    parseAndAssertResult("""{__name__="foo bar baz"}""")()
+    parseAndAssertResult("""{__name__="!@#$%^&*()"}""")()
+    parseAndAssertResult("""{job="app1",__name__="foo bar baz"}""")()
+    parseAndAssertResult("""sum({job="app1",__name__="foo bar baz"})""")()
+    parseAndAssertResult("""histogram_quantile({job="app1",__name__="foo bar baz"})""")()
+    parseAndAssertResult("""({job="app1",__name__="foo bar baz"} + {job="app1",__name__="foo bar baz"})""")()
   }
 
   it("should generate query from LogicalPlan having offset") {
@@ -338,5 +345,12 @@ class LogicalPlanParserSpec extends AnyFunSpec with Matchers {
     val lp = Parser.queryToLogicalPlan(query, 1000, 1000)
     val res = LogicalPlanParser.convertToQuery(lp)
     res shouldEqual "(http_requests_total{job=\"app\"} + 2.1)"
+  }
+
+  it("should fail to convert query to plan if metric name is missing") {
+    val query = """{job="app"}"""
+    assertThrows[IllegalArgumentException] {
+      Parser.queryToLogicalPlan(query, 1000, 1000)
+    }
   }
 }

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
@@ -2148,7 +2148,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getPartitions(routingKey: Map[String, String], timeRange: TimeRange): List[PartitionAssignment] = Nil
       override def getPartitionsTrait(routingKey: Map[String, String], timeRange: TimeRange): List[PartitionAssignmentTrait] = {
         List(PartitionAssignmentV2(
-          Map("remote" -> PartitionDetails("remote", "remote-url", None, 1.0f, "testWorkUnit")),
+          Map("remote" -> PartitionDetails("remote", "remote-url", None, 1.0f)),
           TimeRange(1000 * 1000, 10000 * 1000)
         ))
       }
@@ -2178,7 +2178,7 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
       override def getPartitions(routingKey: Map[String, String], timeRange: TimeRange): List[PartitionAssignment] = Nil
       override def getPartitionsTrait(routingKey: Map[String, String], timeRange: TimeRange): List[PartitionAssignmentTrait] = Nil
       override def getMetadataPartitions(nonMetricShardKeyFilters: scala.Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = {
-        List(PartitionAssignment("remote", "remote-url", TimeRange(1000 * 1000, 10000 * 1000), None, "testWorkUnit"))
+        List(PartitionAssignment("remote", "remote-url", TimeRange(1000 * 1000, 10000 * 1000), None))
       }
     }
     val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)

--- a/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/queryplanner/MultiPartitionPlannerSpec.scala
@@ -2133,5 +2133,63 @@ class MultiPartitionPlannerSpec extends AnyFunSpec with Matchers with PlanValida
     }
   }
 
+  it("should generate correct remote plans for PromQL queries with metric names " +
+     "that cannot prepend selector curly braces") {
+    val queries = Seq(
+      """{__name__="foo bar baz"}""",
+      """{__name__="!@#$%^&*()"}""",
+      """{job="app1",__name__="foo bar baz"}""",
+      """sum({job="app1",__name__="foo bar baz"})""",
+      """histogram_quantile({job="app1",__name__="foo bar baz"})""",
+      """({job="app1",__name__="foo bar baz"} + {job="app1",__name__="foo bar baz"})"""
+    )
 
+    val partitionLocationProvider = new PartitionLocationProvider {
+      override def getPartitions(routingKey: Map[String, String], timeRange: TimeRange): List[PartitionAssignment] = Nil
+      override def getPartitionsTrait(routingKey: Map[String, String], timeRange: TimeRange): List[PartitionAssignmentTrait] = {
+        List(PartitionAssignmentV2(
+          Map("remote" -> PartitionDetails("remote", "remote-url", None, 1.0f, "testWorkUnit")),
+          TimeRange(1000 * 1000, 10000 * 1000)
+        ))
+      }
+      override def getMetadataPartitions(nonMetricShardKeyFilters: scala.Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = ???
+    }
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+
+    for (query <- queries) {
+      val lp = Parser.queryRangeToLogicalPlan(query, TimeStepParams(1000, 100, 10000))
+      val promQlQueryParams = PromQlQueryParams(query, 1000, 100, 10000)
+      val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams,
+        plannerParams = PlannerParams(processMultiPartition = true)))
+      val remoteExecQuery = execPlan.asInstanceOf[PromQlRemoteExec].promQlQueryParams.promQl
+      remoteExecQuery shouldEqual query
+    }
+  }
+
+  it("should generate correct remote plans for metadata queries with metric names " +
+     "that cannot prepend selector curly braces") {
+    val queries = Seq(
+      """{__name__="foo bar baz"}""",
+      """{__name__="!@#$%^&*()"}""",
+      """{job="app1",__name__="!@#$%^&*()"}"""
+    )
+
+    val partitionLocationProvider = new PartitionLocationProvider {
+      override def getPartitions(routingKey: Map[String, String], timeRange: TimeRange): List[PartitionAssignment] = Nil
+      override def getPartitionsTrait(routingKey: Map[String, String], timeRange: TimeRange): List[PartitionAssignmentTrait] = Nil
+      override def getMetadataPartitions(nonMetricShardKeyFilters: scala.Seq[ColumnFilter], timeRange: TimeRange): List[PartitionAssignment] = {
+        List(PartitionAssignment("remote", "remote-url", TimeRange(1000 * 1000, 10000 * 1000), None, "testWorkUnit"))
+      }
+    }
+    val engine = new MultiPartitionPlanner(partitionLocationProvider, localPlanner, "local", dataset, queryConfig)
+
+    for (query <- queries) {
+      val lp = Parser.metadataQueryToLogicalPlan(query, TimeStepParams(1000, 100, 10000))
+      val promQlQueryParams = PromQlQueryParams(query, 1000, 100, 10000)
+      val execPlan = engine.materialize(lp, QueryContext(origQueryParams = promQlQueryParams,
+        plannerParams = PlannerParams(processMultiPartition = true)))
+      val remoteExecQuery = execPlan.asInstanceOf[MetadataRemoteExec].promQlQueryParams.promQl
+      remoteExecQuery shouldEqual query
+    }
+  }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.32.3"
+version in ThisBuild := "0.9.32.4"


### PR DESCRIPTION
Note: one additional commit was required to make these changes Scala 2.12-compatible: acbb5084441ee4064bd0ef2f115814570af72cb6

That commit should be reverted/removed when `develop` changes are merged to `main`.