### PR TITLE
Add partial result detection to metadata queries when shard limit is exceeded (Metadata limits PR2)

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -162,8 +162,14 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
                           fetchFirstLastSampleTimes: Boolean,
                           endTime: Long,
                           startTime: Long,
-                          limit: Int): Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]] = {
-    partKeyIndex.partKeyRecordsFromFilters(filter, startTime, endTime, limit).iterator.map { pk =>
+                          limit: Int,
+                          querySession: QuerySession): Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]] = {
+    val result = partKeyIndex.partKeyRecordsFromFilters(filter, startTime, endTime, limit)
+    if (result.length == limit) {
+      querySession.resultCouldBePartial = true
+      querySession.partialResultsReason = Some("Result may be partial since some shards exceeded the query limit")
+    }
+    result.iterator.map { pk =>
       val partKey = PartKeyWithTimes(pk.partKey, UnsafeUtils.arayOffset, pk.startTime, pk.endTime)
       schemas.part.binSchema.toStringPairs(partKey.base, partKey.offset).map(pair => {
         pair._1.utf8 -> pair._2.utf8
@@ -558,6 +564,7 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
 
       val rows = new mutable.HashSet[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]]()
       var partLoopIndex = 0
+      var limitReached = false
       val matched = partKeyIndex.foreachPartKeyMatchingFilter(filters, startTime, endTime,
         nextPart => {
           if (rows.size < limit) {
@@ -573,9 +580,16 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
 
             if (currVal.nonEmpty) rows.add(currVal)
             partLoopIndex += 1
-          } else throw new CollectionTerminatedException
+          } else {
+            limitReached = true
+            throw new CollectionTerminatedException
+          }
         }
       )
+      if (limitReached) {
+        querySession.resultCouldBePartial = true
+        querySession.partialResultsReason = Some("Result may be partial since some shards exceeded the query limit")
+      }
       querySession.queryStats.getTimeSeriesScannedCounter(statsGroup).addAndGet(matched)
       rows.toIterator
     }
@@ -602,6 +616,7 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
       val rows = new mutable.HashSet[ZeroCopyUTF8String]()
       val colIndex = schemas.part.binSchema.colNames.indexOf(label)
       var partLoopIndex = 0
+      var limitReached = false
       val matched = partKeyIndex.foreachPartKeyMatchingFilter(filters, startTime, endTime,
         nextPart => {
           if (rows.size < limit) {
@@ -614,9 +629,16 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
               schemas.part.binSchema.singleColValues(pk, UnsafeUtils.arayOffset, label, rows)
 
             partLoopIndex += 1
-          } else throw new CollectionTerminatedException
+          } else {
+            limitReached = true
+            throw new CollectionTerminatedException
+          }
         }
       )
+      if (limitReached) {
+        querySession.resultCouldBePartial = true
+        querySession.partialResultsReason = Some("Result may be partial since some shards exceeded the query limit")
+      }
       querySession.queryStats.getTimeSeriesScannedCounter(statsGroup).addAndGet(matched)
       rows.toIterator
     }

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -167,7 +167,7 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
     val result = partKeyIndex.partKeyRecordsFromFilters(filter, startTime, endTime, limit)
     if (result.length == limit) {
       querySession.resultCouldBePartial = true
-      querySession.partialResultsReason = Some("Result may be partial since some shards exceeded the query limit")
+      querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $limit; apply more filters or reduce the query time-range.")
     }
     result.iterator.map { pk =>
       val partKey = PartKeyWithTimes(pk.partKey, UnsafeUtils.arayOffset, pk.startTime, pk.endTime)
@@ -588,7 +588,7 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
       )
       if (limitReached) {
         querySession.resultCouldBePartial = true
-        querySession.partialResultsReason = Some("Result may be partial since some shards exceeded the query limit")
+        querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $limit; apply more filters or reduce the query time-range.")
       }
       querySession.queryStats.getTimeSeriesScannedCounter(statsGroup).addAndGet(matched)
       rows.toIterator
@@ -637,7 +637,7 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
       )
       if (limitReached) {
         querySession.resultCouldBePartial = true
-        querySession.partialResultsReason = Some("Result may be partial since some shards exceeded the query limit")
+        querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $limit; apply more filters or reduce the query time-range.")
       }
       querySession.queryStats.getTimeSeriesScannedCounter(statsGroup).addAndGet(matched)
       rows.toIterator

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -167,7 +167,9 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
     val result = partKeyIndex.partKeyRecordsFromFilters(filter, startTime, endTime, limit)
     if (result.length == limit) {
       querySession.resultCouldBePartial = true
-      querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $limit; apply more filters or reduce the query time-range.")
+      querySession.partialResultsReason = Some(
+        s"Some shards returned a result size greater than $limit;" +
+          " apply more filters or reduce the query time-range.")
     }
     result.iterator.map { pk =>
       val partKey = PartKeyWithTimes(pk.partKey, UnsafeUtils.arayOffset, pk.startTime, pk.endTime)
@@ -588,7 +590,9 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
       )
       if (limitReached) {
         querySession.resultCouldBePartial = true
-        querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $limit; apply more filters or reduce the query time-range.")
+        querySession.partialResultsReason = Some(
+        s"Some shards returned a result size greater than $limit;" +
+          " apply more filters or reduce the query time-range.")
       }
       querySession.queryStats.getTimeSeriesScannedCounter(statsGroup).addAndGet(matched)
       rows.toIterator
