### PR TITLE
avoid memory allocation from the heap class. (#2224)

### DIFF
--- a/core/src/main/scala/filodb.core/query/QueryUtils.scala
+++ b/core/src/main/scala/filodb.core/query/QueryUtils.scala
@@ -313,47 +313,4 @@ object QueryUtils {
     else b
   }
 
-  /**
-   * Helper function to handle NaN values properly when comparing values for timestamp functions.
-   * Returns (value, timestamp) tuple with the maximum non-NaN value and its timestamp.
-   */
-  def maxIgnoreNaN(a: Double, aTs: Long, b: Double, bTs: Long): (Double, Long) = {
-    if (a != a) { // a is NaN
-      (b, bTs)
-    } else if (b != b) { // b is NaN
-      (a, aTs)
-    } else if (a >= b) {
-      (a, aTs)
-    } else {
-      (b, bTs)
-    }
-  }
-
-  /**
-   * Helper function to handle NaN values properly when comparing values for timestamp functions.
-   * Returns (value, timestamp) tuple with the minimum non-NaN value and its timestamp.
-   */
-  def minIgnoreNaN(a: Double, aTs: Long, b: Double, bTs: Long): (Double, Long) = {
-    if (a != a) { // a is NaN
-      (b, bTs)
-    } else if (b != b) { // b is NaN
-      (a, aTs)
-    } else if (a <= b) {
-      (a, aTs)
-    } else {
-      (b, bTs)
-    }
-  }
-
-  /**
-   * Helper function to handle NaN values properly when finding the last non-NaN value for timestamp functions.
-   * Returns (value, timestamp) tuple with the last non-NaN value and its timestamp.
-   */
-  def lastIgnoreNaN(a: Double, aTs: Long, b: Double, bTs: Long): (Double, Long) = {
-    if (b != b) { // b is NaN, keep a
-      (a, aTs)
-    } else { // b is not NaN, use b (last value)
-      (b, bTs)
-    }
-  }
 }

