### PR TITLE
Fix serialization error after Scala upgrade to 2.13

### DIFF
--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelChurnFinder.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelChurnFinder.scala
@@ -126,7 +126,6 @@ class LabelChurnFinder(dsSettings: DownsamplerSettings) extends Serializable wit
    */
   private def fetchLabelValues(split: (String, String),
                        shard: Int): Iterator[LabelValRow] = {
-    logger.info(s"fetchLabelValues: shard=$shard, filters=$filters")
     colStore.scanPartKeysByStartEndTimeRangeNoAsync(datasetRef, shard, split, 0,
         Long.MaxValue, 0, Long.MaxValue)
       .flatMap { pk  =>

--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelStatsKafkaProducer.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelStatsKafkaProducer.scala
@@ -24,7 +24,9 @@ import org.apache.spark.util.LongAccumulator
 class LabelStatsKafkaProducer(config: Config,
                                failuresAcc: LongAccumulator,
                                labelsAcc: LongAccumulator,
-                               workspacesAcc: LongAccumulator) extends StrictLogging {
+                               workspacesAcc: LongAccumulator,
+                               producerFactory: Map[String, String] => KafkaProducer[String, String]
+                               = LabelStatsKafkaProducer.createKafkaProducer) extends StrictLogging {
 
   import LabelChurnFinder._
 
@@ -101,15 +103,20 @@ class LabelStatsKafkaProducer(config: Config,
     broadcastPartition: org.apache.spark.broadcast.Broadcast[String],
     jobTimestamp: Instant
   ): Unit = {
+    val failuresAccLocal   = failuresAcc
+    val labelsAccLocal     = labelsAcc
+    val workspacesAccLocal = workspacesAcc
+    val localFactory       = producerFactory
+
     groupedData.foreachPartition { (partition: Iterator[Row]) =>
-      val localProducer = LabelStatsKafkaProducer.createKafkaProducer(broadcastKafkaProps.value)
+      val localProducer = localFactory(broadcastKafkaProps.value)
 
       try {
         partition.foreach { row =>
           LabelStatsKafkaProducer.publishRow(row, localProducer,
             broadcastTopic.value, broadcastPartition.value, jobTimestamp,
-            failuresAcc, labelsAcc)
-          workspacesAcc.add(1)
+            failuresAccLocal, labelsAccLocal)
+          workspacesAccLocal.add(1)
         }
         localProducer.flush()
       } finally {
@@ -231,7 +238,7 @@ object LabelStatsKafkaProducer {
   ): Unit = {
     val record = new ProducerRecord[String, String](topic, key, message.asJson.noSpaces)
 
-    producer.send(record, (metadata: RecordMetadata, exception: Exception) => {
+    producer.send(record, (_: RecordMetadata, exception: Exception) => {
       if (exception != null) {
         logger.error(s"Failed to publish for workspace=$key, partition=$partition: ${exception.getMessage}")
         failuresAcc.add(1)

--- a/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelStatsKafkaProducerSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelStatsKafkaProducerSpec.scala
@@ -8,7 +8,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.types._
 import org.mockito.ArgumentMatchers.any
-import org.mockito.MockitoSugar
+import org.mockito.{Mockito, MockitoSugar}
 import org.mockito.invocation.InvocationOnMock
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funspec.AnyFunSpec
@@ -290,6 +290,31 @@ class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAn
 
       failuresAcc.value shouldBe 1
       labelsAcc.value shouldBe 1
+    }
+
+    it("should update accumulators for all labels and workspaces via publishLabelStats") {
+      val failuresAcc   = spark.sparkContext.longAccumulator("failures")
+      val labelsAcc     = spark.sparkContext.longAccumulator("labels")
+      val workspacesAcc = spark.sparkContext.longAccumulator("workspaces")
+
+      val factory = new (Map[String, String] => KafkaProducer[String, String]) with Serializable {
+        override def apply(props: Map[String, String]): KafkaProducer[String, String] =
+          Mockito.mock(classOf[KafkaProducer[String, String]])
+      }
+
+      val producer = new LabelStatsKafkaProducer(accConfig, failuresAcc, labelsAcc, workspacesAcc, factory)
+
+      val df = createTestDataFrame(Seq(
+        ("ws-1", "All", "pod",      100L, 200L, 300L, Array[Byte](1), Array[Byte](2), Array[Byte](3)),
+        ("ws-1", "All", "instance",  50L, 100L, 150L, Array[Byte](4), Array[Byte](5), Array[Byte](6)),
+        ("ws-2", "All", "pod",       75L, 125L, 175L, Array[Byte](7), Array[Byte](8), Array[Byte](9))
+      ))
+
+      producer.publishLabelStats(df)
+
+      workspacesAcc.value shouldBe 2
+      labelsAcc.value shouldBe 3
+      failuresAcc.value shouldBe 0
     }
   }
 }


### PR DESCRIPTION
Scala 2.13 lambda compilation change broke Spark task serialization.

In Scala 2.12, lambdas referencing instance fields were compiled as anonymous classes that captured individual field values, "this" was not part of the closure.

In Scala 2.13, lambdas are compiled using invokedynamic, where the lambda body becomes a static method and "this" is passed explicitly as a captured argument.

Added an additional test to verify the behavior.