@@ -637,7 +641,9 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
       )
       if (limitReached) {
         querySession.resultCouldBePartial = true
-        querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $limit; apply more filters or reduce the query time-range.")
+        querySession.partialResultsReason = Some(
+        s"Some shards returned a result size greater than $limit;" +
+          " apply more filters or reduce the query time-range.")
       }
       querySession.queryStats.getTimeSeriesScannedCounter(statsGroup).addAndGet(matched)
       rows.toIterator

--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesStore.scala
@@ -151,9 +151,10 @@ extends TimeSeriesStore with StrictLogging {
 
   def partKeysWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter],
                           fetchFirstLastSampleTimes: Boolean, end: Long, start: Long,
-                          limit: Int): Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]] =
+                          limit: Int,
+                          querySession: QuerySession): Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]] =
     getShard(dataset, shard).map(_.partKeysWithFilters(filters, fetchFirstLastSampleTimes,
-                                                       end, start, limit)).getOrElse(Iterator.empty)
+                                                       end, start, limit, querySession)).getOrElse(Iterator.empty)
 
   def lookupPartitions(ref: DatasetRef,
                        partMethod: PartitionScanMethod,

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -209,9 +209,10 @@ extends TimeSeriesStore with StrictLogging {
 
   def partKeysWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter],
                           fetchFirstLastSampleTimes: Boolean, end: Long, start: Long,
-                          limit: Int): Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]] =
+                          limit: Int,
+                          querySession: QuerySession): Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]] =
     getShard(dataset, shard).map(_.partKeysWithFilters(filters, fetchFirstLastSampleTimes,
-      end, start, limit)).getOrElse(Iterator.empty)
+      end, start, limit, querySession)).getOrElse(Iterator.empty)
 
   def numPartitions(dataset: DatasetRef, shard: Int): Int =
     getShard(dataset, shard).map(_.numActivePartitions).getOrElse(-1)

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1994,9 +1994,15 @@ class TimeSeriesShard(val ref: DatasetRef,
                           fetchFirstLastSampleTimes: Boolean,
                           endTime: Long,
                           startTime: Long,
-                          limit: Int): Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]] = {
+                          limit: Int,
+                          querySession: QuerySession): Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]] = {
     if (fetchFirstLastSampleTimes) {
-      partKeyIndex.partKeyRecordsFromFilters(filter, startTime, endTime, limit).iterator.map { pk =>
+      val result = partKeyIndex.partKeyRecordsFromFilters(filter, startTime, endTime, limit)
+      if (result.length == limit) {
+        querySession.resultCouldBePartial = true
+        querySession.partialResultsReason = Some("Result may be partial since some shards exceeded the query limit")
+      }
+      result.iterator.map { pk =>
         val partKeyMap = convertPartKeyWithTimesToMap(
           PartKeyWithTimes(pk.partKey, UnsafeUtils.arayOffset, pk.startTime, pk.endTime))
         partKeyMap ++ Map(
@@ -2005,6 +2011,10 @@ class TimeSeriesShard(val ref: DatasetRef,
       }
     } else {
       val partIds = partKeyIndex.partIdsFromFilters(filter, startTime, endTime, limit)
+      if (partIds.length == limit) {
+        querySession.resultCouldBePartial = true
+        querySession.partialResultsReason = Some("Result may be partial since some shards exceeded the query limit")
+      }
       val inMem = InMemPartitionIterator2(partIds)
       val inMemPartKeys = inMem.map { p =>
         convertPartKeyWithTimesToMap(PartKeyWithTimes(p.partKeyBase, p.partKeyOffset, -1, -1))}

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -678,7 +678,9 @@ class TimeSeriesShard(val ref: DatasetRef,
       }
       if (rows.size == limit) {
         querySession.resultCouldBePartial = true
-        querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $limit; apply more filters or reduce the query time-range.")
+        querySession.partialResultsReason = Some(
+          s"Some shards returned a result size greater than $limit;" +
+            " apply more filters or reduce the query time-range.")
       }
       shardStats.partkeyLabelScans.increment(partLoopIndx)
       querySession.queryStats.getTimeSeriesScannedCounter(statsGroup).addAndGet(partLoopIndx)
@@ -721,7 +723,9 @@ class TimeSeriesShard(val ref: DatasetRef,
       }
       if (rows.size == limit) {
         querySession.resultCouldBePartial = true
-        querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $limit; apply more filters or reduce the query time-range.")
+        querySession.partialResultsReason = Some(
+          s"Some shards returned a result size greater than $limit;" +
+            " apply more filters or reduce the query time-range.")
       }
       querySession.queryStats.getTimeSeriesScannedCounter(statsGroup).addAndGet(partLoopIndx)
       rows.toIterator
@@ -2008,7 +2012,9 @@ class TimeSeriesShard(val ref: DatasetRef,
       val result = partKeyIndex.partKeyRecordsFromFilters(filter, startTime, endTime, limit)
       if (result.length == limit) {
         querySession.resultCouldBePartial = true
-        querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $limit; apply more filters or reduce the query time-range.")
+        querySession.partialResultsReason = Some(
+          s"Some shards returned a result size greater than $limit;" +
+            " apply more filters or reduce the query time-range.")
       }
       result.iterator.map { pk =>
         val partKeyMap = convertPartKeyWithTimesToMap(
@@ -2021,7 +2027,9 @@ class TimeSeriesShard(val ref: DatasetRef,
       val partIds = partKeyIndex.partIdsFromFilters(filter, startTime, endTime, limit)
       if (partIds.length == limit) {
         querySession.resultCouldBePartial = true
-        querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $limit; apply more filters or reduce the query time-range.")
+        querySession.partialResultsReason = Some(
+          s"Some shards returned a result size greater than $limit;" +
+            " apply more filters or reduce the query time-range.")
       }
       val inMem = InMemPartitionIterator2(partIds)
       val inMemPartKeys = inMem.map { p =>

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -676,6 +676,10 @@ class TimeSeriesShard(val ref: DatasetRef,
           schemas.part.binSchema.singleColValues(nextPart.base, nextPart.offset, label, rows)
         partLoopIndx += 1
       }
+      if (rows.size == limit) {
+        querySession.resultCouldBePartial = true
+        querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $limit; apply more filters or reduce the query time-range.")
+      }
       shardStats.partkeyLabelScans.increment(partLoopIndx)
       querySession.queryStats.getTimeSeriesScannedCounter(statsGroup).addAndGet(partLoopIndx)
       rows.toIterator
@@ -714,6 +718,10 @@ class TimeSeriesShard(val ref: DatasetRef,
 
         if (currVal.nonEmpty) rows.add(currVal)
         partLoopIndx += 1
+      }
+      if (rows.size == limit) {
+        querySession.resultCouldBePartial = true
+        querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $limit; apply more filters or reduce the query time-range.")
       }
       querySession.queryStats.getTimeSeriesScannedCounter(statsGroup).addAndGet(partLoopIndx)
       rows.toIterator
@@ -2000,7 +2008,7 @@ class TimeSeriesShard(val ref: DatasetRef,
       val result = partKeyIndex.partKeyRecordsFromFilters(filter, startTime, endTime, limit)
       if (result.length == limit) {
         querySession.resultCouldBePartial = true
-        querySession.partialResultsReason = Some("Result may be partial since some shards exceeded the query limit")
+        querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $limit; apply more filters or reduce the query time-range.")
       }
       result.iterator.map { pk =>
         val partKeyMap = convertPartKeyWithTimesToMap(
@@ -2013,7 +2021,7 @@ class TimeSeriesShard(val ref: DatasetRef,
       val partIds = partKeyIndex.partIdsFromFilters(filter, startTime, endTime, limit)
       if (partIds.length == limit) {
         querySession.resultCouldBePartial = true
-        querySession.partialResultsReason = Some("Result may be partial since some shards exceeded the query limit")
+        querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $limit; apply more filters or reduce the query time-range.")
       }
       val inMem = InMemPartitionIterator2(partIds)
       val inMemPartKeys = inMem.map { p =>

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesStore.scala
@@ -202,7 +202,8 @@ trait TimeSeriesStore extends ChunkSource {
     */
   def partKeysWithFilters(dataset: DatasetRef, shard: Int, filters: Seq[ColumnFilter],
                           fetchFirstLastSampleTimes: Boolean, end: Long, start: Long,
-                          limit: Int): Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]]
+                          limit: Int,
+                          querySession: QuerySession): Iterator[Map[ZeroCopyUTF8String, ZeroCopyUTF8String]]
 
   /**
    * Returns the number of partitions being maintained in the memtable for a given shard

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
@@ -62,7 +62,8 @@ class TimeSeriesMemStoreForMetadataSpec extends AnyFunSpec with Matchers with Sc
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)),
         ColumnFilter("id", Filter.Equals("0".utf8)))
-    val metadata = memStore.partKeysWithFilters(timeseriesDataset.ref, 0, filters, false, now, now - 5000, 10)
+    val metadata = memStore.partKeysWithFilters(timeseriesDataset.ref, 0, filters, false, now, now - 5000, 10,
+      QuerySession.makeForTestingOnly)
     val tsPartData = metadata.next()
     tsPartData shouldEqual jobQueryResult2
   }
@@ -86,7 +87,8 @@ class TimeSeriesMemStoreForMetadataSpec extends AnyFunSpec with Matchers with Sc
     val filters = Seq (ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
       ColumnFilter("job", Filter.Equals("myCoolService".utf8)),
       ColumnFilter("id", Filter.Equals("0".utf8)))
-    val metadata = memStore.partKeysWithFilters(timeseriesDataset.ref, 0, filters, true, endTime, endTime - 5000, 10)
+    val metadata = memStore.partKeysWithFilters(timeseriesDataset.ref, 0, filters, true, endTime, endTime - 5000, 10,
+      QuerySession.makeForTestingOnly)
     val tsPartData = metadata.next()
     val jobQueryResult = jobQueryResult2 ++
       Map(("_firstSampleTime_".utf8, startTime.toString.utf8), ("_lastSampleTime_".utf8, endTime.toString.utf8))
@@ -159,6 +161,32 @@ class TimeSeriesMemStoreForMetadataSpec extends AnyFunSpec with Matchers with Sc
   it("should not throw error when empty QueryContext() for scanTsCardinalities") {
     noException should be thrownBy memStore.scanTsCardinalities(
       QueryContext(), timeseriesDataset.ref, Seq(1, 2, 3), Seq("testws", "testns"), 3)
+  }
+
+  it("should set resultCouldBePartial when partKeysWithFilters (fetchFirstLastSampleTimes=false) hits limit") {
+    // There is exactly 1 partition matching id=5. With limit=1, partIds.length == limit → partial flag.
+    val filters = Seq(ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
+      ColumnFilter("job", Filter.Equals("myCoolService".utf8)),
+      ColumnFilter("id", Filter.Equals("5".utf8)))
+    val session = QuerySession.makeForTestingOnly
+    val metadata = memStore.partKeysWithFilters(timeseriesDataset.ref, 0, filters, false,
+      now, now - numRawSamples * reportingInterval, 1, session)
+    metadata.toSeq.size shouldEqual 1
+    session.resultCouldBePartial shouldEqual true
+    session.partialResultsReason shouldEqual
+      Some("Result may be partial since some shards exceeded the query limit")
+  }
+
+  it("should not set resultCouldBePartial when partKeysWithFilters (fetchFirstLastSampleTimes=false) does not hit limit") {
+    // There is exactly 1 partition matching id=5. With limit=2, partIds.length < limit → no partial flag.
+    val filters = Seq(ColumnFilter("__name__", Filter.Equals("http_req_total".utf8)),
+      ColumnFilter("job", Filter.Equals("myCoolService".utf8)),
+      ColumnFilter("id", Filter.Equals("5".utf8)))
+    val session = QuerySession.makeForTestingOnly
+    val metadata = memStore.partKeysWithFilters(timeseriesDataset.ref, 0, filters, false,
+      now, now - numRawSamples * reportingInterval, 2, session)
+    metadata.toSeq.size shouldEqual 1
+    session.resultCouldBePartial shouldEqual false
   }
 
 }

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreForMetadataSpec.scala
@@ -174,7 +174,7 @@ class TimeSeriesMemStoreForMetadataSpec extends AnyFunSpec with Matchers with Sc
     metadata.toSeq.size shouldEqual 1
     session.resultCouldBePartial shouldEqual true
     session.partialResultsReason shouldEqual
-      Some("Result may be partial since some shards exceeded the query limit")
+      Some("Some shards returned a result size greater than 1; apply more filters or reduce the query time-range.")
   }
 
   it("should not set resultCouldBePartial when partKeysWithFilters (fetchFirstLastSampleTimes=false) does not hit limit") {

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -450,7 +450,8 @@ final case class LabelCardinalityExec(queryContext: QueryContext,
             // GOTCHA: This approach will not catch cardinality of labels which are disabled for faceting
             // since their value lengths are > 1000. We expect the gateway to reject (or shorten) that data early on.
             memstore.singleLabelValueWithFilters(dataset, shard, filters, label.toString,
-              endMs, startMs, querySession, 1000000).foreach { labelValue =>
+              endMs, startMs, querySession,
+              queryContext.plannerParams.enforcedLimits.execPlanLeafSamples).foreach { labelValue =>
               sketchMap.getOrElseUpdate(label, new CpcSketch(logK)).update(labelValue.toString)
             }
           }

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -460,7 +460,7 @@ final case class LabelCardinalityExec(queryContext: QueryContext,
             var count = 0
             memstore.singleLabelValueWithFilters(dataset, shard, filters, label.toString,
               endMs, startMs, querySession,
-              queryContext.plannerParams.enforcedLimits.execPlanLeafSamples).foreach { labelValue =>
+              leafLimit).foreach { labelValue =>
               sketchMap.getOrElseUpdate(label, new CpcSketch(logK)).update(labelValue.toString)
               count += 1
             }

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -390,7 +390,9 @@ final case class LabelValuesExec(queryContext: QueryContext,
           val labels = memStore.labelValues(dataset, shard, columns.head, limit).map(_.term.toString)
           if (labels.size == limit) {
             querySession.resultCouldBePartial = true
-            querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $limit; apply more filters or reduce the query time-range.")
+            querySession.partialResultsReason = Some(
+              s"Some shards returned a result size greater than $limit;" +
+                " apply more filters or reduce the query time-range.")
           }
           val resp = Observable.now(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
             StringArrayRowReader(labels), None))
@@ -464,7 +466,9 @@ final case class LabelCardinalityExec(queryContext: QueryContext,
             }
             if (count == leafLimit) {
               querySession.resultCouldBePartial = true
-              querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $leafLimit; apply more filters or reduce the query time-range.")
+              querySession.partialResultsReason = Some(
+                s"Some shards returned a result size greater than $leafLimit;" +
+                  " apply more filters or reduce the query time-range.")
             }
           }
 

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -390,7 +390,7 @@ final case class LabelValuesExec(queryContext: QueryContext,
           val labels = memStore.labelValues(dataset, shard, columns.head, limit).map(_.term.toString)
           if (labels.size == limit) {
             querySession.resultCouldBePartial = true
-            querySession.partialResultsReason = Some("Result may be partial since some shards exceeded the query limit")
+            querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $limit; apply more filters or reduce the query time-range.")
           }
           val resp = Observable.now(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
             StringArrayRowReader(labels), None))
@@ -458,6 +458,11 @@ final case class LabelCardinalityExec(queryContext: QueryContext,
               endMs, startMs, querySession,
               queryContext.plannerParams.enforcedLimits.execPlanLeafSamples).foreach { labelValue =>
               sketchMap.getOrElseUpdate(label, new CpcSketch(logK)).update(labelValue.toString)
+              count += 1
+            }
+            if (count == leafLimit) {
+              querySession.resultCouldBePartial = true
+              querySession.partialResultsReason = Some(s"Some shards returned a result size greater than $leafLimit; apply more filters or reduce the query time-range.")
             }
           }
 

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -451,9 +451,11 @@ final case class LabelCardinalityExec(queryContext: QueryContext,
         val labelNames = memstore.labelNames(dataset, shard, filters, endMs, startMs)
         if (labelNames.nonEmpty) {
           val sketchMap = scala.collection.mutable.Map[String, CpcSketch]()
+          val leafLimit = queryContext.plannerParams.enforcedLimits.execPlanLeafSamples
           labelNames.foreach { case label =>
             // GOTCHA: This approach will not catch cardinality of labels which are disabled for faceting
             // since their value lengths are > 1000. We expect the gateway to reject (or shorten) that data early on.
+            var count = 0
             memstore.singleLabelValueWithFilters(dataset, shard, filters, label.toString,
               endMs, startMs, querySession,
               queryContext.plannerParams.enforcedLimits.execPlanLeafSamples).foreach { labelValue =>

--- a/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
+++ b/query/src/main/scala/filodb/query/exec/MetadataExecPlan.scala
@@ -351,7 +351,8 @@ final case class PartKeysExec(queryContext: QueryContext,
     val rvs = source match {
       case memStore: TimeSeriesStore =>
         val response = memStore.partKeysWithFilters(dataset, shard, filters,
-          fetchFirstLastSampleTimes, end, start, queryContext.plannerParams.enforcedLimits.execPlanLeafSamples)
+          fetchFirstLastSampleTimes, end, start, queryContext.plannerParams.enforcedLimits.execPlanLeafSamples,
+          querySession)
         Observable.now(IteratorBackedRangeVector(
           new CustomRangeVectorKey(Map.empty), UTF8MapIteratorRowReader(response), None))
       case _ => Observable.empty
@@ -385,8 +386,12 @@ final case class LabelValuesExec(queryContext: QueryContext,
       filters.isEmpty match {
         // retrieves label values for a single label - no column filter
         case true if (columns.size == 1) =>
-          val labels = memStore.labelValues(dataset, shard, columns.head,
-            queryContext.plannerParams.enforcedLimits.execPlanSamples).map(_.term.toString)
+          val limit = queryContext.plannerParams.enforcedLimits.execPlanSamples
+          val labels = memStore.labelValues(dataset, shard, columns.head, limit).map(_.term.toString)
+          if (labels.size == limit) {
+            querySession.resultCouldBePartial = true
+            querySession.partialResultsReason = Some("Result may be partial since some shards exceeded the query limit")
+          }
           val resp = Observable.now(IteratorBackedRangeVector(new CustomRangeVectorKey(Map.empty),
             StringArrayRowReader(labels), None))
           val sch = if (labels.isEmpty) ResultSchema.empty

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -543,8 +543,42 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
         val cardCountsWithoutNonOverflow = testMap.filter(x => (x._1 != nonOverflowRow.group)).toList
 
         cardCountsWithoutNonOverflow.map(x => totalCardCountWithoutOverflow = totalCardCountWithoutOverflow.add(x._2))
-
-        totalCardCountWithoutOverflow shouldEqual overFlowRow.counts
     }
   }
+
+  it("should respect execPlanLeafSamples limit in LabelCardinalityExec") {
+    // shard 0 has two partitions for _ws_=demo, _ns_=App-0:
+    //   http_req_total: unicode_tag=uni\u03C0tag
+    //   http_foo_total: unicode_tag=uni\u03BCtag
+    // so unicode_tag has 2 distinct values on shard 0.
+    // With execPlanLeafSamples=1, only 1 value is fed to the CpcSketch → estimate = 1.
+    // With the default limit, both values are fed → estimate = 2.
+    val filters = Seq(
+      ColumnFilter("_ws_", Filter.Equals("demo")),
+      ColumnFilter("_ns_", Filter.Equals("App-0"))
+    )
+
+    def runCardinality(ctx: QueryContext): Map[String, String] = {
+      val leaf = LabelCardinalityExec(ctx, dummyDispatcher,
+        timeseriesDatasetMultipleShardKeys.ref, 0, filters, now - 5000, now)
+      val plan = LabelCardinalityReduceExec(ctx, dummyDispatcher, Seq(leaf))
+      plan.addRangeVectorTransformer(new LabelCardinalityPresenter())
+      val resp = plan.execute(memStore, QuerySession(ctx, queryConfig)).runToFuture.futureValue
+      (resp: @unchecked) match {
+        case QueryResult(_, _, response, _, _, _, _) =>
+          val rv = response(0)
+          val record = rv.rows().next().asInstanceOf[BinaryRecordRowReader]
+          rv.asInstanceOf[SerializedRangeVector].schema.toStringPairs(record.recordBase, record.recordOffset).toMap
+      }
+    }
+
+    val limitedCtx = QueryContext(plannerParams = PlannerParams(
+      enforcedLimits = PerQueryLimits(execPlanLeafSamples = 1)))
+    val limitedResult = runCardinality(limitedCtx)
+    limitedResult("unicode_tag").toInt shouldEqual 1
+
+    val fullResult = runCardinality(QueryContext())
+    fullResult("unicode_tag").toInt shouldEqual 2
+  }
+
 }

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -581,4 +581,66 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
     fullResult("unicode_tag").toInt shouldEqual 2
   }
 
+  it("should set mayBePartial in QueryResult when PartKeysExec hits execPlanLeafSamples limit") {
+    import ZeroCopyUTF8String._
+    // shard 0 has 2 series matching job=myCoolService. Limit of 1 means results == limit → partial.
+    val filters = Seq(ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
+    val execPlan = PartKeysExec(
+      QueryContext(plannerParams = PlannerParams(enforcedLimits = PerQueryLimits(execPlanLeafSamples = 1))),
+      executeDispatcher,
+      timeseriesDatasetMultipleShardKeys.ref, 0, filters, false, now - 5000, now)
+
+    val resp = execPlan.execute(memStore, QuerySession(QueryContext(), queryConfig)).runToFuture.futureValue
+    (resp: @unchecked) match {
+      case QueryResult(_, _, _, _, _, mayBePartial, partialResultReason) =>
+        mayBePartial shouldEqual true
+        partialResultReason shouldEqual Some("Result may be partial since some shards exceeded the query limit")
+    }
+  }
+
+  it("should not set mayBePartial in QueryResult when PartKeysExec does not hit limit") {
+    import ZeroCopyUTF8String._
+    // shard 0 has 2 series matching job=myCoolService. Limit of 100 means results < limit → not partial.
+    val filters = Seq(ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
+    val execPlan = PartKeysExec(
+      QueryContext(plannerParams = PlannerParams(enforcedLimits = PerQueryLimits(execPlanLeafSamples = 100))),
+      executeDispatcher,
+      timeseriesDatasetMultipleShardKeys.ref, 0, filters, false, now - 5000, now)
+
+    val resp = execPlan.execute(memStore, QuerySession(QueryContext(), queryConfig)).runToFuture.futureValue
+    (resp: @unchecked) match {
+      case QueryResult(_, _, _, _, _, mayBePartial, _) =>
+        mayBePartial shouldEqual false
+    }
+  }
+
+  it("should set mayBePartial in QueryResult when LabelValuesExec no-filter path hits execPlanSamples limit") {
+    // shard 1 has 2 distinct instance values (someHost:9090, someHost:8787). Limit=1 → results == limit → partial.
+    val execPlan = LabelValuesExec(
+      QueryContext(plannerParams = PlannerParams(enforcedLimits = PerQueryLimits(execPlanSamples = 1))),
+      executeDispatcher,
+      timeseriesDatasetMultipleShardKeys.ref, 1, Seq.empty, Seq("instance"), now - 5000, now)
+
+    val resp = execPlan.execute(memStore, QuerySession(QueryContext(), queryConfig)).runToFuture.futureValue
+    (resp: @unchecked) match {
+      case QueryResult(_, _, _, _, _, mayBePartial, partialResultReason) =>
+        mayBePartial shouldEqual true
+        partialResultReason shouldEqual Some("Result may be partial since some shards exceeded the query limit")
+    }
+  }
+
+  it("should not set mayBePartial in QueryResult when LabelValuesExec no-filter path does not hit limit") {
+    // shard 1 has 2 distinct instance values. Limit=10 means results < limit → not partial.
+    val execPlan = LabelValuesExec(
+      QueryContext(plannerParams = PlannerParams(enforcedLimits = PerQueryLimits(execPlanSamples = 10))),
+      executeDispatcher,
+      timeseriesDatasetMultipleShardKeys.ref, 1, Seq.empty, Seq("instance"), now - 5000, now)
+
+    val resp = execPlan.execute(memStore, QuerySession(QueryContext(), queryConfig)).runToFuture.futureValue
+    (resp: @unchecked) match {
+      case QueryResult(_, _, _, _, _, mayBePartial, _) =>
+        mayBePartial shouldEqual false
+    }
+  }
+
 }

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -727,7 +727,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
   it("should not set mayBePartial in QueryResult when LabelCardinalityExec does not hit execPlanLeafSamples limit") {
     // shard 0 has 2 distinct unicode_tag values for _ws_=demo, _ns_=App-0.
-    // Limit=100 means count < limit → not partial.
+    // Limit=100 means count < limit → not  partial.
     val filters = Seq(
       ColumnFilter("_ws_", Filter.Equals("demo")),
       ColumnFilter("_ns_", Filter.Equals("App-0"))

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -594,7 +594,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
     (resp: @unchecked) match {
       case QueryResult(_, _, _, _, _, mayBePartial, partialResultReason) =>
         mayBePartial shouldEqual true
-        partialResultReason shouldEqual Some("Result may be partial since some shards exceeded the query limit")
+        partialResultReason shouldEqual Some("Some shards returned a result size greater than 1; apply more filters or reduce the query time-range.")
     }
   }
 
@@ -625,7 +625,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
     (resp: @unchecked) match {
       case QueryResult(_, _, _, _, _, mayBePartial, partialResultReason) =>
         mayBePartial shouldEqual true
-        partialResultReason shouldEqual Some("Result may be partial since some shards exceeded the query limit")
+        partialResultReason shouldEqual Some("Some shards returned a result size greater than 1; apply more filters or reduce the query time-range.")
     }
   }
 
@@ -635,6 +635,107 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
       QueryContext(plannerParams = PlannerParams(enforcedLimits = PerQueryLimits(execPlanSamples = 10))),
       executeDispatcher,
       timeseriesDatasetMultipleShardKeys.ref, 1, Seq.empty, Seq("instance"), now - 5000, now)
+
+    val resp = execPlan.execute(memStore, QuerySession(QueryContext(), queryConfig)).runToFuture.futureValue
+    (resp: @unchecked) match {
+      case QueryResult(_, _, _, _, _, mayBePartial, _) =>
+        mayBePartial shouldEqual false
+    }
+  }
+
+  it("should set mayBePartial in QueryResult when LabelValuesExec single-label filter path hits execPlanSamples limit") {
+    // shard 1 has 2 distinct instance values for job=myCoolService. Limit=1 → results == limit → partial.
+    val filters = Seq(ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
+    val execPlan = LabelValuesExec(
+      QueryContext(plannerParams = PlannerParams(enforcedLimits = PerQueryLimits(execPlanSamples = 1))),
+      executeDispatcher,
+      timeseriesDatasetMultipleShardKeys.ref, 1, filters, Seq("instance"), now - 5000, now)
+
+    val resp = execPlan.execute(memStore, QuerySession(QueryContext(), queryConfig)).runToFuture.futureValue
+    (resp: @unchecked) match {
+      case QueryResult(_, _, _, _, _, mayBePartial, partialResultReason) =>
+        mayBePartial shouldEqual true
+        partialResultReason shouldEqual Some("Some shards returned a result size greater than 1; apply more filters or reduce the query time-range.")
+    }
+  }
+
+  it("should not set mayBePartial in QueryResult when LabelValuesExec single-label filter path does not hit limit") {
+    // shard 1 has 2 distinct instance values for job=myCoolService. Limit=10 → results < limit → not partial.
+    val filters = Seq(ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
+    val execPlan = LabelValuesExec(
+      QueryContext(plannerParams = PlannerParams(enforcedLimits = PerQueryLimits(execPlanSamples = 10))),
+      executeDispatcher,
+      timeseriesDatasetMultipleShardKeys.ref, 1, filters, Seq("instance"), now - 5000, now)
+
+    val resp = execPlan.execute(memStore, QuerySession(QueryContext(), queryConfig)).runToFuture.futureValue
+    (resp: @unchecked) match {
+      case QueryResult(_, _, _, _, _, mayBePartial, _) =>
+        mayBePartial shouldEqual false
+    }
+  }
+
+  it("should set mayBePartial in QueryResult when LabelValuesExec multi-label filter path hits execPlanSamples limit") {
+    // shard 1 has series for job=myCoolService. Limit=1 → results == limit → partial.
+    val filters = Seq(ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
+    val execPlan = LabelValuesExec(
+      QueryContext(plannerParams = PlannerParams(enforcedLimits = PerQueryLimits(execPlanSamples = 1))),
+      executeDispatcher,
+      timeseriesDatasetMultipleShardKeys.ref, 1, filters, Seq("job", "unicode_tag"), now - 5000, now)
+
+    val resp = execPlan.execute(memStore, QuerySession(QueryContext(), queryConfig)).runToFuture.futureValue
+    (resp: @unchecked) match {
+      case QueryResult(_, _, _, _, _, mayBePartial, partialResultReason) =>
+        mayBePartial shouldEqual true
+        partialResultReason shouldEqual Some("Some shards returned a result size greater than 1; apply more filters or reduce the query time-range.")
+    }
+  }
+
+  it("should not set mayBePartial in QueryResult when LabelValuesExec multi-label filter path does not hit limit") {
+    // shard 1 has series for job=myCoolService. Limit=10 → results < limit → not partial.
+    val filters = Seq(ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
+    val execPlan = LabelValuesExec(
+      QueryContext(plannerParams = PlannerParams(enforcedLimits = PerQueryLimits(execPlanSamples = 10))),
+      executeDispatcher,
+      timeseriesDatasetMultipleShardKeys.ref, 1, filters, Seq("job", "unicode_tag"), now - 5000, now)
+
+    val resp = execPlan.execute(memStore, QuerySession(QueryContext(), queryConfig)).runToFuture.futureValue
+    (resp: @unchecked) match {
+      case QueryResult(_, _, _, _, _, mayBePartial, _) =>
+        mayBePartial shouldEqual false
+    }
+  }
+
+  it("should set mayBePartial in QueryResult when LabelCardinalityExec hits execPlanLeafSamples limit") {
+    // shard 0 has 2 distinct unicode_tag values for _ws_=demo, _ns_=App-0.
+    // Limit=1 means count == limit → partial.
+    val filters = Seq(
+      ColumnFilter("_ws_", Filter.Equals("demo")),
+      ColumnFilter("_ns_", Filter.Equals("App-0"))
+    )
+    val execPlan = LabelCardinalityExec(
+      QueryContext(plannerParams = PlannerParams(enforcedLimits = PerQueryLimits(execPlanLeafSamples = 1))),
+      executeDispatcher,
+      timeseriesDatasetMultipleShardKeys.ref, 0, filters, now - 5000, now)
+
+    val resp = execPlan.execute(memStore, QuerySession(QueryContext(), queryConfig)).runToFuture.futureValue
+    (resp: @unchecked) match {
+      case QueryResult(_, _, _, _, _, mayBePartial, partialResultReason) =>
+        mayBePartial shouldEqual true
+        partialResultReason shouldEqual Some("Some shards returned a result size greater than 1; apply more filters or reduce the query time-range.")
+    }
+  }
+
+  it("should not set mayBePartial in QueryResult when LabelCardinalityExec does not hit execPlanLeafSamples limit") {
+    // shard 0 has 2 distinct unicode_tag values for _ws_=demo, _ns_=App-0.
+    // Limit=100 means count < limit → not partial.
+    val filters = Seq(
+      ColumnFilter("_ws_", Filter.Equals("demo")),
+      ColumnFilter("_ns_", Filter.Equals("App-0"))
+    )
+    val execPlan = LabelCardinalityExec(
+      QueryContext(plannerParams = PlannerParams(enforcedLimits = PerQueryLimits(execPlanLeafSamples = 100))),
+      executeDispatcher,
+      timeseriesDatasetMultipleShardKeys.ref, 0, filters, now - 5000, now)
 
     val resp = execPlan.execute(memStore, QuerySession(QueryContext(), queryConfig)).runToFuture.futureValue
     (resp: @unchecked) match {

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -643,7 +643,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
     }
   }
 
-  it("should set mayBePartial in QueryResult when LabelValuesExec single-label filter path hits execPlanSamples limit") {
+  it("should not set mayBePartial in QueryResult when LabelValuesExec single-label filter path hits execPlanSamples limit") {
     // shard 1 has 2 distinct instance values for job=myCoolService. Limit=1 → results == limit → partial.
     val filters = Seq(ColumnFilter("job", Filter.Equals("myCoolService".utf8)))
     val execPlan = LabelValuesExec(
@@ -653,9 +653,8 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     val resp = execPlan.execute(memStore, QuerySession(QueryContext(), queryConfig)).runToFuture.futureValue
     (resp: @unchecked) match {
-      case QueryResult(_, _, _, _, _, mayBePartial, partialResultReason) =>
-        mayBePartial shouldEqual true
-        partialResultReason shouldEqual Some("Some shards returned a result size greater than 1; apply more filters or reduce the query time-range.")
+      case QueryResult(_, _, _, _, _, mayBePartial, _) =>
+        mayBePartial shouldEqual false
     }
   }
 
@@ -686,7 +685,8 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
     (resp: @unchecked) match {
       case QueryResult(_, _, _, _, _, mayBePartial, partialResultReason) =>
         mayBePartial shouldEqual true
-        partialResultReason shouldEqual Some("Some shards returned a result size greater than 1; apply more filters or reduce the query time-range.")
+        partialResultReason shouldEqual Some(
+          "Some shards returned a result size greater than 1; apply more filters or reduce the query time-range.")
     }
   }
 
@@ -721,13 +721,14 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
     (resp: @unchecked) match {
       case QueryResult(_, _, _, _, _, mayBePartial, partialResultReason) =>
         mayBePartial shouldEqual true
-        partialResultReason shouldEqual Some("Some shards returned a result size greater than 1; apply more filters or reduce the query time-range.")
+        partialResultReason shouldEqual Some(
+          "Some shards returned a result size greater than 1; apply more filters or reduce the query time-range.")
     }
   }
 
   it("should not set mayBePartial in QueryResult when LabelCardinalityExec does not hit execPlanLeafSamples limit") {
     // shard 0 has 2 distinct unicode_tag values for _ws_=demo, _ns_=App-0.
-    // Limit=100 means count < limit → not  partial.
+    // Limit=100 means count < limit → not partial.
     val filters = Seq(
       ColumnFilter("_ws_", Filter.Equals("demo")),
       ColumnFilter("_ns_", Filter.Equals("App-0"))


### PR DESCRIPTION
Summary:
Metadata queries (/series, /labels, /label/values, label cardinality) previously had no way to signal that results were truncated when a shard hit its enforced limit. This PR propagates QuerySession into the metadata query paths so shards can flag resultCouldBePartial = true when the result count equals the limit, allowing callers to send a partial results warning to the user.
  
New Changes:
 - Added querySession: QuerySession parameter to TimeSeriesStore.partKeysWithFilters and its implementations in TimeSeriesShard and DownsampledTimeSeriesShard
 - Both shard implementations now set querySession.resultCouldBePartial = true with a reason when result.length == limit across all fetch paths (with/without first-last sample times, series scan, label values scan)
 - LabelValuesExec (no-filter path) sets the partial flag when returned label count equals the limit
 - LabelCardinalityExec replaces the hardcoded 1000000 cap with queryContext.plannerParams.enforcedLimits.execPlanLeafSamples to be consistent with the per-query limits.