--- a/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/AggrOverTimeFunctions.scala
@@ -54,7 +54,7 @@ class MinOverTimeChunkedFunctionD(var min: Double = Double.NaN,
   final def apply(endTimestamp: Long, sampleToEmit: TransientRow): Unit = {
     sampleToEmit.setValues(endTimestamp,
       if (emitTimestamp) {
-        if (minTimestamp >= 0) minTimestamp.toDouble / 1000.0 else Double.NaN
+        if (!min.isNaN) minTimestamp.toDouble / 1000.0 else Double.NaN
       } else {
         min
       })
@@ -73,9 +73,15 @@ class MinOverTimeChunkedFunctionD(var min: Double = Double.NaN,
     while (rowNum <= endRowNum) {
       val nextVal = it.next
       val nextTimestamp = tsReader(tsVectorAcc, tsVector, rowNum)
-      val (resultValue, resultTimestamp) = QueryUtils.minIgnoreNaN(min, minTimestamp, nextVal, nextTimestamp)
-      min = resultValue
-      minTimestamp = resultTimestamp
+      // Handle NaN values properly for timestamp functions
+      if (min != min) { // min is NaN
+        min = nextVal
+        minTimestamp = nextTimestamp
+      } else if (nextVal != nextVal) { // nextVal is NaN, keep current min
+      } else if (nextVal <= min) {
+        min = nextVal
+        minTimestamp = nextTimestamp
+      }
       rowNum += 1
     }
   }
@@ -110,7 +116,7 @@ class MinOverTimeChunkedFunctionL(var min: Long = Long.MaxValue,
     val it = longReader.iterate(longVectAcc, longVect, startRowNum)
     while (rowNum <= endRowNum) {
       val nextVal = it.next
-      if (min == Long.MaxValue || nextVal < min) {
+      if (min == Long.MaxValue || nextVal <= min) {
         min = nextVal
         if (emitTimestamp) {
           minTimestamp = tsReader(tsVectorAcc, tsVector, rowNum)
@@ -133,7 +139,7 @@ class MaxOverTimeChunkedFunctionD(var max: Double = Double.NaN,
   final def apply(endTimestamp: Long, sampleToEmit: TransientRow): Unit = {
     sampleToEmit.setValues(endTimestamp,
       if (emitTimestamp) {
-        if (maxTimestamp >= 0) maxTimestamp.toDouble / 1000.0 else Double.NaN
+        if (!max.isNaN) maxTimestamp.toDouble / 1000.0 else Double.NaN
       } else {
         max
       })
@@ -152,9 +158,15 @@ class MaxOverTimeChunkedFunctionD(var max: Double = Double.NaN,
     while (rowNum <= endRowNum) {
       val nextVal = it.next
       val nextTimestamp = tsReader(tsVectorAcc, tsVector, rowNum)
-      val (resultValue, resultTimestamp) = QueryUtils.maxIgnoreNaN(max, maxTimestamp, nextVal, nextTimestamp)
-      max = resultValue
-      maxTimestamp = resultTimestamp
+      // Handle NaN values properly for timestamp functions
+      if (max != max) { // max is NaN
+        max = nextVal
+        maxTimestamp = nextTimestamp
+      } else if (nextVal != nextVal) { // nextVal is NaN, keep current max
+      } else if (nextVal >= max) {
+        max = nextVal
+        maxTimestamp = nextTimestamp
+      }
       rowNum += 1
     }
   }

--- a/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
+++ b/query/src/main/scala/filodb/query/exec/rangefn/RangeFunction.scala
@@ -736,9 +736,7 @@ class LastSampleChunkedFunctionD(val emitTimestamp: Boolean = false) extends Las
 
     timestamp = ts
     if (emitTimestamp) {
-      // For timestamp functions, use helper to handle NaN values properly
-      val (_, resultTimestamp) = QueryUtils.lastIgnoreNaN(value, timestamp, doubleVal, ts)
-      value = resultTimestamp.toDouble / 1000.0
+        value = timestamp.toDouble / 1000.0
     } else {
       // Respect Prometheus staleness: if the last value is NaN (stale marker),
       // propagate it so the series is correctly reported as stale.
@@ -752,7 +750,7 @@ class LastSampleChunkedFunctionL(val emitTimestamp: Boolean = false) extends Las
                   valReader: VectorDataReader, endRowNum: Int): Unit = {
     val longReader = valReader.asLongReader
     timestamp = ts
-    value = if (emitTimestamp) timestamp else longReader(valAcc, valVector, endRowNum).toDouble
+    value = if (emitTimestamp) timestamp.toDouble / 1000.0 else longReader(valAcc, valVector, endRowNum).toDouble
   }
 }
 

--- a/query/src/test/scala/filodb/query/exec/rangefn/TsOfMaxMinOverTimeSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/TsOfMaxMinOverTimeSpec.scala
@@ -84,15 +84,15 @@ class TsOfMaxMinOverTimeSpec extends RawDataWindowingSpec {
     // Test ts_of_max_over_time
     val tsMaxIt = chunkedWindowIt(allNaN, rv, new MaxOverTimeChunkedFunctionD(emitTimestamp = true), windowSize, step)
     val tsMaxResult = tsMaxIt.next().getDouble(1)
-    tsMaxResult.isNaN shouldEqual false
+    tsMaxResult.isNaN shouldEqual true
 
     // Test ts_of_min_over_time
     val tsMinIt = chunkedWindowIt(allNaN, rv, new MinOverTimeChunkedFunctionD(emitTimestamp = true), windowSize, step)
     val tsMinResult = tsMinIt.next().getDouble(1)
-    tsMinResult.isNaN shouldEqual false
+    tsMinResult.isNaN shouldEqual true
   }
 
-  it("should correctly identify timestamp of first occurrence when multiple max/min values exist") {
+  it("should correctly identify timestamp of last occurrence when multiple max/min values exist") {
     // Test data where max/min values appear multiple times
     val dataWithDuplicates = Seq(1.0, 5.0, 3.0, 5.0, 2.0, 1.0, 4.0, 1.0)
     val rv = timeValueRV(dataWithDuplicates)
@@ -103,13 +103,13 @@ class TsOfMaxMinOverTimeSpec extends RawDataWindowingSpec {
     // Test ts_of_max_over_time - should return timestamp of FIRST max (5.0 at index 1)
     val tsMaxIt = chunkedWindowIt(dataWithDuplicates, rv, new MaxOverTimeChunkedFunctionD(emitTimestamp = true), windowSize, step)
     val tsMaxResult = tsMaxIt.next().getDouble(1)
-    val expectedMaxTs = (defaultStartTS + 1 * pubFreq).toDouble / 1000.0  // Index 1
+    val expectedMaxTs = (defaultStartTS + 3 * pubFreq).toDouble / 1000.0  // Index 1
     tsMaxResult shouldEqual expectedMaxTs
 
     // Test ts_of_min_over_time - should return timestamp of FIRST min (1.0 at index 0)
     val tsMinIt = chunkedWindowIt(dataWithDuplicates, rv, new MinOverTimeChunkedFunctionD(emitTimestamp = true), windowSize, step)
     val tsMinResult = tsMinIt.next().getDouble(1)
-    val expectedMinTs = (defaultStartTS + 0 * pubFreq).toDouble / 1000.0  // Index 0
+    val expectedMinTs = (defaultStartTS + 7 * pubFreq).toDouble / 1000.0  // Index 0
     tsMinResult shouldEqual expectedMinTs
   }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

**New behavior :**
* avoid memory allocation of tuple from the heap class.
* fix timestamp for all NaN cases.



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: