### PR TITLE
feat(core): add clearAllocations toggle

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/OffHeapMemory.scala
+++ b/core/src/main/scala/filodb.core/downsample/OffHeapMemory.scala
@@ -25,7 +25,7 @@ class OffHeapMemory(schemas: Seq[Schema],
     reclaimer = new ReclaimListener {
       override def onReclaim(metadata: Long, numBytes: Int): Unit = {}
     },
-    numPagesPerBlock = 50, evictionLock)
+    numPagesPerBlock = 50, evictionLock, storeConfig.clearAllocations)
 
   val blockMemFactory = new BlockMemFactory(blockStore, maxMetaSize, kamonTags, false)
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -454,7 +454,7 @@ class TimeSeriesShard(val ref: DatasetRef,
   // The off-heap block store used for encoded chunks
   private val shardTags = Map("dataset" -> ref.dataset, "shard" -> shardNum.toString)
   private val blockStore = new PageAlignedBlockManager(blockMemorySize, shardStats.memoryStats, reclaimListener,
-    storeConfig.numPagesPerBlock, evictionLock)
+    storeConfig.numPagesPerBlock, evictionLock, storeConfig.clearAllocations)
   private[core] val blockFactoryPool = new BlockMemFactoryPool(blockStore, maxMetaSize, shardTags)
 
   // Requires blockStore.

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -37,7 +37,10 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              acceptDuplicateSamples: Boolean,
                              // approx data resolution, used for estimating the size of data to be scanned for
                              // answering queries, specified in milliseconds
-                             estimatedIngestResolutionMillis: Int) {
+                             estimatedIngestResolutionMillis: Int,
+                             // Zeroes memory when it is first allocated.
+                             // NOTE: this will incur a memset(); memory will be eagerly allocated if enabled.
+                             clearAllocations: Boolean) {
   import collection.JavaConverters._
   def toConfig: Config =
     ConfigFactory.parseMap(Map("flush-interval" -> (flushInterval.toSeconds + "s"),
@@ -61,7 +64,8 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "evicted-pk-bloom-filter-capacity" -> evictedPkBfCapacity,
                                "metering-enabled" -> meteringEnabled,
                                "accept-duplicate-samples" -> acceptDuplicateSamples,
-                               "ingest-resolution-millis" -> estimatedIngestResolutionMillis).asJava)
+                               "ingest-resolution-millis" -> estimatedIngestResolutionMillis,
+                               "clear-allocations" -> clearAllocations).asJava)
 }
 
 final case class AssignShardConfig(address: String, shardList: Seq[Int])
@@ -99,6 +103,7 @@ object StoreConfig {
                                            |accept-duplicate-samples = false
                                            |time-aligned-chunks-enabled = false
                                            |ingest-resolution-millis = 60000
+                                           |clear-allocations = false
                                            |""".stripMargin)
   /** Pass in the config inside the store {}  */
   def apply(storeConfig: Config): StoreConfig = {
@@ -138,7 +143,8 @@ object StoreConfig {
                 config.as[Map[String, String]]("trace-filters"),
                 config.getBoolean("metering-enabled"),
                 config.getBoolean("accept-duplicate-samples"),
-                config.getInt("ingest-resolution-millis"))
+                config.getInt("ingest-resolution-millis"),
+                config.getBoolean("clear-allocations"))
   }
 }
 

--- a/core/src/main/scala/filodb.memory/BlockManager.scala
+++ b/core/src/main/scala/filodb.memory/BlockManager.scala
@@ -122,7 +122,8 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
                               val stats: MemoryStats,
                               reclaimer: ReclaimListener,
                               numPagesPerBlock: Int,
-                              reclaimLock: EvictionLock)
+                              reclaimLock: EvictionLock,
+                              clearAllocations: Boolean = false)
   extends BlockManager with StrictLogging {
   import PageAlignedBlockManager._
 
@@ -282,7 +283,7 @@ class PageAlignedBlockManager(val totalMemorySizeInBytes: Long,
     val numBlocks: Int = Math.floor(totalMemorySizeInBytes.toDouble / blockSizeInBytes).toInt
     val blocks = new util.ArrayDeque[Block]()
     logger.info(s"Allocating $numBlocks blocks of $blockSizeInBytes bytes each, total $totalMemorySizeInBytes")
-    firstPageAddress = MemoryIO.getCheckedInstance().allocateMemory(totalMemorySizeInBytes, false)
+    firstPageAddress = MemoryIO.getCheckedInstance().allocateMemory(totalMemorySizeInBytes, clearAllocations)
     for (i <- 0 until numBlocks) {
       val address = firstPageAddress + (i * blockSizeInBytes)
       blocks.add(new Block(address, blockSizeInBytes, reclaimer))

--- a/core/src/test/scala/filodb.memory/PageAlignedBlockManagerSpec.scala
+++ b/core/src/test/scala/filodb.memory/PageAlignedBlockManagerSpec.scala
@@ -8,6 +8,8 @@ import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import filodb.memory.format.UnsafeUtils
+
 object PageAlignedBlockManagerSpec {
   val testReclaimer = new ReclaimListener {
     var reclaimedBytes = 0
@@ -264,6 +266,21 @@ class PageAlignedBlockManagerSpec extends AnyFlatSpec with Matchers with BeforeA
     // Should reclaim multiple blocks.
     blockManager.numFreeBlocks shouldEqual 5
 
+    blockManager.releaseBlocks()
+  }
+
+  /**
+   * This is more of a sanity-check than anything; the OS may not even return dirty,
+   *   non-zeroed memory when malloc() is called.
+   */
+  it should "zero block memory when clearAllocations is true" in {
+    val stats = new MemoryStats(Map("zeroTest" -> "zeroTest"))
+    val blockManager = new PageAlignedBlockManager(
+      2 * pageSize, stats, testReclaimer, 1, evictionLock, clearAllocations = true)
+    val block = blockManager.requestBlock(false).get
+    for (offset <- 0L until block.capacity) {
+      UnsafeUtils.unsafe.getByte(block.address + offset) shouldEqual 0.toByte
+    }
     blockManager.releaseBlocks()
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Currently, when memory is allocated by a `BlockManager`, it is hard-coded to never zero the memory.

**New behavior :**

This PR instead adds a configurable toggle to zero allocated memory.

**BREAKING CHANGES**

When `clearAllocations` is enabled, we expect that [memory will be allocated eagerly](https://github.com/jnr/jffi/blob/774a37fe1e11a0aa25761d908d493ad8e7b628b5/jni/jffi/MemoryIO.c#L392); it is currently allocated lazily. This will (hopefully) help prevent gradual, memory-induced performance degradation over time, but its other side-effects are currently unknown.