### PR TITLE
feat(core): add MapEncoder.getValueBytes and deduplicate toJavaMap/ge…

### DIFF
--- a/core/src/main/scala/filodb.core/binaryrecord2/MapEncoder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/MapEncoder.scala
@@ -106,36 +106,9 @@ object MapEncoder {
    */
   def toJavaMap(data: Array[Byte], schema: RecordSchema): java.util.Map[String, String] = {
     val map = new util.TreeMap[String, String]()
-    if (data == null || data.length == 0) return map
-
-    var pos = 0
-    while (pos < data.length) {
-      val firstByte = data(pos) & 0xFF
-      val predefIndex = firstByte ^ 0xC0
-
-      if (predefIndex < 64) {
-        // Predefined key — decode from schema
-        val keyOff = schema.predefKeyOffsets(predefIndex)
-        val keyLen = UTF8StringShort.numBytes(schema.predefKeyBytes, keyOff)
-        val keyStr = new String(schema.predefKeyBytes,
-          (keyOff + 1 - UnsafeUtils.arayOffset).toInt, keyLen, StandardCharsets.UTF_8)
-
-        val valLen = UnsafeUtils.getShort(data, UnsafeUtils.arayOffset + pos + 1) & 0xFFFF
-        val valStr = new String(data, pos + 3, valLen, StandardCharsets.UTF_8)
-        map.put(keyStr, valStr)
-        pos += 3 + valLen
-      } else {
-        // Full key
-        val keyLen = firstByte
-        val keyStr = new String(data, pos + 1, keyLen, StandardCharsets.UTF_8)
-
-        val valLenPos = pos + 1 + keyLen
-        val valLen = UnsafeUtils.getShort(data, UnsafeUtils.arayOffset + valLenPos) & 0xFFFF
-        val valStr = new String(data, valLenPos + 2, valLen, StandardCharsets.UTF_8)
-        map.put(keyStr, valStr)
-        pos += 1 + keyLen + 2 + valLen
-      }
-    }
+    forEach(data, schema, new MapEntryConsumer {
+      override def consume(key: String, value: String): Unit = { map.put(key, value) }
+    })
     map
   }
 
@@ -159,30 +132,17 @@ object MapEncoder {
    * Returns null if the key is not found.
    */
   def getValue(data: Array[Byte], schema: RecordSchema, key: String): String = {
-    if (data == null || data.length == 0 || key == null) return null
+    val pos = findKeyPos(data, schema, key)
+    if (pos < 0) null else decodeValueAtPos(data, pos)
+  }
 
-    val keyBytes = key.getBytes(StandardCharsets.UTF_8)
-    val keyKey = RecordSchema.makeKeyKey(keyBytes, 0, keyBytes.length, 7)
-    val predefNum = schema.predefKeyNumMap.getOrElse(keyKey, -1)
-
-    if (predefNum >= 0) {
-      val expectedByte = (0xC0 | predefNum).toByte
-      var pos = 0
-      while (pos < data.length) {
-        if (data(pos) == expectedByte) return decodeValueAtPos(data, pos)
-        pos += entryByteLength(data, pos)
-      }
-    } else {
-      var pos = 0
-      while (pos < data.length) {
-        val firstByte = data(pos) & 0xFF
-        if ((firstByte ^ 0xC0) >= 64 && keyMatchesAtPos(data, pos, schema, keyBytes)) {
-          return decodeValueAtPos(data, pos)
-        }
-        pos += entryByteLength(data, pos)
-      }
-    }
-    null
+  /**
+   * Look up a single key's value in encoded bytes, returning raw UTF-8 bytes.
+   * Returns null if the key is not found.  No String allocation on the value.
+   */
+  def getValueBytes(data: Array[Byte], schema: RecordSchema, key: String): Array[Byte] = {
+    val pos = findKeyPos(data, schema, key)
+    if (pos < 0) null else copyValueBytesAtPos(data, pos)
   }
 
   /**
@@ -335,6 +295,34 @@ object MapEncoder {
     else util.Arrays.copyOf(buf, outPos)
   }
 
+  /** Scan encoded bytes for the given key. Returns the entry position, or -1 if not found. */
+  private def findKeyPos(data: Array[Byte], schema: RecordSchema, key: String): Int = {
+    if (data == null || data.length == 0 || key == null) return -1
+
+    val keyBytes = key.getBytes(StandardCharsets.UTF_8)
+    val keyKey = RecordSchema.makeKeyKey(keyBytes, 0, keyBytes.length, 7)
+    val predefNum = schema.predefKeyNumMap.getOrElse(keyKey, -1)
+
+    if (predefNum >= 0) {
+      val expectedByte = (0xC0 | predefNum).toByte
+      var pos = 0
+      while (pos < data.length) {
+        if (data(pos) == expectedByte) return pos
+        pos += entryByteLength(data, pos)
+      }
+    } else {
+      var pos = 0
+      while (pos < data.length) {
+        val firstByte = data(pos) & 0xFF
+        if ((firstByte ^ 0xC0) >= 64 && keyMatchesAtPos(data, pos, schema, keyBytes)) {
+          return pos
+        }
+        pos += entryByteLength(data, pos)
+      }
+    }
+    -1
+  }
+
   private def entryKeyMatchesAny(data: Array[Byte], pos: Int, schema: RecordSchema,
                                  keys: Array[Array[Byte]]): Boolean = {
     var i = 0
@@ -400,6 +388,21 @@ object MapEncoder {
       val valLenPos = pos + 1 + keyLen
       val valLen = UnsafeUtils.getShort(data, UnsafeUtils.arayOffset + valLenPos) & 0xFFFF
       new String(data, valLenPos + 2, valLen, StandardCharsets.UTF_8)
+    }
+  }
+
+  /** Copy the value bytes at the given entry position into a new byte[]. */
+  private def copyValueBytesAtPos(data: Array[Byte], pos: Int): Array[Byte] = {
+    val firstByte = data(pos) & 0xFF
+    val predefIndex = firstByte ^ 0xC0
+    if (predefIndex < 64) {
+      val valLen = UnsafeUtils.getShort(data, UnsafeUtils.arayOffset + pos + 1) & 0xFFFF
+      util.Arrays.copyOfRange(data, pos + 3, pos + 3 + valLen)
+    } else {
+      val keyLen = firstByte
+      val valLenPos = pos + 1 + keyLen
+      val valLen = UnsafeUtils.getShort(data, UnsafeUtils.arayOffset + valLenPos) & 0xFFFF
+      util.Arrays.copyOfRange(data, valLenPos + 2, valLenPos + 2 + valLen)
     }
   }
 

--- a/core/src/test/scala/filodb.core/binaryrecord2/MapEncoderSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/MapEncoderSpec.scala
@@ -663,6 +663,56 @@ class MapEncoderSpec extends AnyFunSpec with Matchers {
     }
   }
 
+  describe("MapEncoder.getValueBytes") {
+    it("should return UTF-8 bytes for predefined key") {
+      val tags = sortedMap("_ws_" -> "aci-telemetry", "_ns_" -> "filodb-local", "dc" -> "us-west-2")
+      val encoded = MapEncoder.encode(tags, partSchema)
+      MapEncoder.getValueBytes(encoded, partSchema, "_ws_") shouldEqual
+        "aci-telemetry".getBytes(StandardCharsets.UTF_8)
+      MapEncoder.getValueBytes(encoded, partSchema, "_ns_") shouldEqual
+        "filodb-local".getBytes(StandardCharsets.UTF_8)
+    }
+
+    it("should return UTF-8 bytes for non-predefined key") {
+      val tags = sortedMap("_ws_" -> "ws", "region" -> "us-east-1", "custom_key" -> "custom_val")
+      val encoded = MapEncoder.encode(tags, partSchema)
+      MapEncoder.getValueBytes(encoded, partSchema, "region") shouldEqual
+        "us-east-1".getBytes(StandardCharsets.UTF_8)
+      MapEncoder.getValueBytes(encoded, partSchema, "custom_key") shouldEqual
+        "custom_val".getBytes(StandardCharsets.UTF_8)
+    }
+
+    it("should return null for missing key") {
+      val tags = sortedMap("_ws_" -> "ws", "_ns_" -> "ns")
+      val encoded = MapEncoder.encode(tags, partSchema)
+      MapEncoder.getValueBytes(encoded, partSchema, "missing") shouldBe null
+    }
+
+    it("should return null for null/empty data") {
+      MapEncoder.getValueBytes(null, partSchema, "_ws_") shouldBe null
+      MapEncoder.getValueBytes(MapEncoder.EMPTY, partSchema, "_ws_") shouldBe null
+    }
+
+    it("should return null for null key") {
+      val tags = sortedMap("_ws_" -> "ws")
+      val encoded = MapEncoder.encode(tags, partSchema)
+      MapEncoder.getValueBytes(encoded, partSchema, null) shouldBe null
+    }
+
+    it("should match getValue results for all test maps") {
+      testTagMaps.foreach { case (_, tags) =>
+        val encoded = MapEncoder.encode(tags, partSchema)
+        val iter = tags.entrySet().iterator()
+        while (iter.hasNext) {
+          val entry = iter.next()
+          val fromString = MapEncoder.getValue(encoded, partSchema, entry.getKey)
+          val fromBytes = MapEncoder.getValueBytes(encoded, partSchema, entry.getKey)
+          fromBytes shouldEqual fromString.getBytes(StandardCharsets.UTF_8)
+        }
+      }
+    }
+  }
+
   describe("MapEncoder.forEach") {
     it("should iterate all entries in order matching map") {
       val tags = sortedMap(


### PR DESCRIPTION
…tValue

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
- `MapEncoder.toJavaMap` manually parses every encoded entry (predefined key resolution, value decoding, position advancement), duplicating the same logic already in `forEach/forEachBytes`.
- `MapEncoder.getValue` inlines its own key-search loop, making it impossible to reuse the scan logic for other value-return types. There is no way to look up a value as raw UTF-8 bytes without String allocation.

**New behavior :**
- `toJavaMap` delegates to forEach, removing ~30 lines of duplicated entry-parsing logic.              
- `getValue` uses an extracted `findKeyPos` helper, separating key search from value decoding.
- New `getValueBytes` method returns a value as raw `byte[]` (no String allocation), reusing `findKeyPos`  
  and a new `copyValueBytesAtPos` helper.                                                                
- Tests added for `getValueBytes` covering predefined keys, non-predefined keys, missing keys, null/empty data, and cross-validation against getValue.      


**BREAKING CHANGES**

N/A

**Other information**: