### PR TITLE
feat(core): add zero-alloc lookup, iteration, and filtering to MapEncoder

### DIFF
--- a/core/src/main/scala/filodb.core/binaryrecord2/MapEncoder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/MapEncoder.scala
@@ -139,12 +139,25 @@ object MapEncoder {
     if (data == null || data.length == 0 || key == null) return null
 
     val keyBytes = key.getBytes(StandardCharsets.UTF_8)
-    var pos = 0
-    while (pos < data.length) {
-      if (keyMatchesAtPos(data, pos, schema, keyBytes)) {
-        return decodeValueAtPos(data, pos)
+    val keyKey = RecordSchema.makeKeyKey(keyBytes, 0, keyBytes.length, 7)
+    val predefNum = schema.predefKeyNumMap.getOrElse(keyKey, -1)
+
+    if (predefNum >= 0) {
+      val expectedByte = (0xC0 | predefNum).toByte
+      var pos = 0
+      while (pos < data.length) {
+        if (data(pos) == expectedByte) return decodeValueAtPos(data, pos)
+        pos += entryByteLength(data, pos)
       }
-      pos += entryByteLength(data, pos)
+    } else {
+      var pos = 0
+      while (pos < data.length) {
+        val firstByte = data(pos) & 0xFF
+        if ((firstByte ^ 0xC0) >= 64 && keyMatchesAtPos(data, pos, schema, keyBytes)) {
+          return decodeValueAtPos(data, pos)
+        }
+        pos += entryByteLength(data, pos)
+      }
     }
     null
   }

--- a/core/src/main/scala/filodb.core/binaryrecord2/MapEncoder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/MapEncoder.scala
@@ -36,13 +36,13 @@ object MapEncoder {
 
   /**
    * Encode a tag map into RecordBuilder's wire format with predefined key handling.
-   * TreeMap guarantees keys are sorted, matching RecordBuilder's convention.
+   * SortedMap guarantees keys are sorted, matching RecordBuilder's convention.
    *
-   * @param tags TreeMap of tag key-value pairs (sorted by key)
+   * @param tags SortedMap of tag key-value pairs (sorted by key)
    * @param schema the RecordSchema with predefined key definitions for encoding
    * @return encoded byte[] in RecordBuilder wire format
    */
-  def encode(tags: java.util.TreeMap[String, String], schema: RecordSchema): Array[Byte] = {
+  def encode(tags: java.util.SortedMap[String, String], schema: RecordSchema): Array[Byte] = {
     if (tags == null || tags.isEmpty) return EMPTY
 
     // Upper bound: each entry at most 1 + keyLen*3 + 2 + valLen*3 (UTF-8 worst case)

--- a/core/src/main/scala/filodb.core/binaryrecord2/MapEncoder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/MapEncoder.scala
@@ -207,8 +207,28 @@ object MapEncoder {
   }
 
   /**
-   * Shared implementation for retain/remove. Walks encoded bytes, resolves each key,
-   * and copies entry bytes to the output buffer based on set membership.
+   * Overload of retain that accepts pre-encoded UTF-8 key byte arrays.
+   * Both sides compared as raw bytes — zero per-entry String allocation.
+   * Caller should convert keys to bytes once and reuse across calls.
+   */
+  def retain(data: Array[Byte], schema: RecordSchema,
+             keysToKeep: Array[Array[Byte]]): Array[Byte] = {
+    filterEntriesByBytes(data, schema, keysToKeep, keep = true)
+  }
+
+  /**
+   * Overload of remove that accepts pre-encoded UTF-8 key byte arrays.
+   * Both sides compared as raw bytes — zero per-entry String allocation.
+   * Caller should convert keys to bytes once and reuse across calls.
+   */
+  def remove(data: Array[Byte], schema: RecordSchema,
+             keysToRemove: Array[Array[Byte]]): Array[Byte] = {
+    filterEntriesByBytes(data, schema, keysToRemove, keep = false)
+  }
+
+  /**
+   * Shared implementation for retain/remove (String version). Walks encoded bytes,
+   * resolves each key to a String, and checks set membership.
    *
    * @param keep if true, keeps entries IN the set (retain). If false, keeps entries NOT in the set (remove).
    */
@@ -219,7 +239,7 @@ object MapEncoder {
       return if (keep) EMPTY else util.Arrays.copyOf(data, data.length)
     }
 
-    val buf = new Array[Byte](data.length) // output can't be larger than input
+    val buf = new Array[Byte](data.length)
     var outPos = 0
     var pos = 0
 
@@ -237,6 +257,48 @@ object MapEncoder {
 
     if (outPos == 0) EMPTY
     else util.Arrays.copyOf(buf, outPos)
+  }
+
+  /**
+   * Shared implementation for retain/remove (byte array version). Walks encoded
+   * bytes, matches each key via byte comparison — zero per-entry String allocation.
+   *
+   * @param keep if true, keeps entries IN the set (retain). If false, keeps entries NOT in the set (remove).
+   */
+  private def filterEntriesByBytes(data: Array[Byte], schema: RecordSchema,
+                                   keys: Array[Array[Byte]], keep: Boolean): Array[Byte] = {
+    if (data == null || data.length == 0) return EMPTY
+    if (keys == null || keys.length == 0) {
+      return if (keep) EMPTY else util.Arrays.copyOf(data, data.length)
+    }
+
+    val buf = new Array[Byte](data.length)
+    var outPos = 0
+    var pos = 0
+
+    while (pos < data.length) {
+      val entryLen = entryByteLength(data, pos)
+      val inSet = entryKeyMatchesAny(data, pos, schema, keys)
+
+      if ((keep && inSet) || (!keep && !inSet)) {
+        System.arraycopy(data, pos, buf, outPos, entryLen)
+        outPos += entryLen
+      }
+      pos += entryLen
+    }
+
+    if (outPos == 0) EMPTY
+    else util.Arrays.copyOf(buf, outPos)
+  }
+
+  private def entryKeyMatchesAny(data: Array[Byte], pos: Int, schema: RecordSchema,
+                                 keys: Array[Array[Byte]]): Boolean = {
+    var i = 0
+    while (i < keys.length) {
+      if (keyMatchesAtPos(data, pos, schema, keys(i))) return true
+      i += 1
+    }
+    false
   }
 
   /** Check if the encoded key at pos matches keyBytes without allocating a String. */

--- a/core/src/main/scala/filodb.core/binaryrecord2/MapEncoder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/MapEncoder.scala
@@ -8,6 +8,13 @@ import filodb.memory.UTF8StringShort
 import filodb.memory.format.UnsafeUtils
 import filodb.memory.format.UnsafeUtils.{arayOffset, setByte}
 
+/**
+ * Callback for iterating over encoded map entries via MapEncoder.forEach.
+ */
+trait MapEntryConsumer {
+  def consume(key: String, value: String): Unit
+}
+
 // scalastyle:off null
 /**
  * Stateless utility for encoding/decoding tag maps in RecordBuilder's exact wire format.
@@ -123,4 +130,160 @@ object MapEncoder {
 
   /** Check if encoded map bytes are empty. */
   def isEmpty(data: Array[Byte]): Boolean = data == null || data.length == 0
+
+  /**
+   * Look up a single key's value in encoded bytes without decoding the entire map.
+   * Returns null if the key is not found.
+   */
+  def getValue(data: Array[Byte], schema: RecordSchema, key: String): String = {
+    if (data == null || data.length == 0 || key == null) return null
+
+    val keyBytes = key.getBytes(StandardCharsets.UTF_8)
+    var pos = 0
+    while (pos < data.length) {
+      if (keyMatchesAtPos(data, pos, schema, keyBytes)) {
+        return decodeValueAtPos(data, pos)
+      }
+      pos += entryByteLength(data, pos)
+    }
+    null
+  }
+
+  /**
+   * Iterate all entries, invoking consumer with decoded key and value Strings.
+   * No Map allocation — entries are streamed one at a time.
+   */
+  def forEach(data: Array[Byte], schema: RecordSchema, consumer: MapEntryConsumer): Unit = {
+    if (data == null || data.length == 0) return
+
+    var pos = 0
+    while (pos < data.length) {
+      consumer.consume(resolveKeyAtPos(data, pos, schema), decodeValueAtPos(data, pos))
+      pos += entryByteLength(data, pos)
+    }
+  }
+
+  /**
+   * Return new encoded bytes containing only entries whose key is in keysToKeep.
+   * Entry bytes are copied directly — values are never decoded to String.
+   */
+  def retain(data: Array[Byte], schema: RecordSchema,
+             keysToKeep: java.util.Set[String]): Array[Byte] = {
+    filterEntries(data, schema, keysToKeep, keep = true)
+  }
+
+  /**
+   * Return new encoded bytes with entries whose key is in keysToRemove removed.
+   * Entry bytes are copied directly — values are never decoded to String.
+   */
+  def remove(data: Array[Byte], schema: RecordSchema,
+             keysToRemove: java.util.Set[String]): Array[Byte] = {
+    filterEntries(data, schema, keysToRemove, keep = false)
+  }
+
+  /**
+   * Shared implementation for retain/remove. Walks encoded bytes, resolves each key,
+   * and copies entry bytes to the output buffer based on set membership.
+   *
+   * @param keep if true, keeps entries IN the set (retain). If false, keeps entries NOT in the set (remove).
+   */
+  private def filterEntries(data: Array[Byte], schema: RecordSchema,
+                            keySet: java.util.Set[String], keep: Boolean): Array[Byte] = {
+    if (data == null || data.length == 0) return EMPTY
+    if (keySet == null || keySet.isEmpty) {
+      return if (keep) EMPTY else util.Arrays.copyOf(data, data.length)
+    }
+
+    val buf = new Array[Byte](data.length) // output can't be larger than input
+    var outPos = 0
+    var pos = 0
+
+    while (pos < data.length) {
+      val keyStr = resolveKeyAtPos(data, pos, schema)
+      val entryLen = entryByteLength(data, pos)
+
+      val inSet = keySet.contains(keyStr)
+      if ((keep && inSet) || (!keep && !inSet)) {
+        System.arraycopy(data, pos, buf, outPos, entryLen)
+        outPos += entryLen
+      }
+      pos += entryLen
+    }
+
+    if (outPos == 0) EMPTY
+    else util.Arrays.copyOf(buf, outPos)
+  }
+
+  /** Check if the encoded key at pos matches keyBytes without allocating a String. */
+  private def keyMatchesAtPos(data: Array[Byte], pos: Int, schema: RecordSchema,
+                              keyBytes: Array[Byte]): Boolean = {
+    val firstByte = data(pos) & 0xFF
+    val predefIndex = firstByte ^ 0xC0
+    if (predefIndex < 64) {
+      val keyOff = schema.predefKeyOffsets(predefIndex)
+      val keyLen = UTF8StringShort.numBytes(schema.predefKeyBytes, keyOff)
+      if (keyLen != keyBytes.length) return false
+      val startIdx = (keyOff + 1 - UnsafeUtils.arayOffset).toInt
+      var i = 0
+      while (i < keyLen) {
+        if (keyBytes(i) != schema.predefKeyBytes(startIdx + i)) return false
+        i += 1
+      }
+      true
+    } else {
+      val keyLen = firstByte
+      if (keyLen != keyBytes.length) return false
+      var i = 0
+      while (i < keyLen) {
+        if (keyBytes(i) != data(pos + 1 + i)) return false
+        i += 1
+      }
+      true
+    }
+  }
+
+  /** Resolve the key String at the given position in encoded data. */
+  private def resolveKeyAtPos(data: Array[Byte], pos: Int, schema: RecordSchema): String = {
+    val firstByte = data(pos) & 0xFF
+    val predefIndex = firstByte ^ 0xC0
+    if (predefIndex < 64) {
+      val keyOff = schema.predefKeyOffsets(predefIndex)
+      val keyLen = UTF8StringShort.numBytes(schema.predefKeyBytes, keyOff)
+      new String(schema.predefKeyBytes,
+        (keyOff + 1 - UnsafeUtils.arayOffset).toInt, keyLen, StandardCharsets.UTF_8)
+    } else {
+      val keyLen = firstByte
+      new String(data, pos + 1, keyLen, StandardCharsets.UTF_8)
+    }
+  }
+
+  /** Decode the value String at the given entry position. */
+  private def decodeValueAtPos(data: Array[Byte], pos: Int): String = {
+    val firstByte = data(pos) & 0xFF
+    val predefIndex = firstByte ^ 0xC0
+    if (predefIndex < 64) {
+      val valLen = UnsafeUtils.getShort(data, UnsafeUtils.arayOffset + pos + 1) & 0xFFFF
+      new String(data, pos + 3, valLen, StandardCharsets.UTF_8)
+    } else {
+      val keyLen = firstByte
+      val valLenPos = pos + 1 + keyLen
+      val valLen = UnsafeUtils.getShort(data, UnsafeUtils.arayOffset + valLenPos) & 0xFFFF
+      new String(data, valLenPos + 2, valLen, StandardCharsets.UTF_8)
+    }
+  }
+
+  /** Compute the total byte length of the entry at the given position. */
+  private def entryByteLength(data: Array[Byte], pos: Int): Int = {
+    val firstByte = data(pos) & 0xFF
+    val predefIndex = firstByte ^ 0xC0
+    if (predefIndex < 64) {
+      val valLen = UnsafeUtils.getShort(data, UnsafeUtils.arayOffset + pos + 1) & 0xFFFF
+      3 + valLen
+    } else {
+      val keyLen = firstByte
+      val valLenPos = pos + 1 + keyLen
+      val valLen = UnsafeUtils.getShort(data, UnsafeUtils.arayOffset + valLenPos) & 0xFFFF
+      1 + keyLen + 2 + valLen
+    }
+  }
 }

--- a/core/src/main/scala/filodb.core/binaryrecord2/MapEncoder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/MapEncoder.scala
@@ -15,6 +15,17 @@ trait MapEntryConsumer {
   def consume(key: String, value: String): Unit
 }
 
+/**
+ * Zero-allocation callback for iterating over encoded map entries via
+ * MapEncoder.forEachBytes.  Key and value are delivered as (base, offset, length)
+ * triples pointing directly into either the encoded data or the schema's
+ * predefined-key byte array — no String objects are created.
+ */
+trait MapEntryBytesConsumer {
+  def consume(keyBase: Array[Byte], keyOffset: Int, keyLen: Int,
+              valBase: Array[Byte], valOffset: Int, valLen: Int): Unit
+}
+
 // scalastyle:off null
 /**
  * Stateless utility for encoding/decoding tag maps in RecordBuilder's exact wire format.
@@ -177,14 +188,47 @@ object MapEncoder {
   /**
    * Iterate all entries, invoking consumer with decoded key and value Strings.
    * No Map allocation — entries are streamed one at a time.
+   * Delegates to forEachBytes so the entry header is parsed exactly once per entry.
    */
   def forEach(data: Array[Byte], schema: RecordSchema, consumer: MapEntryConsumer): Unit = {
+    forEachBytes(data, schema, new MapEntryBytesConsumer {
+      override def consume(keyBase: Array[Byte], keyOffset: Int, keyLen: Int,
+                           valBase: Array[Byte], valOffset: Int, valLen: Int): Unit = {
+        consumer.consume(
+          new String(keyBase, keyOffset, keyLen, StandardCharsets.UTF_8),
+          new String(valBase, valOffset, valLen, StandardCharsets.UTF_8))
+      }
+    })
+  }
+
+  /**
+   * Zero-allocation iteration: delivers raw byte slices for each key and value.
+   * Key bytes point into schema.predefKeyBytes (predefined keys) or data (full keys).
+   * Value bytes always point into data.  The entry header is parsed exactly once
+   * per entry — no redundant helper calls.
+   */
+  def forEachBytes(data: Array[Byte], schema: RecordSchema, consumer: MapEntryBytesConsumer): Unit = {
     if (data == null || data.length == 0) return
 
     var pos = 0
     while (pos < data.length) {
-      consumer.consume(resolveKeyAtPos(data, pos, schema), decodeValueAtPos(data, pos))
-      pos += entryByteLength(data, pos)
+      val firstByte = data(pos) & 0xFF
+      val predefIndex = firstByte ^ 0xC0
+      if (predefIndex < 64) {
+        val keyOff = schema.predefKeyOffsets(predefIndex)
+        val keyLen = UTF8StringShort.numBytes(schema.predefKeyBytes, keyOff)
+        val valLen = UnsafeUtils.getShort(data, UnsafeUtils.arayOffset + pos + 1) & 0xFFFF
+        consumer.consume(schema.predefKeyBytes, (keyOff + 1 - UnsafeUtils.arayOffset).toInt, keyLen,
+                         data, pos + 3, valLen)
+        pos += 3 + valLen
+      } else {
+        val keyLen = firstByte
+        val valLenPos = pos + 1 + keyLen
+        val valLen = UnsafeUtils.getShort(data, UnsafeUtils.arayOffset + valLenPos) & 0xFFFF
+        consumer.consume(data, pos + 1, keyLen,
+                         data, valLenPos + 2, valLen)
+        pos += 1 + keyLen + 2 + valLen
+      }
     }
   }
 

--- a/core/src/main/scala/filodb.core/binaryrecord2/MapEncoder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/MapEncoder.scala
@@ -131,6 +131,18 @@ object MapEncoder {
   /** Check if encoded map bytes are empty. */
   def isEmpty(data: Array[Byte]): Boolean = data == null || data.length == 0
 
+  /** Return the number of entries in encoded map bytes. */
+  def size(data: Array[Byte]): Int = {
+    if (data == null || data.length == 0) return 0
+    var n = 0
+    var pos = 0
+    while (pos < data.length) {
+      pos += entryByteLength(data, pos)
+      n += 1
+    }
+    n
+  }
+
   /**
    * Look up a single key's value in encoded bytes without decoding the entire map.
    * Returns null if the key is not found.

--- a/core/src/test/scala/filodb.core/binaryrecord2/MapEncoderSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/MapEncoderSpec.scala
@@ -305,6 +305,9 @@ class MapEncoderSpec extends AnyFunSpec with Matchers {
     hash1 shouldEqual hash2
   }
 
+  private def toByteArrays(keys: String*): Array[Array[Byte]] =
+    keys.map(_.getBytes(StandardCharsets.UTF_8)).toArray
+
   // ── RecordBuilder.encodeMapFrom(TreeMap) tests ─────────────────────
   // Verifies that encodeMapFrom produces identical records to addMap (Scala path).
 
@@ -842,6 +845,125 @@ class MapEncoderSpec extends AnyFunSpec with Matchers {
         }
 
         // Union equals original
+        val union = new TreeMap[String, String]()
+        union.putAll(retained)
+        union.putAll(removed)
+        union shouldEqual tags
+      }
+    }
+  }
+
+  describe("MapEncoder.retain (bytes)") {
+    it("should keep only specified keys (predefined and non-predefined)") {
+      val tags = sortedMap("_ws_" -> "ws", "_ns_" -> "ns", "dc" -> "us-west-2", "region" -> "us-east-1")
+      val encoded = MapEncoder.encode(tags, partSchema)
+
+      val retained = MapEncoder.retain(encoded, partSchema, toByteArrays("_ws_", "_ns_"))
+      MapEncoder.size(retained) shouldEqual 2
+      MapEncoder.getValue(retained, partSchema, "_ws_") shouldEqual "ws"
+      MapEncoder.getValue(retained, partSchema, "_ns_") shouldEqual "ns"
+    }
+
+    it("should return EMPTY when no keys match") {
+      val tags = sortedMap("_ws_" -> "ws", "_ns_" -> "ns")
+      val encoded = MapEncoder.encode(tags, partSchema)
+
+      val retained = MapEncoder.retain(encoded, partSchema, toByteArrays("missing"))
+      MapEncoder.isEmpty(retained) shouldBe true
+    }
+
+    it("should return EMPTY for empty keys array") {
+      val tags = sortedMap("_ws_" -> "ws")
+      val encoded = MapEncoder.encode(tags, partSchema)
+      MapEncoder.isEmpty(MapEncoder.retain(encoded, partSchema, Array.empty[Array[Byte]])) shouldBe true
+    }
+
+    it("should handle null/empty data") {
+      val keys = toByteArrays("_ws_")
+      MapEncoder.isEmpty(MapEncoder.retain(null, partSchema, keys)) shouldBe true
+      MapEncoder.isEmpty(MapEncoder.retain(MapEncoder.EMPTY, partSchema, keys)) shouldBe true
+    }
+
+    it("should produce identical results to String-based retain") {
+      testTagMaps.foreach { case (_, tags) =>
+        val encoded = MapEncoder.encode(tags, partSchema)
+        val keysToKeep = new JHashSet[String]()
+        keysToKeep.add("_ws_")
+        keysToKeep.add("_ns_")
+
+        val fromString = MapEncoder.retain(encoded, partSchema, keysToKeep)
+        val fromBytes = MapEncoder.retain(encoded, partSchema, toByteArrays("_ws_", "_ns_"))
+
+        MapEncoder.toJavaMap(fromBytes, partSchema) shouldEqual MapEncoder.toJavaMap(fromString, partSchema)
+      }
+    }
+  }
+
+  describe("MapEncoder.remove (bytes)") {
+    it("should remove specified keys") {
+      val tags = sortedMap("_ws_" -> "ws", "_ns_" -> "ns", "dc" -> "us-west-2", "region" -> "us-east-1")
+      val encoded = MapEncoder.encode(tags, partSchema)
+
+      val removed = MapEncoder.remove(encoded, partSchema, toByteArrays("_ws_", "_ns_"))
+      MapEncoder.size(removed) shouldEqual 2
+      MapEncoder.getValue(removed, partSchema, "dc") shouldEqual "us-west-2"
+      MapEncoder.getValue(removed, partSchema, "region") shouldEqual "us-east-1"
+    }
+
+    it("should return all entries when no keys match") {
+      val tags = sortedMap("_ws_" -> "ws", "_ns_" -> "ns")
+      val encoded = MapEncoder.encode(tags, partSchema)
+
+      val removed = MapEncoder.remove(encoded, partSchema, toByteArrays("missing"))
+      MapEncoder.size(removed) shouldEqual tags.size()
+      MapEncoder.toJavaMap(removed, partSchema) shouldEqual tags
+    }
+
+    it("should return copy of all entries for empty keys array") {
+      val tags = sortedMap("_ws_" -> "ws", "_ns_" -> "ns")
+      val encoded = MapEncoder.encode(tags, partSchema)
+      val removed = MapEncoder.remove(encoded, partSchema, Array.empty[Array[Byte]])
+      MapEncoder.size(removed) shouldEqual tags.size()
+      MapEncoder.toJavaMap(removed, partSchema) shouldEqual tags
+    }
+
+    it("should handle null/empty data") {
+      val keys = toByteArrays("_ws_")
+      MapEncoder.isEmpty(MapEncoder.remove(null, partSchema, keys)) shouldBe true
+      MapEncoder.isEmpty(MapEncoder.remove(MapEncoder.EMPTY, partSchema, keys)) shouldBe true
+    }
+
+    it("should produce identical results to String-based remove") {
+      testTagMaps.foreach { case (_, tags) =>
+        val encoded = MapEncoder.encode(tags, partSchema)
+        val keysToRemove = new JHashSet[String]()
+        keysToRemove.add("_ws_")
+        keysToRemove.add("_ns_")
+
+        val fromString = MapEncoder.remove(encoded, partSchema, keysToRemove)
+        val fromBytes = MapEncoder.remove(encoded, partSchema, toByteArrays("_ws_", "_ns_"))
+
+        MapEncoder.toJavaMap(fromBytes, partSchema) shouldEqual MapEncoder.toJavaMap(fromString, partSchema)
+      }
+    }
+  }
+
+  describe("retain(bytes) and remove(bytes) are complementary") {
+    it("should produce non-overlapping partitions that union to original") {
+      testTagMaps.foreach { case (_, tags) =>
+        val encoded = MapEncoder.encode(tags, partSchema)
+        val keys = toByteArrays("_ws_", "_ns_")
+
+        val retained = MapEncoder.toJavaMap(MapEncoder.retain(encoded, partSchema, keys), partSchema)
+        val removed = MapEncoder.toJavaMap(MapEncoder.remove(encoded, partSchema, keys), partSchema)
+
+        (retained.size() + removed.size()) shouldEqual tags.size()
+
+        val retainedIter = retained.keySet().iterator()
+        while (retainedIter.hasNext) {
+          removed.containsKey(retainedIter.next()) shouldBe false
+        }
+
         val union = new TreeMap[String, String]()
         union.putAll(retained)
         union.putAll(removed)

--- a/core/src/test/scala/filodb.core/binaryrecord2/MapEncoderSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/MapEncoderSpec.scala
@@ -630,6 +630,13 @@ class MapEncoderSpec extends AnyFunSpec with Matchers {
       MapEncoder.getValue(encoded, partSchema, "missing") shouldBe null
     }
 
+    it("should return null for absent predefined key") {
+      val tags = sortedMap("dc" -> "us-west-2", "region" -> "us-east-1")
+      val encoded = MapEncoder.encode(tags, partSchema)
+      MapEncoder.getValue(encoded, partSchema, "_ws_") shouldBe null
+      MapEncoder.getValue(encoded, partSchema, "_ns_") shouldBe null
+    }
+
     it("should return null for null/empty data") {
       MapEncoder.getValue(null, partSchema, "_ws_") shouldBe null
       MapEncoder.getValue(MapEncoder.EMPTY, partSchema, "_ws_") shouldBe null
@@ -750,6 +757,13 @@ class MapEncoderSpec extends AnyFunSpec with Matchers {
         val retained = MapEncoder.retain(encoded, partSchema, keysToKeep)
         val decoded = MapEncoder.toJavaMap(retained, partSchema)
 
+        var expectedCount = 0
+        val keysIter = keysToKeep.iterator()
+        while (keysIter.hasNext) {
+          if (tags.containsKey(keysIter.next())) expectedCount += 1
+        }
+        decoded.size() shouldEqual expectedCount
+
         val iter = decoded.entrySet().iterator()
         while (iter.hasNext) {
           val entry = iter.next()
@@ -817,6 +831,9 @@ class MapEncoderSpec extends AnyFunSpec with Matchers {
 
         val retained = MapEncoder.toJavaMap(MapEncoder.retain(encoded, partSchema, keysToKeep), partSchema)
         val removed = MapEncoder.toJavaMap(MapEncoder.remove(encoded, partSchema, keysToKeep), partSchema)
+
+        // Sizes must be disjoint and sum to original
+        (retained.size() + removed.size()) shouldEqual tags.size()
 
         // No overlap
         val retainedIter = retained.keySet().iterator()

--- a/core/src/test/scala/filodb.core/binaryrecord2/MapEncoderSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/MapEncoderSpec.scala
@@ -710,6 +710,131 @@ class MapEncoderSpec extends AnyFunSpec with Matchers {
     }
   }
 
+  describe("MapEncoder.forEachBytes") {
+    it("should deliver correct byte slices for predefined and non-predefined keys") {
+      val tags = sortedMap(
+        "_ns_" -> "filodb-local", "_ws_" -> "aci-telemetry",
+        "dc" -> "us-west-2", "region" -> "us-east-1"
+      )
+      val encoded = MapEncoder.encode(tags, partSchema)
+
+      val collected = new JLinkedHashMap[String, String]()
+      MapEncoder.forEachBytes(encoded, partSchema, new MapEntryBytesConsumer {
+        override def consume(keyBase: Array[Byte], keyOffset: Int, keyLen: Int,
+                             valBase: Array[Byte], valOffset: Int, valLen: Int): Unit = {
+          val k = new String(keyBase, keyOffset, keyLen, StandardCharsets.UTF_8)
+          val v = new String(valBase, valOffset, valLen, StandardCharsets.UTF_8)
+          collected.put(k, v)
+        }
+      })
+
+      collected.size() shouldEqual tags.size()
+      val collectedIter = collected.entrySet().iterator()
+      val tagsIter = tags.entrySet().iterator()
+      while (collectedIter.hasNext) {
+        val c = collectedIter.next()
+        val t = tagsIter.next()
+        c.getKey shouldEqual t.getKey
+        c.getValue shouldEqual t.getValue
+      }
+    }
+
+    it("should handle empty/null data") {
+      var called = false
+      val consumer = new MapEntryBytesConsumer {
+        override def consume(keyBase: Array[Byte], keyOffset: Int, keyLen: Int,
+                             valBase: Array[Byte], valOffset: Int, valLen: Int): Unit = called = true
+      }
+      MapEncoder.forEachBytes(null, partSchema, consumer)
+      called shouldBe false
+      MapEncoder.forEachBytes(MapEncoder.EMPTY, partSchema, consumer)
+      called shouldBe false
+    }
+
+    it("should produce identical results to String-based forEach for all test maps") {
+      testTagMaps.foreach { case (_, tags) =>
+        val encoded = MapEncoder.encode(tags, partSchema)
+
+        val fromString = new TreeMap[String, String]()
+        MapEncoder.forEach(encoded, partSchema, new MapEntryConsumer {
+          override def consume(key: String, value: String): Unit = fromString.put(key, value)
+        })
+
+        val fromBytes = new TreeMap[String, String]()
+        MapEncoder.forEachBytes(encoded, partSchema, new MapEntryBytesConsumer {
+          override def consume(keyBase: Array[Byte], keyOffset: Int, keyLen: Int,
+                               valBase: Array[Byte], valOffset: Int, valLen: Int): Unit = {
+            fromBytes.put(
+              new String(keyBase, keyOffset, keyLen, StandardCharsets.UTF_8),
+              new String(valBase, valOffset, valLen, StandardCharsets.UTF_8))
+          }
+        })
+
+        fromBytes shouldEqual fromString
+      }
+    }
+
+    it("should handle predefined-keys-only maps") {
+      val tags = sortedMap("_ns_" -> "ns", "_ws_" -> "ws")
+      val encoded = MapEncoder.encode(tags, partSchema)
+
+      val collected = new TreeMap[String, String]()
+      MapEncoder.forEachBytes(encoded, partSchema, new MapEntryBytesConsumer {
+        override def consume(keyBase: Array[Byte], keyOffset: Int, keyLen: Int,
+                             valBase: Array[Byte], valOffset: Int, valLen: Int): Unit = {
+          collected.put(
+            new String(keyBase, keyOffset, keyLen, StandardCharsets.UTF_8),
+            new String(valBase, valOffset, valLen, StandardCharsets.UTF_8))
+        }
+      })
+      collected shouldEqual tags
+    }
+
+    it("should handle non-predefined-keys-only maps") {
+      val tags = sortedMap("custom1" -> "val1", "custom2" -> "val2", "region" -> "us-east-1")
+      val encoded = MapEncoder.encode(tags, partSchema)
+
+      val collected = new TreeMap[String, String]()
+      MapEncoder.forEachBytes(encoded, partSchema, new MapEntryBytesConsumer {
+        override def consume(keyBase: Array[Byte], keyOffset: Int, keyLen: Int,
+                             valBase: Array[Byte], valOffset: Int, valLen: Int): Unit = {
+          collected.put(
+            new String(keyBase, keyOffset, keyLen, StandardCharsets.UTF_8),
+            new String(valBase, valOffset, valLen, StandardCharsets.UTF_8))
+        }
+      })
+      collected shouldEqual tags
+    }
+
+    it("should point key bytes into schema.predefKeyBytes for predefined keys") {
+      val tags = sortedMap("_ws_" -> "ws")
+      val encoded = MapEncoder.encode(tags, partSchema)
+
+      var receivedKeyBase: Array[Byte] = null
+      MapEncoder.forEachBytes(encoded, partSchema, new MapEntryBytesConsumer {
+        override def consume(keyBase: Array[Byte], keyOffset: Int, keyLen: Int,
+                             valBase: Array[Byte], valOffset: Int, valLen: Int): Unit = {
+          receivedKeyBase = keyBase
+        }
+      })
+      (receivedKeyBase eq partSchema.predefKeyBytes) shouldBe true
+    }
+
+    it("should point key bytes into data array for non-predefined keys") {
+      val tags = sortedMap("custom" -> "val")
+      val encoded = MapEncoder.encode(tags, partSchema)
+
+      var receivedKeyBase: Array[Byte] = null
+      MapEncoder.forEachBytes(encoded, partSchema, new MapEntryBytesConsumer {
+        override def consume(keyBase: Array[Byte], keyOffset: Int, keyLen: Int,
+                             valBase: Array[Byte], valOffset: Int, valLen: Int): Unit = {
+          receivedKeyBase = keyBase
+        }
+      })
+      (receivedKeyBase eq encoded) shouldBe true
+    }
+  }
+
   describe("MapEncoder.retain") {
     it("should keep only specified keys") {
       val tags = sortedMap("_ws_" -> "ws", "_ns_" -> "ns", "dc" -> "us-west-2", "region" -> "us-east-1")

--- a/core/src/test/scala/filodb.core/binaryrecord2/MapEncoderSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/MapEncoderSpec.scala
@@ -2,6 +2,7 @@ package filodb.core.binaryrecord2
 
 import java.nio.charset.StandardCharsets
 import java.util.TreeMap
+import java.util.{HashSet => JHashSet, LinkedHashMap => JLinkedHashMap}
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -591,6 +592,228 @@ class MapEncoderSpec extends AnyFunSpec with Matchers {
 
       recordBytes(scalaBase, scalaOff) shouldEqual
         recordBytes(treeBase, treeOff)
+    }
+  }
+
+  describe("MapEncoder.getValue") {
+    it("should return value for predefined key") {
+      val tags = sortedMap("_ws_" -> "aci-telemetry", "_ns_" -> "filodb-local", "dc" -> "us-west-2")
+      val encoded = MapEncoder.encode(tags, partSchema)
+      MapEncoder.getValue(encoded, partSchema, "_ws_") shouldEqual "aci-telemetry"
+      MapEncoder.getValue(encoded, partSchema, "_ns_") shouldEqual "filodb-local"
+    }
+
+    it("should return value for non-predefined key") {
+      val tags = sortedMap("_ws_" -> "ws", "region" -> "us-east-1", "custom_key" -> "custom_val")
+      val encoded = MapEncoder.encode(tags, partSchema)
+      MapEncoder.getValue(encoded, partSchema, "region") shouldEqual "us-east-1"
+      MapEncoder.getValue(encoded, partSchema, "custom_key") shouldEqual "custom_val"
+    }
+
+    it("should return null for missing key") {
+      val tags = sortedMap("_ws_" -> "ws", "_ns_" -> "ns")
+      val encoded = MapEncoder.encode(tags, partSchema)
+      MapEncoder.getValue(encoded, partSchema, "missing") shouldBe null
+    }
+
+    it("should return null for null/empty data") {
+      MapEncoder.getValue(null, partSchema, "_ws_") shouldBe null
+      MapEncoder.getValue(MapEncoder.EMPTY, partSchema, "_ws_") shouldBe null
+    }
+
+    it("should return null for null key") {
+      val tags = sortedMap("_ws_" -> "ws")
+      val encoded = MapEncoder.encode(tags, partSchema)
+      MapEncoder.getValue(encoded, partSchema, null) shouldBe null
+    }
+
+    it("should match getValue results with toJavaMap.get for all test maps") {
+      testTagMaps.foreach { case (desc, tags) =>
+        val encoded = MapEncoder.encode(tags, partSchema)
+        val decoded = MapEncoder.toJavaMap(encoded, partSchema)
+        val iter = tags.entrySet().iterator()
+        while (iter.hasNext) {
+          val entry = iter.next()
+          MapEncoder.getValue(encoded, partSchema, entry.getKey) shouldEqual decoded.get(entry.getKey)
+        }
+      }
+    }
+  }
+
+  describe("MapEncoder.forEach") {
+    it("should iterate all entries in order matching toJavaMap") {
+      val tags = sortedMap(
+        "_ns_" -> "filodb-local", "_ws_" -> "aci-telemetry",
+        "dc" -> "us-west-2", "region" -> "us-east-1"
+      )
+      val encoded = MapEncoder.encode(tags, partSchema)
+
+      val collected = new JLinkedHashMap[String, String]()
+      MapEncoder.forEach(encoded, partSchema, new MapEntryConsumer {
+        override def consume(key: String, value: String): Unit = collected.put(key, value)
+      })
+
+      val decoded = MapEncoder.toJavaMap(encoded, partSchema)
+      collected.size() shouldEqual decoded.size()
+      val collectedIter = collected.entrySet().iterator()
+      val decodedIter = decoded.entrySet().iterator()
+      while (collectedIter.hasNext) {
+        val c = collectedIter.next()
+        val d = decodedIter.next()
+        c.getKey shouldEqual d.getKey
+        c.getValue shouldEqual d.getValue
+      }
+    }
+
+    it("should handle empty/null data") {
+      var called = false
+      val consumer = new MapEntryConsumer {
+        override def consume(key: String, value: String): Unit = called = true
+      }
+      MapEncoder.forEach(null, partSchema, consumer)
+      called shouldBe false
+      MapEncoder.forEach(MapEncoder.EMPTY, partSchema, consumer)
+      called shouldBe false
+    }
+
+    it("should iterate all test maps correctly") {
+      testTagMaps.foreach { case (_, tags) =>
+        val encoded = MapEncoder.encode(tags, partSchema)
+        val collected = new TreeMap[String, String]()
+        MapEncoder.forEach(encoded, partSchema, new MapEntryConsumer {
+          override def consume(key: String, value: String): Unit = collected.put(key, value)
+        })
+        collected shouldEqual tags
+      }
+    }
+  }
+
+  describe("MapEncoder.retain") {
+    it("should keep only specified keys") {
+      val tags = sortedMap("_ws_" -> "ws", "_ns_" -> "ns", "dc" -> "us-west-2", "region" -> "us-east-1")
+      val encoded = MapEncoder.encode(tags, partSchema)
+
+      val keysToKeep = new JHashSet[String]()
+      keysToKeep.add("_ws_")
+      keysToKeep.add("_ns_")
+
+      val retained = MapEncoder.retain(encoded, partSchema, keysToKeep)
+      val result = MapEncoder.toJavaMap(retained, partSchema)
+      result.size() shouldEqual 2
+      result.get("_ws_") shouldEqual "ws"
+      result.get("_ns_") shouldEqual "ns"
+    }
+
+    it("should return EMPTY when no keys match") {
+      val tags = sortedMap("_ws_" -> "ws", "_ns_" -> "ns")
+      val encoded = MapEncoder.encode(tags, partSchema)
+
+      val keysToKeep = new JHashSet[String]()
+      keysToKeep.add("missing")
+
+      val retained = MapEncoder.retain(encoded, partSchema, keysToKeep)
+      MapEncoder.isEmpty(retained) shouldBe true
+    }
+
+    it("should return EMPTY for empty keysToKeep") {
+      val tags = sortedMap("_ws_" -> "ws")
+      val encoded = MapEncoder.encode(tags, partSchema)
+      val retained = MapEncoder.retain(encoded, partSchema, new JHashSet[String]())
+      MapEncoder.isEmpty(retained) shouldBe true
+    }
+
+    it("should handle null/empty data") {
+      val keys = new JHashSet[String]()
+      keys.add("_ws_")
+      MapEncoder.isEmpty(MapEncoder.retain(null, partSchema, keys)) shouldBe true
+      MapEncoder.isEmpty(MapEncoder.retain(MapEncoder.EMPTY, partSchema, keys)) shouldBe true
+    }
+
+    it("should produce valid encoded bytes that round-trip correctly") {
+      testTagMaps.foreach { case (_, tags) =>
+        val encoded = MapEncoder.encode(tags, partSchema)
+        val keysToKeep = new JHashSet[String]()
+        keysToKeep.add("_ws_")
+        keysToKeep.add("_ns_")
+
+        val retained = MapEncoder.retain(encoded, partSchema, keysToKeep)
+        val decoded = MapEncoder.toJavaMap(retained, partSchema)
+
+        val iter = decoded.entrySet().iterator()
+        while (iter.hasNext) {
+          val entry = iter.next()
+          keysToKeep.contains(entry.getKey) shouldBe true
+          entry.getValue shouldEqual tags.get(entry.getKey)
+        }
+      }
+    }
+  }
+
+  describe("MapEncoder.remove") {
+    it("should remove specified keys") {
+      val tags = sortedMap("_ws_" -> "ws", "_ns_" -> "ns", "dc" -> "us-west-2", "region" -> "us-east-1")
+      val encoded = MapEncoder.encode(tags, partSchema)
+
+      val keysToRemove = new JHashSet[String]()
+      keysToRemove.add("_ws_")
+      keysToRemove.add("_ns_")
+
+      val removed = MapEncoder.remove(encoded, partSchema, keysToRemove)
+      val result = MapEncoder.toJavaMap(removed, partSchema)
+      result.size() shouldEqual 2
+      result.get("dc") shouldEqual "us-west-2"
+      result.get("region") shouldEqual "us-east-1"
+    }
+
+    it("should return all entries when no keys match") {
+      val tags = sortedMap("_ws_" -> "ws", "_ns_" -> "ns")
+      val encoded = MapEncoder.encode(tags, partSchema)
+
+      val keysToRemove = new JHashSet[String]()
+      keysToRemove.add("missing")
+
+      val removed = MapEncoder.remove(encoded, partSchema, keysToRemove)
+      MapEncoder.toJavaMap(removed, partSchema) shouldEqual tags
+    }
+
+    it("should return copy of all entries for empty keysToRemove") {
+      val tags = sortedMap("_ws_" -> "ws", "_ns_" -> "ns")
+      val encoded = MapEncoder.encode(tags, partSchema)
+      val removed = MapEncoder.remove(encoded, partSchema, new JHashSet[String]())
+      MapEncoder.toJavaMap(removed, partSchema) shouldEqual tags
+    }
+
+    it("should handle null/empty data") {
+      val keys = new JHashSet[String]()
+      keys.add("_ws_")
+      MapEncoder.isEmpty(MapEncoder.remove(null, partSchema, keys)) shouldBe true
+      MapEncoder.isEmpty(MapEncoder.remove(MapEncoder.EMPTY, partSchema, keys)) shouldBe true
+    }
+  }
+
+  describe("retain and remove are complementary") {
+    it("should produce non-overlapping partitions that union to original") {
+      testTagMaps.foreach { case (desc, tags) =>
+        val encoded = MapEncoder.encode(tags, partSchema)
+        val keysToKeep = new JHashSet[String]()
+        keysToKeep.add("_ws_")
+        keysToKeep.add("_ns_")
+
+        val retained = MapEncoder.toJavaMap(MapEncoder.retain(encoded, partSchema, keysToKeep), partSchema)
+        val removed = MapEncoder.toJavaMap(MapEncoder.remove(encoded, partSchema, keysToKeep), partSchema)
+
+        // No overlap
+        val retainedIter = retained.keySet().iterator()
+        while (retainedIter.hasNext) {
+          removed.containsKey(retainedIter.next()) shouldBe false
+        }
+
+        // Union equals original
+        val union = new TreeMap[String, String]()
+        union.putAll(retained)
+        union.putAll(removed)
+        union shouldEqual tags
+      }
     }
   }
 }

--- a/core/src/test/scala/filodb.core/binaryrecord2/MapEncoderSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/MapEncoderSpec.scala
@@ -595,6 +595,20 @@ class MapEncoderSpec extends AnyFunSpec with Matchers {
     }
   }
 
+  describe("MapEncoder.size") {
+    it("should return correct size for all test maps") {
+      testTagMaps.foreach { case (_, tags) =>
+        val encoded = MapEncoder.encode(tags, partSchema)
+        MapEncoder.size(encoded) shouldEqual tags.size()
+      }
+    }
+
+    it("should return 0 for null/empty data") {
+      MapEncoder.size(null) shouldEqual 0
+      MapEncoder.size(MapEncoder.EMPTY) shouldEqual 0
+    }
+  }
+
   describe("MapEncoder.getValue") {
     it("should return value for predefined key") {
       val tags = sortedMap("_ws_" -> "aci-telemetry", "_ns_" -> "filodb-local", "dc" -> "us-west-2")
@@ -627,21 +641,20 @@ class MapEncoderSpec extends AnyFunSpec with Matchers {
       MapEncoder.getValue(encoded, partSchema, null) shouldBe null
     }
 
-    it("should match getValue results with toJavaMap.get for all test maps") {
+    it("should match getValue results with map.get for all test maps") {
       testTagMaps.foreach { case (desc, tags) =>
         val encoded = MapEncoder.encode(tags, partSchema)
-        val decoded = MapEncoder.toJavaMap(encoded, partSchema)
         val iter = tags.entrySet().iterator()
         while (iter.hasNext) {
           val entry = iter.next()
-          MapEncoder.getValue(encoded, partSchema, entry.getKey) shouldEqual decoded.get(entry.getKey)
+          MapEncoder.getValue(encoded, partSchema, entry.getKey) shouldEqual tags.get(entry.getKey)
         }
       }
     }
   }
 
   describe("MapEncoder.forEach") {
-    it("should iterate all entries in order matching toJavaMap") {
+    it("should iterate all entries in order matching map") {
       val tags = sortedMap(
         "_ns_" -> "filodb-local", "_ws_" -> "aci-telemetry",
         "dc" -> "us-west-2", "region" -> "us-east-1"
@@ -653,10 +666,9 @@ class MapEncoderSpec extends AnyFunSpec with Matchers {
         override def consume(key: String, value: String): Unit = collected.put(key, value)
       })
 
-      val decoded = MapEncoder.toJavaMap(encoded, partSchema)
-      collected.size() shouldEqual decoded.size()
+      collected.size() shouldEqual tags.size()
       val collectedIter = collected.entrySet().iterator()
-      val decodedIter = decoded.entrySet().iterator()
+      val decodedIter = tags.entrySet().iterator()
       while (collectedIter.hasNext) {
         val c = collectedIter.next()
         val d = decodedIter.next()
@@ -698,10 +710,9 @@ class MapEncoderSpec extends AnyFunSpec with Matchers {
       keysToKeep.add("_ns_")
 
       val retained = MapEncoder.retain(encoded, partSchema, keysToKeep)
-      val result = MapEncoder.toJavaMap(retained, partSchema)
-      result.size() shouldEqual 2
-      result.get("_ws_") shouldEqual "ws"
-      result.get("_ns_") shouldEqual "ns"
+      MapEncoder.size(retained) shouldEqual 2
+      MapEncoder.getValue(retained, partSchema, "_ws_") shouldEqual "ws"
+      MapEncoder.getValue(retained, partSchema, "_ns_") shouldEqual "ns"
     }
 
     it("should return EMPTY when no keys match") {
@@ -759,10 +770,9 @@ class MapEncoderSpec extends AnyFunSpec with Matchers {
       keysToRemove.add("_ns_")
 
       val removed = MapEncoder.remove(encoded, partSchema, keysToRemove)
-      val result = MapEncoder.toJavaMap(removed, partSchema)
-      result.size() shouldEqual 2
-      result.get("dc") shouldEqual "us-west-2"
-      result.get("region") shouldEqual "us-east-1"
+      MapEncoder.size(removed) shouldEqual 2
+      MapEncoder.getValue(removed, partSchema, "dc") shouldEqual "us-west-2"
+      MapEncoder.getValue(removed, partSchema, "region") shouldEqual "us-east-1"
     }
 
     it("should return all entries when no keys match") {
@@ -773,6 +783,9 @@ class MapEncoderSpec extends AnyFunSpec with Matchers {
       keysToRemove.add("missing")
 
       val removed = MapEncoder.remove(encoded, partSchema, keysToRemove)
+      MapEncoder.size(removed) shouldEqual tags.size()
+      MapEncoder.getValue(removed, partSchema, "_ws_") shouldEqual "ws"
+      MapEncoder.getValue(removed, partSchema, "_ns_") shouldEqual "ns"
       MapEncoder.toJavaMap(removed, partSchema) shouldEqual tags
     }
 
@@ -780,6 +793,9 @@ class MapEncoderSpec extends AnyFunSpec with Matchers {
       val tags = sortedMap("_ws_" -> "ws", "_ns_" -> "ns")
       val encoded = MapEncoder.encode(tags, partSchema)
       val removed = MapEncoder.remove(encoded, partSchema, new JHashSet[String]())
+      MapEncoder.size(removed) shouldEqual tags.size()
+      MapEncoder.getValue(removed, partSchema, "_ws_") shouldEqual "ws"
+      MapEncoder.getValue(removed, partSchema, "_ns_") shouldEqual "ns"
       MapEncoder.toJavaMap(removed, partSchema) shouldEqual tags
     }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
`MapEncoder` only provides `encode` and `toJavaMap` — any operation on encoded tag bytes requires a full decode into a `TreeMap`, even when only one or two values are needed. This forces unnecessary allocations in hot paths like rule matching and partition key extraction in the preaggregation pipeline.


**New behavior :**
Adds targeted operations that work directly on encoded `byte[]` without full map decoding:                                                                
 
  - **`getValue(data, schema, key)`** — Single-key lookup with predefined key fast path (single-byte comparison). Returns null if not found.                
  - **`forEach(data, schema, consumer)`** — Streaming iteration via `MapEntryConsumer` callback. No map allocation.
  - **`retain(data, schema, keysToKeep)`** / **`remove(data, schema, keysToRemove)`** — Filter encoded bytes by key set. Raw byte copying, no decode/re-encode.                                                                                                                                         
  - **`size(data)`** — Entry count without decoding. 
  - Comprehensive tests added for all new methods across multiple tag map shapes (small/large keys, predefined/non-predefined, edge cases). 

**BREAKING CHANGES**

N/A

**Other information**: