### PR TITLE
fix(metrics): Add sleep to ensure metrics are flushed before JVM exits

### DIFF
--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelChurnFinder.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelChurnFinder.scala
@@ -65,7 +65,7 @@ object LabelChurnFinderMain extends App {
   labelsPublished.increment(labelsAcc.value)
   kafkaFailures.increment(failuresAcc.value)
   jobDuration.record(System.currentTimeMillis() - jobStartMs)
-
+  Thread.sleep(62000) // allow Kamon MosaicReporter periodic tick to fire and complete gRPC publish before shutdown
   spark.stop()
 }
 


### PR DESCRIPTION
Pull Request checklist

 The commit(s) message(s) follows the contribution [guidelines](https://github.com/filodb/FiloDB/pull/CONTRIBUTING.md) ?
 Tests for the changes have been added (for bug fixes / features) ?
 Docs have been added / updated (for bug fixes / features) ?

Current behavior : churn-finder-job metrics are not flushed due to race condition in Kamon shutdown hook

New behavior : Added sleep before spark.stop() to allow Kamon metrics flush in LabelChurnFinderMain
 
