### PR TITLE
perf(coord): Zero copy of binary record into Arrow VSR during query execution

### DIFF
--- a/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
@@ -149,12 +149,20 @@ object ArrowSerializedRangeVectorOps {
       if (state.rowNum >= maxNumRows) {
         addNewVsr()
       }
-      val dataAddress = state.currentRvkBrVec.getDataBufferAddress + state.currentWriteOffset()
-      srb.reset(UnsafeUtils.ZeroPointer, dataAddress, state.bytesRemaining)
+      val writeOffsetBefore = state.currentWriteOffset()
+      val bufAddrBefore     = state.currentRvkBrVec.getDataBufferAddress
+      srb.reset(UnsafeUtils.ZeroPointer, bufAddrBefore + writeOffsetBefore, state.bytesRemaining)
       srb.addFromReader(row, recordSchema, 0)
-      // Re-read after write: a spill inside srb may have switched to a new VSR and reset rowNum to 0.
-      val bytesWritten = (srb.nextRecordOffset -
-                          (state.currentRvkBrVec.getDataBufferAddress + state.currentWriteOffset())).toInt
+      // If srb ran out of space mid-record, its requireBytes callback called addNewVsr(), which
+      // switched state.currentRvkBrVec to a fresh buffer (new address) and reset state.rowNum to 0.
+      // Detect the spill via the address change so bytesWritten is always anchored to the buffer
+      // that srb actually wrote into, regardless of any future change to addNewVsr().
+      val writeBase =
+        if (state.currentRvkBrVec.getDataBufferAddress != bufAddrBefore)
+          state.currentRvkBrVec.getDataBufferAddress  // spilled: new buffer, write starts at offset 0
+        else
+          bufAddrBefore + writeOffsetBefore            // no spill: same buffer, original offset
+      val bytesWritten = (srb.nextRecordOffset - writeBase).toInt
       state.commitRow(bytesWritten, isRvk = 0)
     }
 

--- a/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
@@ -6,28 +6,18 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.Using
 
 import org.apache.arrow.memory.BufferAllocator
-import org.apache.arrow.vector.{BitVector, VarBinaryVector, VectorSchemaRoot}
+import org.apache.arrow.vector.{BitVector, BitVectorHelper, VarBinaryVector, VectorSchemaRoot}
 import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
 import org.jctools.queues.MpscArrayQueue
 
 import filodb.core.Utils
-import filodb.core.binaryrecord2.{RecordBuilder, RecordSchema}
-import filodb.core.binaryrecord2.RecordContainer.BRIterator
+import filodb.core.binaryrecord2.{RecordSchema, SingleRecordBuilder}
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, HistogramColumn}
 import filodb.core.query._
+import filodb.grpc.ProtoRangeVector
 import filodb.memory.data.ChunkMap
 import filodb.memory.format.{RowReader, UnsafeUtils}
-
-case class RespHeader(resultSchema: ResultSchema)
-case class RespFooter(queryStats: QueryStats, throwable: Option[Throwable])
-
-/**
- * Written in RVK vector
- * @param srv if present, this is the entire SRV and no data rows will follow. Other case class fields will be ignored.
- * @param key if present, this is the RVK for the following data rows
- * @param outputRange the output range for the RV, needed reconstructing the RV
- */
-case class RvMetadata(srv: Option[SerializableRangeVector], key: Option[RangeVectorKey], outputRange: Option[RvRange])
+import filodb.query.ProtoConverters._
 
 object ArrowSerializedRangeVectorOps {
   // scalastyle:off null
@@ -35,7 +25,7 @@ object ArrowSerializedRangeVectorOps {
     // stores boolean value indicating whether the row contains RVK or data, and
     // if RVK then the RVK is stored in the second column as binary
     val isRvk = new Field("isRvk", FieldType.notNullable(new ArrowType.Bool()), null)
-    // if isRvk is true, then this column stores the serialized RVK
+    // if isRvk is true, then this column stores the proto-serialized RvMetadata
     // if isRvk is false, then this column stores the serialized BR for the data row
     val rvkBr = new Field("rvkBr", FieldType.nullable(new ArrowType.Binary()), null)
     new Schema(util.Arrays.asList(isRvk, rvkBr))
@@ -71,6 +61,32 @@ object ArrowSerializedRangeVectorOps {
         null
       }
     }
+
+    def currentWriteOffset(): Int = currentRvkBrVec.getOffsetBuffer.getInt(rowNum.toLong * 4)
+
+    // Commits one row into the VarBinary/isRvk vectors after the caller has written `bytesWritten`
+    // bytes into the data buffer starting at currentWriteOffset().  bytesWritten == 0 encodes a
+    // null row (validity bit unset, zero-length offset range).
+    //
+    // Why we maintain the offset chain here rather than using VarBinaryVector.set() / setNull():
+    //   Arrow's setNull(i) only unsets the validity bit; it never touches the offset buffer.
+    //   This leaves offsetBuffer[i+1] == 0, so the next write would land at the start of the
+    //   data buffer and silently overwrite existing bytes.  VarBinaryVector.set() avoids this via
+    //   fillHoles(), but bypassing set() (as we do for zero-copy BinaryRecord and proto writes)
+    //   means fillHoles is never called.  We therefore maintain the offset chain eagerly: copy
+    //   offsetBuffer[rowNum] to offsetBuffer[rowNum+1] for null rows, or advance it by bytesWritten
+    //   for non-null rows.  This invariant is confirmed against Arrow 11 and the latest arrow-java.
+    def commitRow(bytesWritten: Int, isRvk: Int): Unit = {
+      val offsetBuf   = currentRvkBrVec.getOffsetBuffer
+      val writeOffset = offsetBuf.getInt(rowNum.toLong * 4)
+      offsetBuf.setInt((rowNum + 1).toLong * 4, writeOffset + bytesWritten)
+      if (bytesWritten > 0) BitVectorHelper.setBit(currentRvkBrVec.getValidityBuffer, rowNum)
+      else BitVectorHelper.unsetBit(currentRvkBrVec.getValidityBuffer, rowNum)
+      currentRvkBrVec.setLastSet(rowNum)
+      currentIsRvkVec.set(rowNum, isRvk)
+      rowNum += 1
+      bytesRemaining -= bytesWritten
+    }
   }
 
   /**
@@ -79,23 +95,17 @@ object ArrowSerializedRangeVectorOps {
    * @param recordSchema the RecordSchema of the RangeVector rows
    * @param execPlan the execution plan string for this RangeVector, used for logging and
    *                 debugging purposes
-   * @param builder the RecordBuilder to use for building the BR records from the RangeVector rows.
-   *                This is used for now since we are not able to write BR to arrow vec directly yet.
    * @param queryStats the QueryStats to update with CPU time spent in this method
    * @param allocator the Arrow BufferAllocator to use for allocating Arrow buffers
    * @param state the container that holds vsr pointers, to be retained across RV population calls
-   * @param brIterator the BRIterator to use for iterating through the BR records without
-   *                   new allocations
    */
-  // scalastyle:off parameter.number method.length
+  // scalastyle:off method.length
   def populateRvContentsIntoVsrs(rv: RangeVector,
                                  recordSchema: RecordSchema,
                                  execPlan: String,
-                                 builder: RecordBuilder, // should go away in future once we write to Arrow directly
                                  queryStats: QueryStats,
                                  allocator: BufferAllocator,
-                                 state: VsrPopulationState,
-                                 brIterator: BRIterator): Unit = {
+                                 state: VsrPopulationState): Unit = {
 
     // TODO update metrics & query statistics on result bytes during RV serialization
 
@@ -127,48 +137,45 @@ object ArrowSerializedRangeVectorOps {
       state.bytesRemaining = maxVecLen
     }
 
+    val srb = new SingleRecordBuilder(UnsafeUtils.ZeroPointer, 0L, 0) ({
+      addNewVsr()
+      val writeOffset = state.currentRvkBrVec.getOffsetBuffer.getInt(state.rowNum.toLong * 4)
+      (UnsafeUtils.ZeroPointer,
+       state.currentRvkBrVec.getDataBufferAddress + writeOffset,
+       state.bytesRemaining)
+    })
+
     def addFromReader(row: RowReader): Unit = {
-      // TODO - we should write the BR record directly to Arrow buffers instead of using on-heap RecordBuilder and
-      // then copying to Arrow buffers. This is just a temporary solution to get the data into Arrow format for now.
-      builder.reset(true)
-      builder.addFromReader(row, recordSchema, 0)
-      // avoid allocation by reusing brIterator
-      builder.lastContainer.iterate(brIterator).foreach { br =>
-        // check and ensure br.recordLength is available in vector capacity,
-        // if not then create a new vector and add to vsrs
-        if (state.bytesRemaining < br.recordLength || state.rowNum >= maxNumRows) {
-          addNewVsr()
-        }
-        state.currentIsRvkVec.set(state.rowNum, 0)
-        state.currentRvkBrVec.set(state.rowNum, br.recordBase.asInstanceOf[Array[Byte]],
-          br.recordOffset.toInt - UnsafeUtils.arayOffset, br.recordLength)
-        state.rowNum += 1
-        state.bytesRemaining -= br.recordLength
+      if (state.rowNum >= maxNumRows) {
+        addNewVsr()
       }
+      val dataAddress = state.currentRvkBrVec.getDataBufferAddress + state.currentWriteOffset()
+      srb.reset(UnsafeUtils.ZeroPointer, dataAddress, state.bytesRemaining)
+      srb.addFromReader(row, recordSchema, 0)
+      // Re-read after write: a spill inside srb may have switched to a new VSR and reset rowNum to 0.
+      val bytesWritten = (srb.nextRecordOffset -
+                          (state.currentRvkBrVec.getDataBufferAddress + state.currentWriteOffset())).toInt
+      state.commitRow(bytesWritten, isRvk = 0)
+    }
+
+    def addNullRow(): Unit = {
+      if (state.rowNum >= maxNumRows) addNewVsr()
+      state.commitRow(bytesWritten = 0, isRvk = 0)
     }
 
     if (state.currentVsr == null) addNewVsr()
 
     rv match {
       case srv: SerializableRangeVector if srv.hasFormulatedRows =>
-        // If the RV has formulated rows, we can serialize the entire RV as a single object
-        // and skip the row iteration and BR building
-        val rvMetadata = RvMetadata(Some(srv), None, None)
-        FlightKryoSerDeser.serializeToArrowVsr(rvMetadata, state) { () =>
-          addNewVsr()
-        }
+        // If the RV has formulated rows, serialize the entire RV as a single proto object
+        // and skip row iteration and BR building
+        FlightProtoSerDeser.serializeSrvToArrowVsr(srv, state) { () => addNewVsr() }
         state.currentIsRvkVec.setValueCount(state.rowNum)
         state.currentRvkBrVec.setValueCount(state.rowNum)
         state.currentVsr.setRowCount(state.rowNum)
       case _ =>
-        // If the RV does not have formulated rows, serialize the RV key and output range separately, and then
-        // iterate through the rows to build the BR records
-        // Begin by serializing the RangeVector key into the VSR.
-        val rvMetadata = RvMetadata(None, Some(rv.key), rv.outputRange)
-        FlightKryoSerDeser.serializeToArrowVsr(rvMetadata, state) { () =>
-          addNewVsr()
-        }
-        // now add the rows
+        // Serialize the RV key and output range as a proto header row, then iterate data rows
+        FlightProtoSerDeser.serializeRvKeyToArrowVsr(rv.key, rv.outputRange, state) { () => addNewVsr() }
         val startNs = Utils.currentThreadCpuTimeNanos
         try {
           ChunkMap.validateNoSharedLocks(execPlan)
@@ -181,10 +188,7 @@ object ArrowSerializedRangeVectorOps {
                 recordSchema.columns(1).colType == HistogramColumn && !nextRow.getHistogram(1).isEmpty) {
                 addFromReader(nextRow)
               } else {
-                if (state.rowNum >= maxNumRows) addNewVsr()
-                state.currentRvkBrVec.setNull(state.rowNum)
-                state.currentIsRvkVec.set(state.rowNum, 0)
-                state.rowNum += 1
+                addNullRow()
               }
             }
             state.currentIsRvkVec.setValueCount(state.rowNum)
@@ -203,7 +207,7 @@ object ArrowSerializedRangeVectorOps {
                                schema: ResultSchema): Seq[SerializableRangeVector] = {
     val result = ArrayBuffer[SerializableRangeVector]()
 
-    var currentAsrvMetdata: RvMetadata = null
+    var currentRvKey: ProtoRangeVector.RvKey = null
     var currentStartVsrIndex = 0
     var currentStartRowIndex = 0
     var currentNumDataRows = 0
@@ -216,40 +220,38 @@ object ArrowSerializedRangeVectorOps {
 
       for (rowIndex <- 0 until vsr.getRowCount) {
         if (isRvkVec.get(rowIndex) == 1) {
-          // Found a new RV key row
-          if (currentAsrvMetdata != null) {
-            // Save the previous RV
+          // Found a new RV key row — flush the previous RV if any
+          if (currentRvKey != null) {
             result += new ArrowSerializedRangeVector(
-              currentAsrvMetdata.key.get, vsrs, schema.toRecordSchema, currentStartVsrIndex,
-              currentStartRowIndex, currentNumDataRows, currentAsrvMetdata.outputRange)
+              currentRvKey.getKey.fromProto, vsrs, schema.toRecordSchema, currentStartVsrIndex,
+              currentStartRowIndex, currentNumDataRows,
+              if (currentRvKey.hasRvRange) Some(currentRvKey.getRvRange.fromProto) else None)
           }
 
-          // Deserialize the new RV key
-          val keyBytes = rvkBrVec.get(rowIndex)
-          val md = FlightKryoSerDeser.deserialize(keyBytes).asInstanceOf[RvMetadata]
-          if (md.srv.isDefined) {
-            currentAsrvMetdata = null
-            result += md.srv.get
-          } else if (md.key.isDefined) {
-            currentAsrvMetdata = md
+          val proto = FlightProtoSerDeser.deserializeFromBytes(rvkBrVec.get(rowIndex))
+          if (proto.hasSrv) {
+            currentRvKey = null
+            result += proto.getSrv.fromProto
+          } else if (proto.hasRvKey) {
+            currentRvKey = proto.getRvKey
             currentStartVsrIndex = vsrIndex
             currentStartRowIndex = rowIndex
-            currentNumDataRows = 0 // Reset data row count
+            currentNumDataRows = 0
           } else {
             throw new IllegalStateException(s"Invalid RV metadata in VSR at index $vsrIndex, row $rowIndex")
           }
         } else {
-          // Data row (rvkVec is null)
           currentNumDataRows += 1
         }
       }
     }
 
-    // Don't forget the last RV
-    if (currentAsrvMetdata != null) {
+    // Flush the last RV
+    if (currentRvKey != null) {
       result += new ArrowSerializedRangeVector(
-        currentAsrvMetdata.key.get, vsrs, schema.toRecordSchema, currentStartVsrIndex,
-        currentStartRowIndex, currentNumDataRows, currentAsrvMetdata.outputRange)
+        currentRvKey.getKey.fromProto, vsrs, schema.toRecordSchema, currentStartVsrIndex,
+        currentStartRowIndex, currentNumDataRows,
+        if (currentRvKey.hasRvRange) Some(currentRvKey.getRvRange.fromProto) else None)
     }
 
     result.toSeq

--- a/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
@@ -14,7 +14,6 @@ import filodb.core.Utils
 import filodb.core.binaryrecord2.{RecordSchema, SingleRecordBuilder}
 import filodb.core.metadata.Column.ColumnType.{DoubleColumn, HistogramColumn}
 import filodb.core.query._
-import filodb.grpc.ProtoRangeVector
 import filodb.memory.data.ChunkMap
 import filodb.memory.format.{RowReader, UnsafeUtils}
 import filodb.query.ProtoConverters._
@@ -215,7 +214,8 @@ object ArrowSerializedRangeVectorOps {
                                schema: ResultSchema): Seq[SerializableRangeVector] = {
     val result = ArrayBuffer[SerializableRangeVector]()
 
-    var currentRvKey: ProtoRangeVector.RvKey = null
+    var currentKey: RangeVectorKey = null
+    var currentRvRange: Option[RvRange] = None
     var currentStartVsrIndex = 0
     var currentStartRowIndex = 0
     var currentNumDataRows = 0
@@ -229,19 +229,22 @@ object ArrowSerializedRangeVectorOps {
       for (rowIndex <- 0 until vsr.getRowCount) {
         if (isRvkVec.get(rowIndex) == 1) {
           // Found a new RV key row — flush the previous RV if any
-          if (currentRvKey != null) {
+          if (currentKey != null) {
             result += new ArrowSerializedRangeVector(
-              currentRvKey.getKey.fromProto, vsrs, schema.toRecordSchema, currentStartVsrIndex,
-              currentStartRowIndex, currentNumDataRows,
-              if (currentRvKey.hasRvRange) Some(currentRvKey.getRvRange.fromProto) else None)
+              currentKey, vsrs, schema.toRecordSchema, currentStartVsrIndex,
+              currentStartRowIndex, currentNumDataRows, currentRvRange)
           }
 
           val proto = FlightProtoSerDeser.deserializeFromBytes(rvkBrVec.get(rowIndex))
           if (proto.hasSrv) {
-            currentRvKey = null
+            currentKey = null
+            currentRvRange = None
             result += proto.getSrv.fromProto
           } else if (proto.hasRvKey) {
-            currentRvKey = proto.getRvKey
+            val rvKeyProto = proto.getRvKey
+            val (base, offset, _) = UnsafeUtils.BOLfromBuffer(rvKeyProto.getRvKey.asReadOnlyByteBuffer())
+            currentKey = BrMapRangeVectorKey(base, offset)
+            currentRvRange = if (rvKeyProto.hasRvRange) Some(rvKeyProto.getRvRange.fromProto) else None
             currentStartVsrIndex = vsrIndex
             currentStartRowIndex = rowIndex
             currentNumDataRows = 0
@@ -255,11 +258,10 @@ object ArrowSerializedRangeVectorOps {
     }
 
     // Flush the last RV
-    if (currentRvKey != null) {
+    if (currentKey != null) {
       result += new ArrowSerializedRangeVector(
-        currentRvKey.getKey.fromProto, vsrs, schema.toRecordSchema, currentStartVsrIndex,
-        currentStartRowIndex, currentNumDataRows,
-        if (currentRvKey.hasRvRange) Some(currentRvKey.getRvRange.fromProto) else None)
+        currentKey, vsrs, schema.toRecordSchema, currentStartVsrIndex,
+        currentStartRowIndex, currentNumDataRows, currentRvRange)
     }
 
     result.toSeq

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FlightKryoSerDeser.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FlightKryoSerDeser.scala
@@ -4,17 +4,14 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.Using
 
 import com.esotericsoftware.kryo.Kryo
-import com.esotericsoftware.kryo.io.{ByteBufferInput, Input, Output}
+import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.serializers.FieldSerializer
 import com.esotericsoftware.kryo.util.{DefaultClassResolver, DefaultStreamFactory, ListReferenceResolver}
 import io.altoo.akka.serialization.kryo.serializer.scala._
-import org.apache.arrow.memory.ArrowBuf
 import org.jctools.queues.MpmcArrayQueue
 import org.objenesis.strategy.StdInstantiatorStrategy
 
 import filodb.coordinator.client.KryoInit
-import filodb.coordinator.flight.ArrowSerializedRangeVectorOps.{maxNumRows, VsrPopulationState}
-import filodb.core.query._
 
 object FlightKryoSerDeser {
 
@@ -30,8 +27,6 @@ object FlightKryoSerDeser {
       else {
         val k = new ScalaKryo(new DefaultClassResolver(), new ListReferenceResolver(), new DefaultStreamFactory())
         k.setClassLoader(getClass.getClassLoader)
-        k.register(classOf[RespHeader])
-        k.register(classOf[RespFooter])
         k.setInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(new StdInstantiatorStrategy))
 
         val ki = new KryoInit()
@@ -124,7 +119,6 @@ object FlightKryoSerDeser {
     // TODO all query plans
 
     // Flight Objects
-    k.register(classOf[RvMetadata])
   }
 
   def deserialize(bytes: Array[Byte]): Any = {
@@ -136,55 +130,6 @@ object FlightKryoSerDeser {
     } finally {
       kryoPool.release(k)
     }
-  }
-
-  def deserializeFromArrowBuf(buf: ArrowBuf): Any = {
-    val k = kryoPool.borrow()
-    try {
-      Using.resource(new ByteBufferInput(buf.nioBuffer())) { input =>
-        k.kryo.readClassAndObject(input)
-      }
-    } finally {
-      kryoPool.release(k)
-    }
-  }
-
-  def serializeToArrowBuf(obj: Any, fAllocator: FlightAllocator): ArrowBuf = {
-    fAllocator.withRequestAllocator { allocator =>
-      val k = kryoPool.borrow()
-      // scalastyle:off null
-      var buf: ArrowBuf = null
-      try {
-        k.kryo.writeClassAndObject(k.out, obj)
-        buf = allocator.buffer(k.out.position())
-        buf.writeBytes(k.out.getBuffer, 0, k.out.position())
-        buf.writerIndex(k.out.position()).readerIndex(0)
-        buf
-      } catch {
-        case e: Throwable =>
-          if (buf != null) buf.close()
-          throw e
-      } finally {
-        kryoPool.release(k)
-      }
-    } {
-      throw new IllegalStateException("FlightAllocator is already closed, cannot serialize to ArrowBuf")
-    }
-  }
-
-  def serializeToArrowVsr(obj: Any, state: VsrPopulationState)
-                         (needNewVec: () => Unit): Unit = {
-      val k = kryoPool.borrow()
-      try {
-        k.kryo.writeClassAndObject(k.out, obj)
-        if (state.bytesRemaining < k.out.position() || state.rowNum >= maxNumRows) needNewVec()
-        state.currentRvkBrVec.set(state.rowNum, k.out.getBuffer, 0, k.out.position())
-        state.currentIsRvkVec.set(state.rowNum, 1)
-        state.bytesRemaining -= k.out.position()
-        state.rowNum += 1
-      } finally {
-        kryoPool.release(k)
-      }
   }
 
   def serializeToBytes(obj: Any): Array[Byte] = {

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FlightPlanDispatcher.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FlightPlanDispatcher.scala
@@ -114,6 +114,8 @@ case class FlightPlanDispatcher(location: Location,
               footerThrowable = if (footer.hasThrowable) Some(footer.getThrowable.fromProto) else None
               qLogger.debug(s"FlightPlanDispatcher received footer for queryPlanId=${plan.planId} with stats: " +
                 s"${footerStats.get}, throwable: $footerThrowable")
+            } else {
+              qLogger.warn(s"FlightPlanDispatcher received metadata with unknown type for queryPlanId=${plan.planId}")
             }
           }
           // Error on stream is thrown as exception and will be handled at onErrorHandle below

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FlightPlanDispatcher.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FlightPlanDispatcher.scala
@@ -14,9 +14,10 @@ import org.apache.arrow.vector.{VectorLoader, VectorSchemaRoot, VectorUnloader}
 import filodb.coordinator.QueryScheduler
 import filodb.core.QueryTimeoutException
 import filodb.core.memstore.FiloSchedulers
-import filodb.core.query.{QuerySession, QueryStats}
+import filodb.core.query.{QuerySession, QueryStats, ResultSchema}
 import filodb.core.store.ChunkSource
 import filodb.query.{QueryError, QueryResponse, QueryResult, StreamQueryResponse}
+import filodb.query.ProtoConverters._
 import filodb.query.exec.{ExecPlan, ExecPlanWithClientParams, PlanDispatcher}
 
 case class FlightPlanDispatcher(location: Location,
@@ -67,8 +68,9 @@ case class FlightPlanDispatcher(location: Location,
       val flightAllocator = querySession.flightAllocator.get
       FiloSchedulers.assertThreadName(FiloSchedulers.FlightIoSchedName)
       Using.resource(client.getStream(ticket, CallOptions.timeout(timeoutMs, TimeUnit.MILLISECONDS))) { stream =>
-        var respHeader: Option[RespHeader] = None
-        var respFooter: Option[RespFooter] = None
+        var resultSchema: Option[ResultSchema] = None
+        var footerStats: Option[QueryStats] = None
+        var footerThrowable: Option[Throwable] = None
         val vsrs = mutable.ListBuffer[VectorSchemaRoot]()
         var canceled = false
         // Order of messages: ResultSchema, zero or more RVs with metadata, QueryStats, Throwable (if error)
@@ -91,7 +93,7 @@ case class FlightPlanDispatcher(location: Location,
                 s"vectorSize0=${reqVsr.getVector(0).getValueCount} " +
                 s"vectorSize1=${reqVsr.getVector(1).getValueCount}")
 
-              require(respHeader.isDefined, "ResultSchema must be received before RangeVectors")
+              require(resultSchema.isDefined, "ResultSchema must be received before RangeVectors")
               vsrs += reqVsr
               qLogger.debug(s"FlightPlanDispatcher received VSR planId=${plan.planId}")
             } {
@@ -101,27 +103,29 @@ case class FlightPlanDispatcher(location: Location,
               canceled = true
             }
           } else {
-            FlightKryoSerDeser.deserializeFromArrowBuf(stream.getLatestMetadata) match {
-              case header: RespHeader =>
-                respHeader = Some(header)
-                qLogger.debug(s"FlightPlanDispatcher received RespHeader for queryPlanId=${plan.planId} " +
-                  s"with schema: ${header.resultSchema}")
-              case footer: RespFooter =>
-                respFooter = Some(footer)
-                qLogger.debug(s"FlightPlanDispatcher received RespFooter for queryPlanId=${plan.planId} with stats: " +
-                  s"${footer.queryStats}, throwable: ${footer.throwable}")
+            val meta = FlightProtoSerDeser.deserializeMetadata(stream.getLatestMetadata)
+            if (meta.hasHeader) {
+              resultSchema = Some(meta.getHeader.getResultSchema.fromProto)
+              qLogger.debug(s"FlightPlanDispatcher received header for queryPlanId=${plan.planId} " +
+                s"with schema: ${resultSchema.get}")
+            } else if (meta.hasFooter) {
+              val footer = meta.getFooter
+              footerStats = Some(footer.getQueryStats.fromProto)
+              footerThrowable = if (footer.hasThrowable) Some(footer.getThrowable.fromProto) else None
+              qLogger.debug(s"FlightPlanDispatcher received footer for queryPlanId=${plan.planId} with stats: " +
+                s"${footerStats.get}, throwable: $footerThrowable")
             }
           }
           // Error on stream is thrown as exception and will be handled at onErrorHandle below
         }
         if (canceled) {
           QueryError(plan.queryContext.queryId, QueryStats(), new RuntimeException("FlightAllocator closed"))
-        } else if (respFooter.isDefined && respFooter.get.throwable.isDefined) {
-          QueryError(plan.queryContext.queryId, respFooter.get.queryStats, respFooter.get.throwable.get)
+        } else if (footerThrowable.isDefined) {
+          QueryError(plan.queryContext.queryId, footerStats.getOrElse(QueryStats()), footerThrowable.get)
         } else {
-          val srvs = ArrowSerializedRangeVectorOps.convertVsrsIntoArrowSrvs(vsrs.toSeq, respHeader.get.resultSchema)
-          QueryResult(plan.queryContext.queryId, respHeader.get.resultSchema, srvs,
-            respFooter.map(_.queryStats).getOrElse(QueryStats()))
+          val srvs = ArrowSerializedRangeVectorOps.convertVsrsIntoArrowSrvs(vsrs.toSeq, resultSchema.get)
+          QueryResult(plan.queryContext.queryId, resultSchema.get, srvs,
+            footerStats.getOrElse(QueryStats()))
         }
       }
     }.onErrorHandle { ex =>

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FlightProtoSerDeser.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FlightProtoSerDeser.scala
@@ -13,12 +13,13 @@ object FlightProtoSerDeser {
 
   // 8 KB covers any realistic partition-key label set.
   // One (buf, builder) pair per thread; reset before each key write — no per-call heap allocation.
-  private val KeySerBufSize = 8192
+  // Watch out when changing to use virtual threads, this thread-local memory can explode
+  private val RvKeySerBufSize = 8192 // TODO make configurable
   private val threadLocalKeyBuf = new ThreadLocal[(Array[Byte], SingleRecordBuilder)] {
     override def initialValue(): (Array[Byte], SingleRecordBuilder) = {
-      val buf = new Array[Byte](KeySerBufSize)
-      val srb = new SingleRecordBuilder(buf, UnsafeUtils.arayOffset, KeySerBufSize)({
-        throw new IllegalStateException(s"RV key binary record exceeds $KeySerBufSize bytes")
+      val buf = new Array[Byte](RvKeySerBufSize)
+      val srb = new SingleRecordBuilder(buf, UnsafeUtils.arayOffset, RvKeySerBufSize)({
+        throw new IllegalStateException(s"RV key binary record exceeds $RvKeySerBufSize bytes")
       })
       (buf, srb)
     }
@@ -31,7 +32,7 @@ object FlightProtoSerDeser {
   def serializeRvKeyToArrowVsr(key: RangeVectorKey, outputRange: Option[RvRange],
                                 state: VsrPopulationState)(needNewVec: () => Unit): Unit = {
     val (buf, srb) = threadLocalKeyBuf.get()
-    srb.reset(buf, UnsafeUtils.arayOffset, KeySerBufSize)
+    srb.reset(buf, UnsafeUtils.arayOffset, RvKeySerBufSize)
     key.writeToMapBr(srb)
     val contentBytes = UnsafeUtils.getInt(buf, UnsafeUtils.arayOffset)
     // unsafeWrap avoids copying buf into a new ByteString. The ByteString wraps the thread-local
@@ -53,6 +54,8 @@ object FlightProtoSerDeser {
   private def writeProto(msg: com.google.protobuf.MessageLite, state: VsrPopulationState,
                          needNewVec: () => Unit): Unit = {
     val size = msg.getSerializedSize
+    require(size <= ArrowSerializedRangeVectorOps.maxVecLen,
+      s"Serialized proto size $size exceeds Arrow buffer capacity ${ArrowSerializedRangeVectorOps.maxVecLen}")
     if (state.bytesRemaining < size || state.rowNum >= maxNumRows) needNewVec()
     // IMPROVE we are allocating a new buffer and output stream for every proto?
     // Ok for now since it is once per RVK and not once per data point, and not in hot path.

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FlightProtoSerDeser.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FlightProtoSerDeser.scala
@@ -1,0 +1,78 @@
+package filodb.coordinator.flight
+
+import org.apache.arrow.memory.ArrowBuf
+
+import filodb.coordinator.flight.ArrowSerializedRangeVectorOps.{maxNumRows, VsrPopulationState}
+import filodb.core.query.{FlightAllocator, QueryStats, RangeVectorKey, ResultSchema, RvRange, SerializableRangeVector}
+import filodb.grpc.{GrpcMultiPartitionQueryService, ProtoRangeVector}
+import filodb.query.ProtoConverters._
+
+object FlightProtoSerDeser {
+
+  def serializeSrvToArrowVsr(srv: SerializableRangeVector, state: VsrPopulationState)
+                             (needNewVec: () => Unit): Unit =
+    writeProto(ProtoRangeVector.RvMetadata.newBuilder().setSrv(srv.toProto).build(), state, needNewVec)
+
+  def serializeRvKeyToArrowVsr(key: RangeVectorKey, outputRange: Option[RvRange],
+                                state: VsrPopulationState)(needNewVec: () => Unit): Unit = {
+    val rkBuilder = ProtoRangeVector.RvKey.newBuilder().setKey(key.toProto)
+    outputRange.foreach(r => rkBuilder.setRvRange(r.toProto))
+    writeProto(ProtoRangeVector.RvMetadata.newBuilder().setRvKey(rkBuilder.build()).build(), state, needNewVec)
+  }
+
+  def deserializeFromBytes(bytes: Array[Byte]): ProtoRangeVector.RvMetadata =
+    ProtoRangeVector.RvMetadata.parseFrom(bytes)
+
+  // Writes proto bytes directly into the VarBinaryVector data buffer without an intermediate byte[].
+  // Mirrors the manual offset-chain bookkeeping in addFromReader — see the comment there for why
+  // VarBinaryVector.set() is not used.
+  private def writeProto(msg: com.google.protobuf.MessageLite, state: VsrPopulationState,
+                         needNewVec: () => Unit): Unit = {
+    val size = msg.getSerializedSize
+    if (state.bytesRemaining < size || state.rowNum >= maxNumRows) needNewVec()
+    // IMPROVE we are allocating a new buffer and output stream for every proto?
+    // Ok for now since it is once per RVK and not once per data point, and not in hot path.
+    // But see if we can avoid this as well later.
+    val out = com.google.protobuf.CodedOutputStream.newInstance(
+      state.currentRvkBrVec.getDataBuffer.nioBuffer(state.currentWriteOffset().toLong, size))
+    msg.writeTo(out)
+    state.commitRow(size, isRvk = 1)
+  }
+
+  def serializeHeaderToArrowBuf(resultSchema: ResultSchema, fAllocator: FlightAllocator): ArrowBuf =
+    toArrowBuf(GrpcMultiPartitionQueryService.FlightMetadata.newBuilder()
+      .setHeader(GrpcMultiPartitionQueryService.FlightResultHeader.newBuilder()
+        .setResultSchema(resultSchema.toProto)).build().toByteArray, fAllocator)
+
+  def serializeFooterToArrowBuf(queryStats: QueryStats, throwable: Option[Throwable],
+                                 fAllocator: FlightAllocator): ArrowBuf = {
+    val footerBuilder = GrpcMultiPartitionQueryService.FlightResultFooter.newBuilder()
+      .setQueryStats(queryStats.toProto)
+    throwable.foreach(t => footerBuilder.setThrowable(t.toProto))
+    toArrowBuf(GrpcMultiPartitionQueryService.FlightMetadata.newBuilder()
+      .setFooter(footerBuilder.build()).build().toByteArray, fAllocator)
+  }
+
+  def deserializeMetadata(buf: ArrowBuf): GrpcMultiPartitionQueryService.FlightMetadata =
+    GrpcMultiPartitionQueryService.FlightMetadata.parseFrom(
+      com.google.protobuf.CodedInputStream.newInstance(buf.nioBuffer()))
+
+  // It still allocates byte array, but used only in flight response header/footer and it is not in the hot path
+  private def toArrowBuf(bytes: Array[Byte], fAllocator: FlightAllocator): ArrowBuf =
+    fAllocator.withRequestAllocator { allocator =>
+      val buf = allocator.buffer(bytes.length)
+      buf.writeBytes(bytes, 0, bytes.length)
+      buf
+    } {
+      throw new IllegalStateException("FlightAllocator is already closed, cannot serialize to ArrowBuf")
+    }
+
+  private[flight] def rvKeyToProtoBytes(key: RangeVectorKey, outputRange: Option[RvRange]): Array[Byte] = {
+    val rkBuilder = ProtoRangeVector.RvKey.newBuilder().setKey(key.toProto)
+    outputRange.foreach(r => rkBuilder.setRvRange(r.toProto))
+    ProtoRangeVector.RvMetadata.newBuilder().setRvKey(rkBuilder.build()).build().toByteArray
+  }
+
+  private[flight] def srvToProtoBytes(srv: SerializableRangeVector): Array[Byte] =
+    ProtoRangeVector.RvMetadata.newBuilder().setSrv(srv.toProto).build().toByteArray
+}

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FlightProtoSerDeser.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FlightProtoSerDeser.scala
@@ -3,11 +3,26 @@ package filodb.coordinator.flight
 import org.apache.arrow.memory.ArrowBuf
 
 import filodb.coordinator.flight.ArrowSerializedRangeVectorOps.{maxNumRows, VsrPopulationState}
+import filodb.core.binaryrecord2.SingleRecordBuilder
 import filodb.core.query.{FlightAllocator, QueryStats, RangeVectorKey, ResultSchema, RvRange, SerializableRangeVector}
 import filodb.grpc.{GrpcMultiPartitionQueryService, ProtoRangeVector}
+import filodb.memory.format.UnsafeUtils
 import filodb.query.ProtoConverters._
 
 object FlightProtoSerDeser {
+
+  // 8 KB covers any realistic partition-key label set.
+  // One (buf, builder) pair per thread; reset before each key write — no per-call heap allocation.
+  private val KeySerBufSize = 8192
+  private val threadLocalKeyBuf = new ThreadLocal[(Array[Byte], SingleRecordBuilder)] {
+    override def initialValue(): (Array[Byte], SingleRecordBuilder) = {
+      val buf = new Array[Byte](KeySerBufSize)
+      val srb = new SingleRecordBuilder(buf, UnsafeUtils.arayOffset, KeySerBufSize)({
+        throw new IllegalStateException(s"RV key binary record exceeds $KeySerBufSize bytes")
+      })
+      (buf, srb)
+    }
+  }
 
   def serializeSrvToArrowVsr(srv: SerializableRangeVector, state: VsrPopulationState)
                              (needNewVec: () => Unit): Unit =
@@ -15,7 +30,16 @@ object FlightProtoSerDeser {
 
   def serializeRvKeyToArrowVsr(key: RangeVectorKey, outputRange: Option[RvRange],
                                 state: VsrPopulationState)(needNewVec: () => Unit): Unit = {
-    val rkBuilder = ProtoRangeVector.RvKey.newBuilder().setKey(key.toProto)
+    val (buf, srb) = threadLocalKeyBuf.get()
+    srb.reset(buf, UnsafeUtils.arayOffset, KeySerBufSize)
+    key.writeToMapBr(srb)
+    val contentBytes = UnsafeUtils.getInt(buf, UnsafeUtils.arayOffset)
+    // unsafeWrap avoids copying buf into a new ByteString. The ByteString wraps the thread-local
+    // array directly, so it must not outlive this call. Safety: writeProto serialises the message
+    // synchronously into the Arrow buffer, consuming the bytes before returning. buf is only reused
+    // on the next call to this method, by which point the ByteString is no longer referenced.
+    val rkBuilder = ProtoRangeVector.RvKey.newBuilder()
+      .setRvKey(com.google.protobuf.UnsafeByteOperations.unsafeWrap(buf, 0, contentBytes + 4))
     outputRange.foreach(r => rkBuilder.setRvRange(r.toProto))
     writeProto(ProtoRangeVector.RvMetadata.newBuilder().setRvKey(rkBuilder.build()).build(), state, needNewVec)
   }
@@ -66,12 +90,6 @@ object FlightProtoSerDeser {
     } {
       throw new IllegalStateException("FlightAllocator is already closed, cannot serialize to ArrowBuf")
     }
-
-  private[flight] def rvKeyToProtoBytes(key: RangeVectorKey, outputRange: Option[RvRange]): Array[Byte] = {
-    val rkBuilder = ProtoRangeVector.RvKey.newBuilder().setKey(key.toProto)
-    outputRange.foreach(r => rkBuilder.setRvRange(r.toProto))
-    ProtoRangeVector.RvMetadata.newBuilder().setRvKey(rkBuilder.build()).build().toByteArray
-  }
 
   private[flight] def srvToProtoBytes(srv: SerializableRangeVector): Array[Byte] =
     ProtoRangeVector.RvMetadata.newBuilder().setSrv(srv.toProto).build().toByteArray

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FlightQueryResultStreaming.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FlightQueryResultStreaming.scala
@@ -22,8 +22,6 @@ import org.apache.arrow.vector.{VectorLoader, VectorUnloader}
 import filodb.coordinator.QueryScheduler
 import filodb.coordinator.flight.ArrowSerializedRangeVectorOps.VsrPopulationState
 import filodb.core.QueryTimeoutException
-import filodb.core.binaryrecord2.BinaryRecordRowReader
-import filodb.core.binaryrecord2.RecordContainer.BRIterator
 import filodb.core.memstore.FiloSchedulers
 import filodb.core.metrics.FilodbMetrics
 import filodb.core.query._
@@ -201,12 +199,10 @@ trait FlightQueryResultStreaming extends StrictLogging {
           Task.eval {
             logger.debug(s"Streaming result for queryPlanId=${execPlan.planId}")
             FiloSchedulers.assertThreadName(FiloSchedulers.FlightIoSchedName)
-            val respHeader = RespHeader(res.resultSchema)
-            // ownership of metadata buf that is the result of serializeToArrowBuf is now with flight listener
-            // and hence not closed here
+            // ownership of metadata buf is now with flight listener and hence not closed here
             flightAllocator.checkAllocatorLimits(execPlan.queryContext)
             logger.debug(s"Sending header for queryPlanId=${execPlan.planId}")
-            listener.putMetadata(FlightKryoSerDeser.serializeToArrowBuf(respHeader, flightAllocator))
+            listener.putMetadata(FlightProtoSerDeser.serializeHeaderToArrowBuf(res.resultSchema, flightAllocator))
           }.flatMap { _ =>
             Task.eval {
               logger.debug(s"Sending RVs for queryPlanId=${execPlan.planId}")
@@ -221,7 +217,6 @@ trait FlightQueryResultStreaming extends StrictLogging {
             }.bracket { state =>
               FiloSchedulers.assertThreadName(FiloSchedulers.FlightIoSchedName)
               listener.start(state.flightVsr)
-              val rb = SerializedRangeVector.newBuilder()
               if (res.result.forall(rv => rv.isInstanceOf[ArrowSerializedRangeVector] ||
                                             (rv.isInstanceOf[SerializableRangeVector] &&
                                             rv.asInstanceOf[SerializableRangeVector].hasFormulatedRows))) {
@@ -248,7 +243,6 @@ trait FlightQueryResultStreaming extends StrictLogging {
                 }.completedL
               } else {
                 val recSchema = res.resultSchema.toRecordSchema
-                val brIterator = new BRIterator(new BinaryRecordRowReader(recSchema))
                 Observable.fromIterable(res.result).mapEval { rv =>
                   if (rv.isInstanceOf[ArrowSerializedRangeVector]) {
                     // Mixed is unexpected but we should still be able to handle it - just log at
@@ -265,8 +259,8 @@ trait FlightQueryResultStreaming extends StrictLogging {
                     logger.debug(s"Serializing RV into Arrow for queryPlanId=${execPlan.planId} ")
                     flightAllocator.withRequestAllocator { allocator =>
                       ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(rv, recSchema,
-                        s"${execPlan.queryContext.queryId}:${queryResult.id}", rb, res.queryStats,
-                        allocator, state, brIterator)
+                        s"${execPlan.queryContext.queryId}:${queryResult.id}", res.queryStats,
+                        allocator, state)
                     } {
                       throw new IllegalStateException("FlightAllocator is already closed, cannot populate VSRs")
                     }
@@ -339,10 +333,8 @@ trait FlightQueryResultStreaming extends StrictLogging {
       // checkAllocatorLimits(flightAllocator, execPlan.queryContext)
       logger.debug(s"Sending response footer for queryPlanId=${execPlan.planId} and completing " +
         s"stream for queryStats=$s, throwable=$t")
-      val respFooter = RespFooter(s, t)
-      // ownership of metadata buf that is the result of serializeToArrowBuf is now with flight listener
-      // and hence not closed here
-      listener.putMetadata(FlightKryoSerDeser.serializeToArrowBuf(respFooter, flightAllocator))
+      // ownership of metadata buf is now with flight listener and hence not closed here
+      listener.putMetadata(FlightProtoSerDeser.serializeFooterToArrowBuf(s, t, flightAllocator))
       listener.completed()
     }
   }

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FlightQueryResultStreaming.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FlightQueryResultStreaming.scala
@@ -40,9 +40,8 @@ object FlightQueryResultStreaming {
  */
 trait FlightQueryResultStreaming extends StrictLogging {
 
-  // FIXME enable debugging for now until we stabilize and productionize. Then remove.
-  //  It has performance overhead.
-  System.setProperty("arrow.memory.debug.allocator", "true") // allows debugging of memory leaks - look into logs
+  // Enable if debugging. Then certainly remove - It has performance overhead.
+  // System.setProperty("arrow.memory.debug.allocator", "true") // allows debugging of memory leaks - look into logs
 
   def serverAllocator: BufferAllocator
   def sysConfig: com.typesafe.config.Config

--- a/coordinator/src/test/scala/filodb.coordinator/ProtoConvertersSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/ProtoConvertersSpec.scala
@@ -5,20 +5,19 @@ import com.typesafe.config.ConfigFactory
 
 import filodb.core.{DatasetRef, GdeltTestData, TestData}
 import filodb.core.metadata.{Dataset, DatasetOptions}
-import filodb.core.query.{ColumnFilter, ColumnInfo, CustomRangeVectorKey, NoCloseCursor, QueryConfig, QueryContext, QueryStats, RangeVector, RangeVectorCursor, RangeVectorKey, ResultSchema, RvRange, SerializedRangeVector, TransientRow}
+import filodb.core.query.{ColumnFilter, ColumnInfo, CustomRangeVectorKey, NoCloseCursor, QueryConfig, QueryContext, QueryStats, RangeVector, RangeVectorCursor, RangeVectorKey, ResultSchema, RvRange, TransientRow}
 import filodb.core.store.AllChunkScan
 import filodb.query.exec.{InProcessPlanDispatcher, MultiSchemaPartitionsExec}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 import filodb.coordinator.ProtoConverters._
-import filodb.core.binaryrecord2.{BinaryRecordRowReader, RecordBuilder}
+import filodb.core.binaryrecord2.RecordBuilder
 import java.util.concurrent.TimeUnit
 
 import org.apache.arrow.memory.RootAllocator
 
 import filodb.coordinator.flight.ArrowSerializedRangeVectorOps
-import filodb.core.binaryrecord2.RecordContainer.BRIterator
 import filodb.core.metadata.Column.ColumnType
 import filodb.memory.format.{ZeroCopyUTF8String => UTF8Str}
 import filodb.query.ProtoConverters.{SerializableRangeVectorFromProtoConverter, SerializableRangeVectorToProtoConverter}
@@ -99,7 +98,6 @@ class ProtoConvertersSpec extends AnyFunSpec with Matchers {
         ColumnInfo("value", ColumnType.DoubleColumn)
       ), 1)
       val recSchema = resSchema.toRecordSchema
-      val rb = SerializedRangeVector.newBuilder()
 
       val outputRange = Some(RvRange(1000, 1000, 5000))
       val rv = toRv(
@@ -110,11 +108,10 @@ class ProtoConvertersSpec extends AnyFunSpec with Matchers {
 
       val queryStats = QueryStats()
       val vsrs = ArrowSerializedRangeVectorOps.VsrPopulationState()
-      val brIterator = new BRIterator(new BinaryRecordRowReader(recSchema))
 
       // Populate VSR
       ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
-        rv, recSchema, "testExecPlan", rb, queryStats, allocator, vsrs, brIterator
+        rv, recSchema, "testExecPlan", queryStats, allocator, vsrs
       )
 
       // Convert to ArrowSerializedRangeVector2 instances

--- a/coordinator/src/test/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorSpec.scala
+++ b/coordinator/src/test/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorSpec.scala
@@ -267,14 +267,27 @@ class ArrowSerializedRangeVectorSpec extends AnyFunSpec with Matchers with Befor
       val key = CustomRangeVectorKey(Map(UTF8Str("metric") -> UTF8Str("counter")))
 
       // Create a large dataset that will span multiple VSRs
-      // we choose 52425 because next RVK is written at row 52426, and new VSR is created for 52427
-      // (proto RvMetadata bytes = 36, data row bytes = 20;
-      //  floor((1048576 - 2*36) / 20) = 52425 data rows fill the first VSR leaving < 20 bytes free after RVK)
+      // we choose 52424 because next RVK is written at row 52425, and new VSR is created for 52426
+      // Here is the math:
+      // For key Map("metric" -> "counter"):
+      //  - BinaryRecord = 4B header + 4B fixed field + 2B map len + 7B key (1+6) + 9B value (2+7) = 26 bytes
+      //  - Proto bytes rvKey = 1 field: 1B tag + 1B varint(26) + 26B = 28 bytes
+      //  - Proto RvRange (fields 3×int64): 3+5+3 = 11 bytes, wrapped as field 2: 1+1+11 = 13 bytes
+      //  - RvKey total = 28+13 = 41 bytes, wrapped in RvMetadata oneof field 2: 1+1+41 = 43 bytes
+      //
+      // maxVectorLen = 1048576 (1 MB)
+      // proto RvMetadata bytes = 43, data row bytes = 20
+      // Since we are trying to spill over the second RV key, we subtract 2*43 before dividing it by data record size.
+      // Flooring that gives us number of records we can fit in the first VSR before we have to spill over to second VSR
+      // for the next RVK.
+      // NumRecords N = floor((1048576 - 2×43) / 20) = floor(52424.5) = 52424
+      //
+      // 52424 data rows fill the first VSR leaving < 20 bytes free after RVK)
       // This tests the edge case where RVK is at the last row of a VSR, and next data row goes into new VSR.
       // If content of vector is modified, we may need to adjust this number to ensure RVK is at last row of VSR.
       // Do by adding temporary print statements in ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs to
       // find the row number when RVK is written and when new VSR is created.
-      val largeDataset = (1 to 52425).map { i =>
+      val largeDataset = (1 to 52424).map { i =>
         (i.toLong * 1000, i.toDouble)
       }
 

--- a/coordinator/src/test/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorSpec.scala
+++ b/coordinator/src/test/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorSpec.scala
@@ -5,8 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
 import org.apache.arrow.memory.RootAllocator
 
-import filodb.core.binaryrecord2.RecordContainer.BRIterator
-import filodb.core.binaryrecord2.{BinaryRecordRowReader, RecordSchema}
+import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.metadata.Column.ColumnType
 import filodb.core.query._
 import filodb.memory.format.{ZeroCopyUTF8String => UTF8Str}
@@ -16,7 +15,6 @@ class ArrowSerializedRangeVectorSpec extends AnyFunSpec with Matchers with Befor
 
   System.setProperty("arrow.memory.debug.allocator", "true")
   private val allocator = new RootAllocator(10000000)
-  private val rb = SerializedRangeVector.newBuilder()
 
   val resSchema = new ResultSchema(Seq(
     ColumnInfo("time", ColumnType.TimestampColumn),
@@ -69,16 +67,15 @@ class ArrowSerializedRangeVectorSpec extends AnyFunSpec with Matchers with Befor
 
       val queryStats = QueryStats()
       val vsrs = ArrowSerializedRangeVectorOps.VsrPopulationState()
-      val brIterator = new BRIterator(new BinaryRecordRowReader(recSchema))
 
       // Populate VSR
       ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
-        rv, recSchema, "testExecPlan", rb, queryStats, allocator, vsrs, brIterator
+        rv, recSchema, "testExecPlan", queryStats, allocator, vsrs
       )
 
       val srv2 = ScalarFixedDouble(RangeParams(1, 1, 5), 100.0)
       ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
-        srv2, recSchema, "testExecPlan", rb, queryStats, allocator, vsrs, brIterator
+        srv2, recSchema, "testExecPlan", queryStats, allocator, vsrs
       )
 
       // Convert to ArrowSerializedRangeVector2 instances
@@ -117,10 +114,9 @@ class ArrowSerializedRangeVectorSpec extends AnyFunSpec with Matchers with Befor
 
       val queryStats = QueryStats()
       val vsrs = ArrowSerializedRangeVectorOps.VsrPopulationState()
-      val brIterator = new BRIterator(new BinaryRecordRowReader(recSchema))
 
       ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
-        rv, recSchema, "testExecPlan", rb, queryStats, allocator, vsrs, brIterator
+        rv, recSchema, "testExecPlan", queryStats, allocator, vsrs
       )
 
       val allVsrs = vsrs.finishedVsrs ++ Seq(vsrs.currentVsr)
@@ -163,10 +159,9 @@ class ArrowSerializedRangeVectorSpec extends AnyFunSpec with Matchers with Befor
 
       val queryStats = QueryStats()
       val vsrs = ArrowSerializedRangeVectorOps.VsrPopulationState()
-      val brIterator = new BRIterator(new BinaryRecordRowReader(recSchema))
 
       ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
-        rv, recSchema, "testExecPlan", rb, queryStats, allocator, vsrs, brIterator
+        rv, recSchema, "testExecPlan", queryStats, allocator, vsrs
       )
 
       val allVsrs = vsrs.finishedVsrs ++ Seq(vsrs.currentVsr)
@@ -199,17 +194,16 @@ class ArrowSerializedRangeVectorSpec extends AnyFunSpec with Matchers with Befor
 
       val queryStats = QueryStats()
       val vsrs = ArrowSerializedRangeVectorOps.VsrPopulationState()
-      val brIterator = new BRIterator(new BinaryRecordRowReader(recSchema))
 
       // Populate multiple RVs
       ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
-        rv1, recSchema, "testExecPlan", rb, queryStats, allocator, vsrs, brIterator
+        rv1, recSchema, "testExecPlan", queryStats, allocator, vsrs
       )
       ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
-        rv2, recSchema, "testExecPlan", rb, queryStats, allocator, vsrs, brIterator
+        rv2, recSchema, "testExecPlan", queryStats, allocator, vsrs
       )
       ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
-        rv3, recSchema, "testExecPlan", rb, queryStats, allocator, vsrs, brIterator
+        rv3, recSchema, "testExecPlan", queryStats, allocator, vsrs
       )
 
       val allVsrs = vsrs.finishedVsrs ++ Seq(vsrs.currentVsr)
@@ -246,10 +240,9 @@ class ArrowSerializedRangeVectorSpec extends AnyFunSpec with Matchers with Befor
 
       val queryStats = QueryStats()
       val vsrs = ArrowSerializedRangeVectorOps.VsrPopulationState()
-      val brIterator = new BRIterator(new BinaryRecordRowReader(recSchema))
 
       ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
-        rv, recSchema, "testExecPlan", rb, queryStats, allocator, vsrs, brIterator
+        rv, recSchema, "testExecPlan", queryStats, allocator, vsrs
       )
 
       val allVsrs = vsrs.finishedVsrs ++ Seq(vsrs.currentVsr)
@@ -274,12 +267,14 @@ class ArrowSerializedRangeVectorSpec extends AnyFunSpec with Matchers with Befor
       val key = CustomRangeVectorKey(Map(UTF8Str("metric") -> UTF8Str("counter")))
 
       // Create a large dataset that will span multiple VSRs
-      // we choose 52411 because next RVK is written at row 52412, and new VSR is created for 52413
+      // we choose 52425 because next RVK is written at row 52426, and new VSR is created for 52427
+      // (proto RvMetadata bytes = 36, data row bytes = 20;
+      //  floor((1048576 - 2*36) / 20) = 52425 data rows fill the first VSR leaving < 20 bytes free after RVK)
       // This tests the edge case where RVK is at the last row of a VSR, and next data row goes into new VSR.
       // If content of vector is modified, we may need to adjust this number to ensure RVK is at last row of VSR.
       // Do by adding temporary print statements in ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs to
       // find the row number when RVK is written and when new VSR is created.
-      val largeDataset = (1 to 52411).map { i =>
+      val largeDataset = (1 to 52425).map { i =>
         (i.toLong * 1000, i.toDouble)
       }
 
@@ -288,14 +283,13 @@ class ArrowSerializedRangeVectorSpec extends AnyFunSpec with Matchers with Befor
 
       val queryStats = QueryStats()
       val vsrs = ArrowSerializedRangeVectorOps.VsrPopulationState()
-      val brIterator = new BRIterator(new BinaryRecordRowReader(recSchema))
 
       ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
-        rv, recSchema, "testExecPlan", rb, queryStats, allocator, vsrs, brIterator
+        rv, recSchema, "testExecPlan", queryStats, allocator, vsrs
       )
-      println(s"Done with first RV, now adding one more row to trigger RVK at last row of VSR")
+      // println(s"Done with first RV, now adding one more row to trigger RVK at last row of VSR")
       ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
-        rv, recSchema, "testExecPlan", rb, queryStats, allocator, vsrs, brIterator
+        rv, recSchema, "testExecPlan", queryStats, allocator, vsrs
       )
 
       val allVsrs = vsrs.finishedVsrs ++ Seq(vsrs.finishAndGetCurrentVsr())
@@ -334,10 +328,9 @@ class ArrowSerializedRangeVectorSpec extends AnyFunSpec with Matchers with Befor
 
       val queryStats = QueryStats()
       val vsrs = ArrowSerializedRangeVectorOps.VsrPopulationState()
-      val brIterator = new BRIterator(new BinaryRecordRowReader(recSchema))
 
       ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
-        rv, recSchema, "testExecPlan", rb, queryStats, allocator, vsrs, brIterator
+        rv, recSchema, "testExecPlan", queryStats, allocator, vsrs
       )
 
       val allVsrs = vsrs.finishedVsrs ++ Seq(vsrs.currentVsr)
@@ -363,10 +356,9 @@ class ArrowSerializedRangeVectorSpec extends AnyFunSpec with Matchers with Befor
 
       val queryStats = QueryStats()
       val vsrs = ArrowSerializedRangeVectorOps.VsrPopulationState()
-      val brIterator = new BRIterator(new BinaryRecordRowReader(recSchema))
 
       ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
-        rv, recSchema, "testExecPlan", rb, queryStats, allocator, vsrs, brIterator
+        rv, recSchema, "testExecPlan", queryStats, allocator, vsrs
       )
 
       val allVsrs = vsrs.finishedVsrs ++ Seq(vsrs.currentVsr)
@@ -399,10 +391,9 @@ class ArrowSerializedRangeVectorSpec extends AnyFunSpec with Matchers with Befor
 
       val queryStats = QueryStats()
       val vsrs = ArrowSerializedRangeVectorOps.VsrPopulationState()
-      val brIterator = new BRIterator(new BinaryRecordRowReader(recSchema))
 
       ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
-        rv, recSchema, "testExecPlan", rb, queryStats, allocator, vsrs, brIterator
+        rv, recSchema, "testExecPlan", queryStats, allocator, vsrs
       )
 
       val allVsrs = vsrs.finishedVsrs ++ Seq(vsrs.currentVsr)
@@ -414,6 +405,98 @@ class ArrowSerializedRangeVectorSpec extends AnyFunSpec with Matchers with Befor
       cursor.hasNext shouldEqual false
 
       an[NoSuchElementException] should be thrownBy cursor.next()
+
+      allVsrs.foreach(_.close())
+    }
+
+    it("addNullRow should keep the Arrow offset chain intact so data rows after nulls are not corrupted") {
+      // Arrow's VarBinaryVector.setNull only clears the validity bit — it never updates the offset
+      // buffer. If addNullRow skipped the offset propagation (offsetBuffer[i+1] = offsetBuffer[i]),
+      // the next addFromReader would read offsetBuffer[rowNum]=0 and write at byte 0, silently
+      // overwriting the RVK kryo bytes that live at the start of the data buffer.
+      //
+      // This test catches that regression by:
+      //   1. Placing NaN (null) rows before and between real data rows.
+      //   2. Asserting the offset chain is monotonically non-decreasing across every row.
+      //   3. Round-tripping the RV to confirm data rows survive intact.
+      val key = CustomRangeVectorKey(Map(UTF8Str("metric") -> UTF8Str("null_row_test")))
+      // Pattern: null, data, null, data — leading null is the critical case because the RVK
+      // is at position 0 in the data buffer and would be overwritten by a broken offset chain.
+      val rv = toRv(
+        Seq((0, Double.NaN), (1000, 42.0), (2000, Double.NaN), (3000, 99.0)),
+        key,
+        RvRange(0, 1000, 3000)
+      )
+
+      val queryStats = QueryStats()
+      val vsrs = ArrowSerializedRangeVectorOps.VsrPopulationState()
+      ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
+        rv, recSchema, "testExecPlan", queryStats, allocator, vsrs
+      )
+
+      val allVsrs = vsrs.finishedVsrs ++ Seq(vsrs.currentVsr)
+      allVsrs.length shouldEqual 1
+
+      // Verify the offset chain directly: offsetBuffer[i+1] >= offsetBuffer[i] for every row.
+      val rvkBrVec = allVsrs.head.getVector(1).asInstanceOf[org.apache.arrow.vector.VarBinaryVector]
+      val offsetBuf = rvkBrVec.getOffsetBuffer
+      val rowCount  = allVsrs.head.getRowCount
+      for (i <- 0 until rowCount) {
+        val start = offsetBuf.getInt(i.toLong * 4)
+        val end   = offsetBuf.getInt((i + 1).toLong * 4)
+        withClue(s"offset chain broken at row $i: start=$start end=$end") {
+          end should be >= start
+        }
+      }
+
+      // Round-trip: data values must survive and null rows reconstruct as NaN.
+      val srvs = ArrowSerializedRangeVectorOps.convertVsrsIntoArrowSrvs(allVsrs.toSeq, resSchema)
+      srvs.length shouldEqual 1
+      val srv  = srvs.head
+      srv.numRowsSerialized shouldEqual 4
+      val rows = srv.rows().map(r => (r.getLong(0), r.getDouble(1))).toList
+      rows.map(_._1) shouldEqual Seq(0L, 1000L, 2000L, 3000L)
+      rows(0)._2.isNaN shouldBe true
+      rows(1)._2 shouldEqual 42.0
+      rows(2)._2.isNaN shouldBe true
+      rows(3)._2 shouldEqual 99.0
+
+      allVsrs.foreach(_.close())
+    }
+
+    it("data rows should spill to a new VSR when the byte buffer fills before the row count limit") {
+      // Each (timestamp, Double) record occupies 20 bytes on the wire (4 header + 8 Long + 8 Double).
+      // maxVecLen / 20 rows exhaust the 1 MB data buffer well before maxNumRows is reached,
+      // so the VSR split here is driven by byte exhaustion (the spill path in requireBytes),
+      // not the row-count check.
+      import ArrowSerializedRangeVectorOps.{maxNumRows, maxVecLen}
+
+      val rowCount = maxVecLen / 20 + 500          // 52 928, well below maxNumRows (~69 905)
+      assert(rowCount < maxNumRows, "test relies on byte-overflow spill, not row-count overflow")
+
+      val key  = CustomRangeVectorKey(Map(UTF8Str("metric") -> UTF8Str("spill_test")))
+      val data = (1 to rowCount).map(i => (i.toLong * 1000L, i.toDouble))
+      val rv   = toRv(data, key, RvRange(data.head._1, 1000L, data.last._1))
+
+      val queryStats = QueryStats()
+      val vsrs = ArrowSerializedRangeVectorOps.VsrPopulationState()
+
+      ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
+        rv, recSchema, "testExecPlan", queryStats, allocator, vsrs
+      )
+
+      val allVsrs = vsrs.finishedVsrs ++ Seq(vsrs.currentVsr)
+
+      // Byte exhaustion must have triggered exactly one additional VSR allocation.
+      allVsrs.length shouldEqual 2
+
+      val srvs = ArrowSerializedRangeVectorOps.convertVsrsIntoArrowSrvs(allVsrs.toSeq, resSchema)
+      srvs.length shouldEqual 1
+
+      val srv = srvs.head
+      srv.key                shouldEqual key
+      srv.numRowsSerialized  shouldEqual rowCount
+      srv.rows().map(r => (r.getLong(0), r.getDouble(1))).toList shouldEqual data
 
       allVsrs.foreach(_.close())
     }

--- a/coordinator/src/test/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducerSpec.scala
+++ b/coordinator/src/test/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducerSpec.scala
@@ -184,7 +184,7 @@ class FiloDBSinglePartitionFlightProducerSpec extends AnyFunSpec with Matchers w
       rvRows2 shouldEqual List((0 to 100000 by 1000).toList, (0 to 100000 by 1000).toList)
 
       qRes2.result.map(_.key.toString) shouldEqual
-        List("/shard:/Map(host -> host2, region -> region1)", "/shard:/Map(host -> host1, region -> region1)")
+        List("/shard:/Map(host -> host1, region -> region1)", "/shard:/Map(host -> host2, region -> region1)")
 
       qRes2.result.head.asInstanceOf[ArrowSerializedRangeVector].vsrs.foreach(_.close())
       allocator.getAllocatedMemory shouldEqual allocatedMemBeforeQuery

--- a/coordinator/src/test/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducerSpec.scala
+++ b/coordinator/src/test/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducerSpec.scala
@@ -115,8 +115,8 @@ class FiloDBSinglePartitionFlightProducerSpec extends AnyFunSpec with Matchers w
       rvRows2 shouldEqual List((0 to 100000 by 1000).toList, (0 to 100000 by 1000).toList)
 
       qRes2.result.map(_.key.toString) shouldEqual
-        List("/shard:0/b2[schema=schemaID:60110  _metric_=cpu_usage,tags={host: host1, region: region1}] [grp3]",
-          "/shard:0/b2[schema=schemaID:60110  _metric_=cpu_usage,tags={host: host2, region: region1}] [grp0]")
+        List("/shard:/Map(_metric_ -> cpu_usage, host -> host1, region -> region1)",
+             "/shard:/Map(_metric_ -> cpu_usage, host -> host2, region -> region1)")
 
       qRes2.result.head.asInstanceOf[ArrowSerializedRangeVector].vsrs.foreach(_.close())
       allocator.getAllocatedMemory shouldEqual allocatedMemBeforeQuery
@@ -152,10 +152,10 @@ class FiloDBSinglePartitionFlightProducerSpec extends AnyFunSpec with Matchers w
                                (0 to 100000 by 1000).toList, (0 to 100000 by 1000).toList)
 
       qRes2.result.map(_.key.toString) shouldEqual
-        List("/shard:0/b2[schema=schemaID:60110  _metric_=cpu_usage,tags={host: host1, region: region1}] [grp3]",
-             "/shard:0/b2[schema=schemaID:60110  _metric_=cpu_usage,tags={host: host2, region: region1}] [grp0]",
-             "/shard:0/b2[schema=schemaID:60110  _metric_=cpu_usage,tags={host: host1, region: region1}] [grp3]",
-             "/shard:0/b2[schema=schemaID:60110  _metric_=cpu_usage,tags={host: host2, region: region1}] [grp0]")
+        List("/shard:/Map(_metric_ -> cpu_usage, host -> host1, region -> region1)",
+             "/shard:/Map(_metric_ -> cpu_usage, host -> host2, region -> region1)",
+             "/shard:/Map(_metric_ -> cpu_usage, host -> host1, region -> region1)",
+             "/shard:/Map(_metric_ -> cpu_usage, host -> host2, region -> region1)")
 
       qRes2.result.head.asInstanceOf[ArrowSerializedRangeVector].vsrs.foreach(_.close())
       allocator.getAllocatedMemory shouldEqual allocatedMemBeforeQuery

--- a/coordinator/src/test/scala/filodb/coordinator/flight/FlightProtoSerDeserSpec.scala
+++ b/coordinator/src/test/scala/filodb/coordinator/flight/FlightProtoSerDeserSpec.scala
@@ -3,8 +3,10 @@ package filodb.coordinator.flight
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
+import filodb.core.binaryrecord2.SingleRecordBuilder
 import filodb.core.query._
-import filodb.memory.format.{ZeroCopyUTF8String => UTF8Str}
+import filodb.grpc.ProtoRangeVector
+import filodb.memory.format.{UnsafeUtils, ZeroCopyUTF8String => UTF8Str}
 import filodb.query.ProtoConverters._
 
 class FlightProtoSerDeserSpec extends AnyFunSpec with Matchers {
@@ -16,24 +18,49 @@ class FlightProtoSerDeserSpec extends AnyFunSpec with Matchers {
 
   private val rvRange = RvRange(1000L, 15000L, 1060000L)
 
+  // Mirrors the encoding in serializeRvKeyToArrowVsr without needing a live VSR/allocator.
+  private def encodeRvKey(key: RangeVectorKey, range: Option[RvRange]): ProtoRangeVector.RvMetadata = {
+    val buf = new Array[Byte](8192)
+    val srb = new SingleRecordBuilder(buf, UnsafeUtils.arayOffset, 8192)(
+      throw new IllegalStateException("key exceeded 8 KB"))
+    key.writeToMapBr(srb)
+    val contentBytes = UnsafeUtils.getInt(buf, UnsafeUtils.arayOffset)
+    val rkBuilder = ProtoRangeVector.RvKey.newBuilder()
+      .setRvKey(com.google.protobuf.UnsafeByteOperations.unsafeWrap(buf, 0, contentBytes + 4))
+    range.foreach(r => rkBuilder.setRvRange(r.toProto))
+    FlightProtoSerDeser.deserializeFromBytes(
+      ProtoRangeVector.RvMetadata.newBuilder().setRvKey(rkBuilder.build()).build().toByteArray)
+  }
+
+  // Mirrors the decoding in convertVsrsIntoArrowSrvs.
+  private def decodeRvKey(proto: ProtoRangeVector.RvMetadata): BrMapRangeVectorKey = {
+    val rvKeyProto = proto.getRvKey
+    val (base, offset, _) = UnsafeUtils.BOLfromBuffer(rvKeyProto.getRvKey.asReadOnlyByteBuffer())
+    BrMapRangeVectorKey(base, offset)
+  }
+
   describe("FlightProtoSerDeser") {
 
-    it("should round-trip key + output range") {
-      val proto = FlightProtoSerDeser.deserializeFromBytes(
-        FlightProtoSerDeser.rvKeyToProtoBytes(rvKey, Some(rvRange)))
+    it("should round-trip RvKey with output range") {
+      val proto = encodeRvKey(rvKey, Some(rvRange))
       proto.hasRvKey shouldBe true
-      proto.hasSrv  shouldBe false
-      proto.getRvKey.getKey.fromProto.labelValues shouldEqual rvKey.labelValues
+      proto.hasSrv   shouldBe false
+      decodeRvKey(proto).labelValues shouldEqual rvKey.labelValues
       proto.getRvKey.hasRvRange shouldBe true
       proto.getRvKey.getRvRange.fromProto shouldEqual rvRange
     }
 
-    it("should round-trip key with no output range") {
-      val proto = FlightProtoSerDeser.deserializeFromBytes(
-        FlightProtoSerDeser.rvKeyToProtoBytes(rvKey, None))
+    it("should round-trip RvKey with no output range") {
+      val proto = encodeRvKey(rvKey, None)
       proto.hasRvKey shouldBe true
-      proto.getRvKey.getKey.fromProto.labelValues shouldEqual rvKey.labelValues
+      decodeRvKey(proto).labelValues shouldEqual rvKey.labelValues
       proto.getRvKey.hasRvRange shouldBe false
+    }
+
+    it("should round-trip BrMapRangeVectorKey (re-encode an already-decoded key)") {
+      val first  = decodeRvKey(encodeRvKey(rvKey, None))
+      val second = decodeRvKey(encodeRvKey(first, None))
+      second.labelValues shouldEqual rvKey.labelValues
     }
 
     it("should round-trip a ScalarFixedDouble srv") {

--- a/coordinator/src/test/scala/filodb/coordinator/flight/FlightProtoSerDeserSpec.scala
+++ b/coordinator/src/test/scala/filodb/coordinator/flight/FlightProtoSerDeserSpec.scala
@@ -1,0 +1,54 @@
+package filodb.coordinator.flight
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import filodb.core.query._
+import filodb.memory.format.{ZeroCopyUTF8String => UTF8Str}
+import filodb.query.ProtoConverters._
+
+class FlightProtoSerDeserSpec extends AnyFunSpec with Matchers {
+
+  private val rvKey = CustomRangeVectorKey(Map(
+    UTF8Str("__name__") -> UTF8Str("http_requests"),
+    UTF8Str("job")      -> UTF8Str("api-server")
+  ))
+
+  private val rvRange = RvRange(1000L, 15000L, 1060000L)
+
+  describe("FlightProtoSerDeser") {
+
+    it("should round-trip key + output range") {
+      val proto = FlightProtoSerDeser.deserializeFromBytes(
+        FlightProtoSerDeser.rvKeyToProtoBytes(rvKey, Some(rvRange)))
+      proto.hasRvKey shouldBe true
+      proto.hasSrv  shouldBe false
+      proto.getRvKey.getKey.fromProto.labelValues shouldEqual rvKey.labelValues
+      proto.getRvKey.hasRvRange shouldBe true
+      proto.getRvKey.getRvRange.fromProto shouldEqual rvRange
+    }
+
+    it("should round-trip key with no output range") {
+      val proto = FlightProtoSerDeser.deserializeFromBytes(
+        FlightProtoSerDeser.rvKeyToProtoBytes(rvKey, None))
+      proto.hasRvKey shouldBe true
+      proto.getRvKey.getKey.fromProto.labelValues shouldEqual rvKey.labelValues
+      proto.getRvKey.hasRvRange shouldBe false
+    }
+
+    it("should round-trip a ScalarFixedDouble srv") {
+      val sfd = ScalarFixedDouble(RangeParams(100, 15, 200), 42.0)
+      val proto = FlightProtoSerDeser.deserializeFromBytes(
+        FlightProtoSerDeser.srvToProtoBytes(sfd))
+      proto.hasSrv  shouldBe true
+      proto.hasRvKey shouldBe false
+      proto.getSrv.fromProto shouldEqual sfd
+    }
+
+    it("should parse empty bytes without throwing (proto3 default), with no fields set") {
+      val proto = FlightProtoSerDeser.deserializeFromBytes(Array.emptyByteArray)
+      proto.hasSrv   shouldBe false
+      proto.hasRvKey shouldBe false
+    }
+  }
+}

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilder.scala
@@ -33,29 +33,18 @@ import filodb.memory.format.vectors.Histogram
  */
 class RecordBuilder(memFactory: MemFactory,
                     containerSize: Int = RecordBuilder.DefaultContainerSize,
-                    reuseOneContainer: Boolean = false) extends StrictLogging {
+                    reuseOneContainer: Boolean = false) extends RecordBuilderBase with StrictLogging {
   import RecordBuilder._
   import UnsafeUtils._
   require(containerSize >= RecordBuilder.MinContainerSize, s"RecordBuilder.containerSize < minimum")
 
-  private var curBase: Any = UnsafeUtils.ZeroPointer
-  private var fieldNo: Int = -1
-  private var curRecordOffset: Long = -1L
-  private var curRecEndOffset: Long = -1L
-  private var maxOffset: Long = -1L
-  private var mapOffset: Long = -1L
-  private var recHash: Int = -1
-
   private val containers = new collection.mutable.ArrayBuffer[RecordContainer]
-  var schema: RecordSchema = _
-  var firstPartField = Int.MaxValue
-  private var hashOffset: Int = 0
 
   if (reuseOneContainer) newContainer()
 
   /**
-    * Override to return a different clock, intended when running tests.
-    */
+   * Override to return a different clock, intended when running tests.
+   */
   def currentTimeMillis: Long = System.currentTimeMillis()
 
   // Reset last container and all pointers
@@ -67,23 +56,6 @@ class RecordBuilder(memFactory: MemFactory,
     recHash = -1
   }
 
-  /**
-   * If somehow the state is inconsistent, and only a partial record is written,
-   * rewind the curRecordOffset back to the curRecEndOffset.  In other words, rewind the write pointer
-   * back to the end of previous record.  Partially written data is lost, but state is consistent again.
-   */
-  def rewind(): Unit = {
-    curRecEndOffset = curRecordOffset
-  }
-
-  // Check that we are at end of a record.  If a partial record is written, just rewind so state is not inconsistent.
-  private def checkPointers(): Unit = {
-    if (curRecEndOffset != curRecordOffset) {
-      logger.warn(s"Partial record was written, perhaps exception occurred.  Rewinding to end of previous record.")
-      rewind()
-    }
-  }
-
   // Only reset the container offsets, but not the fieldNo, mapOffset, recHash
   private def resetContainerPointers(): Unit = {
     curRecordOffset = containers.last.offset + ContainerHeaderLen
@@ -92,391 +64,9 @@ class RecordBuilder(memFactory: MemFactory,
     curBase = containers.last.base
   }
 
-  private[binaryrecord2] def setSchema(newSchema: RecordSchema): Unit = if (newSchema != schema) {
-    schema = newSchema
-    hashOffset = newSchema.fieldOffset(newSchema.numFields)
-    firstPartField = schema.partitionFieldStart.getOrElse(Int.MaxValue)
-  }
-
-  /**
-   * Start building a new BinaryRecord with a possibly new schema.
-   * This must be called after a previous endRecord() or when the builder just started.
-   * NOTE: it's probably better to use an alternative startNewRecord with one of the schema types.
-   * @param recSchema the RecordSchema to use for this record
-   * @param schemaID the schemaID to use.  It may not be the same as the schema of the recSchema - for example
-   *        for partition keys.  However for ingestion records it would be the same.
-   */
-  private[core] final def startNewRecord(recSchema: RecordSchema, schemaID: Int): Unit = {
-    checkPointers()
-
-    // Set schema, hashoffset, and write schema ID if needed
-    setSchema(recSchema)
-    requireBytes(schema.variableAreaStart)
-
-    if (recSchema.partitionFieldStart.isDefined) { setShort(curBase, curRecordOffset + 4, schemaID.toShort) }
-
-    // write length header and update RecEndOffset
-    setInt(curBase, curRecordOffset, schema.variableAreaStart - 4)
-    curRecEndOffset = curRecordOffset + schema.variableAreaStart
-
-    fieldNo = 0
-    recHash = HASH_INIT
-  }
-
-  // startNewRecord when one uses a RecordSchema for say query results, or where schemaID is not needed.
-  final def startNewRecord(schema: RecordSchema): Unit = {
-    // TODO: use types to eliminate this check?
-    require(schema.partitionFieldStart.isEmpty, s"Cannot use schema $schema with no schemaID")
-    startNewRecord(schema, 0)
-  }
-
-  // startNewRecord for an ingestion schema.  Use this if creating an ingestion record, ensures right ID is used.
-  final def startNewRecord(schema: Schema): Unit =
-    startNewRecord(schema.ingestionSchema, schema.schemaHash)
-
-  final def startNewRecord(partSchema: PartitionSchema, schemaID: Int): Unit =
-    startNewRecord(partSchema.binSchema, schemaID)
-
-  /**
-   * Adds an integer to the record.  This must be called in the right order or the data might be corrupted.
-   * Also this must be called between startNewRecord and endRecord.
-   * Calling this method after all fields of a record has been filled will lead to an error.
-   */
-  final def addInt(data: Int): Unit = {
-    checkFieldNo()
-    setInt(curBase, curRecordOffset + schema.fieldOffset(fieldNo), data)
-    fieldNo += 1
-  }
-
-  /**
-   * Adds a Long to the record.  This must be called in the right order or the data might be corrupted.
-   * Also this must be called between startNewRecord and endRecord.
-   * Calling this method after all fields of a record has been filled will lead to an error.
-   */
-  final def addLong(data: Long): Unit = {
-    checkFieldNo()
-    setLong(curBase, curRecordOffset + schema.fieldOffset(fieldNo), data)
-    fieldNo += 1
-  }
-
-  /**
-   * Adds a Double to the record.  This must be called in the right order or the data might be corrupted.
-   * Also this must be called between startNewRecord and endRecord.
-   * Calling this method after all fields of a record has been filled will lead to an error.
-   */
-  final def addDouble(data: Double): Unit = {
-    checkFieldNo()
-    setDouble(curBase, curRecordOffset + schema.fieldOffset(fieldNo), data)
-    fieldNo += 1
-  }
-
-  /**
-   * Adds a string or raw bytes to the record.  They must fit in within 64KB.
-   * The variable length area of the BinaryRecord will be extended.
-   */
-  final def addString(bytes: Array[Byte]): Unit =
-    addBlob(bytes, UnsafeUtils.arayOffset, bytes.size)
-
-  final def addString(s: String): Unit = addString(s.getBytes(StandardCharsets.UTF_8))
-
-  final def addBlob(base: Any, offset: Long, numBytes: Int): Unit = {
-    require(numBytes < 65536, s"bytes too large ($numBytes bytes) for addBlob")
-    checkFieldAndMemory(numBytes + 2)
-    UnsafeUtils.setShort(curBase, curRecEndOffset, numBytes.toShort) // length of blob
-    UnsafeUtils.unsafe.copyMemory(base, offset, curBase, curRecEndOffset + 2, numBytes)
-    updateFieldPointerAndLens(numBytes + 2)
-    if (fieldNo >= firstPartField) recHash = combineHash(recHash, BinaryRegion.hash32(base, offset, numBytes))
-    fieldNo += 1
-  }
-
-  final def addBlob(strPtr: ZCUTF8): Unit = addBlob(strPtr.base, strPtr.offset, strPtr.numBytes)
-
-  // Adds a blob from another buffer which already has the length bytes as the first two bytes
-  // For example: buffers created by BinaryHistograms.  OR, a UTF8String medium.
-  final def addBlob(buf: DirectBuffer): Unit = {
-    val numBytes = buf.getShort(0).toInt
-    require(numBytes < buf.capacity)
-    addBlob(buf.byteArray, buf.addressOffset + 2, numBytes)
-  }
-
-  /**
-    * IMPORTANT: Internal method, does not update hash values for the map key/values individually.
-    * If this method is used, then caller needs to also update the partitionHash manually.
-    */
-  private def addMap(base: Any, offset: Long, numBytes: Int): Unit = {
-    require(numBytes < 65536, s"bytes too large ($numBytes bytes) for addMap")
-    checkFieldAndMemory(numBytes + 2)
-    UnsafeUtils.setShort(curBase, curRecEndOffset, numBytes.toShort) // length of blob
-    UnsafeUtils.unsafe.copyMemory(base, offset, curBase, curRecEndOffset + 2, numBytes)
-    updateFieldPointerAndLens(numBytes + 2)
-    fieldNo += 1
-  }
-
-  private def addBlobFromBr(base: Any, offset: Long, col: Int, schema: RecordSchema): Unit = {
-    val blobDataOffset = schema.blobOffset(base, offset, col)
-    val blobNumBytes = schema.blobNumBytes(base, offset, col)
-    addBlob(base, blobDataOffset, blobNumBytes)
-  }
-
-  /**
-    * IMPORTANT: Internal method, does not update hash values for the data.
-    * If this method is used, then caller needs to also update the partitionHash manually.
-    */
-  private def addLargeBlobFromBr(base: Any, offset: Long, col: Int, schema: RecordSchema): Unit = {
-    val strDataOffset = schema.utf8StringOffset(base, offset, col)
-    addMap(base, strDataOffset + 4, BinaryRegionLarge.numBytes(base, strDataOffset))
-  }
-
-  private def addLongFromBr(base: Any, offset: Long, col: Int, schema: RecordSchema): Unit = {
-    addLong(schema.getLong(base, offset, col))
-  }
-
-  private def addDoubleFromBr(base: Any, offset: Long, col: Int, schema: RecordSchema): Unit = {
-    addDouble(schema.getDouble(base, offset, col))
-  }
-
-  /**
-    * Adds fields of a Partition Key Binary Record into the record builder as column values in
-    * the same order. Typically used for the downsampling use case where we copy partition key from
-    * the TimeSeriesPartition into the ingest record for the downsample data.
-    *
-    * This also updates the hash for this record. OK since partKeys are added at the very end
-    * of the record.
-    */
-  final def addPartKeyRecordFields(base: Any, offset: Long, partKeySchema: RecordSchema): Unit = {
-    var id = 0
-    partKeySchema.columns.foreach {
-      case ColumnInfo(_, MapColumn, _, _) => addBlobFromBr(base, offset, id, partKeySchema); id += 1
-      case ColumnInfo(_, StringColumn, _, _) => addBlobFromBr(base, offset, id, partKeySchema); id += 1
-      case ColumnInfo(_, LongColumn, _, _) => addLongFromBr(base, offset, id, partKeySchema); id += 1
-      case ColumnInfo(_, DoubleColumn, _, _) => addDoubleFromBr(base, offset, id, partKeySchema); id += 1
-      case _ => ???
-    }
-    // finally copy the partition hash over
-    recHash = partKeySchema.partitionHash(base, offset)
-  }
 
   import Column.ColumnType._
 
-  /**
-   * A SLOW but FLEXIBLE method to add data to the current field.  Boxes for sure but can take any data.
-   * Relies on passing in an object (Any) and using match, lots of allocations here.
-   * PLEASE don't use it in high performance code / hot paths.  Meant for ease of testing.
-   */
-  def addSlowly(item: Any): Unit = {
-    (schema.columnTypes(fieldNo), item) match {
-      case (IntColumn, i: Int)       => addInt(i)
-      case (LongColumn, l: Long)     => addLong(l)
-      case (TimestampColumn, l: Long) => addLong(l)
-      case (DoubleColumn, d: Double) => addDouble(d)
-      case (StringColumn, s: String) => addString(s)
-      case (StringColumn, a: Array[Byte]) => addString(a)
-      case (StringColumn, z: ZCUTF8) => addBlob(z)
-      case (MapColumn, m: Map[ZCUTF8, ZCUTF8] @unchecked) => addMap(m)
-      case (HistogramColumn, h: Histogram) => addBlob(h.serialize())
-      case (other: Column.ColumnType, v) =>
-        throw new UnsupportedOperationException(s"Column type of $other and value of class ${v.getClass}")
-    }
-  }
-
-  /**
-   * Adds an entire record from a RowReader, with no boxing, using builderAdders
-   * @return the offset or NativePointer if the memFactory is an offheap one, to the new BinaryRecord
-   */
-  final def addFromReader(row: RowReader, schema: RecordSchema, schemID: Int): Long = {
-    startNewRecord(schema, schemID)
-    cforRange { 0 until schema.numFields } { pos =>
-      schema.builderAdders(pos)(row, this)
-    }
-    endRecord()
-  }
-
-  final def addFromReader(row: RowReader, schema: Schema): Long =
-    addFromReader(row, schema.ingestionSchema, schema.schemaHash)
-
-  // Really only for testing. Very slow.  Only for partition keys
-  def partKeyFromObjects(schema: Schema, parts: Any*): Long =
-    addFromReader(SeqRowReader(parts.toSeq), schema.partKeySchema, schema.schemaHash)
-
-  /**
-   * Sorts and adds keys and values from a map.  The easiest way to add a map to a BinaryRecord.
-   */
-  def addMap(map: Map[ZCUTF8, ZCUTF8]): Unit = {
-    startMap()
-    map.toSeq.sortBy(_._1).foreach { case (k, v) =>
-      addMapKeyValue(k.bytes, v.bytes)
-    }
-    endMap()
-  }
-
-  /**
-   * Encodes a Java TreeMap directly into the map field without Scala collection conversion.
-   * TreeMap is already sorted by key, so no re-sorting needed.
-   *
-   * This avoids the overhead of:
-   *   - convertToScalaImmutableMap (Stream, Tuple2, HashMap construction)
-   *   - Scala Map.toSeq.sortBy (TreeMap is already sorted)
-   *   - ZeroCopyUTF8String wrapping
-   *
-   * Produces the same wire format as addMap(Map[ZCUTF8, ZCUTF8]) — identical bytes,
-   * same predefined key handling, same partition hash.
-   *
-   * Usage from Java:
-   *   TreeMap<String, String> tags = new TreeMap<>();
-   *   tags.put("_ns_", "myapp");
-   *   tags.put("_ws_", "demo");
-   *   builder.startNewRecord(schema);
-   *   // ... add other fields ...
-   *   builder.encodeMapFrom(tags);
-   *   builder.endRecord();
-   */
-  final def encodeMapFrom(tags: java.util.TreeMap[String, String]): Unit = {
-    startMap()
-    val iter = tags.entrySet().iterator()
-    while (iter.hasNext) {
-      val entry = iter.next()
-      val keyBytes = entry.getKey.getBytes(StandardCharsets.UTF_8)
-      val valBytes = entry.getValue.getBytes(StandardCharsets.UTF_8)
-      addMapKeyValue(keyBytes, 0, keyBytes.length, valBytes, 0, valBytes.length)
-    }
-    endMap()
-  }
-
-  final def updatePartitionHash(newHash: Int): Unit = {
-    recHash = combineHash(recHash, newHash)
-  }
-
-  /**
-   * Low-level function to start adding a map field.  Must be followed by addMapKeyValue() in sorted order of
-   * keys (UTF8 byte sort).  Might want to use one of the higher level functions.
-   */
-  final def startMap(): Unit = {
-    require(mapOffset == -1L)
-    checkFieldAndMemory(2)   // 2 bytes for map length header
-    mapOffset = curRecEndOffset
-    setShort(curBase, mapOffset, 0)
-    updateFieldPointerAndLens(2)
-    // Don't update fieldNo, we'll be working on map for a while
-  }
-
-  /**
-   * Adds a single key-value pair to the map field started by startMap().
-   * Takes care of matching and translating predefined keys into short codes.
-   * Keys must be < 60KB and values must be < 64KB
-   * Hash is not computed or added for you - it must be separately added by you!
-   *
-   * IMPORTANT: MapEncoder.encode() replicates this encoding logic. If the wire format
-   * changes here (predefined key codes, UTF8StringShort/Medium encoding, byte order),
-   * MapEncoder must be updated to match.
-   */
-  final def addMapKeyValue(keyBytes: Array[Byte], keyOffset: Int, keyLen: Int,
-                           valueBytes: Array[Byte], valueOffset: Int, valueLen: Int,
-                           keyHash: Int = 7): Unit = {
-    require(mapOffset > curRecordOffset, "illegal state, did you call startMap() first?")
-    // check key size, must be < 60KB
-    require(keyLen < 192, s"key is too large: ${keyLen} bytes")
-    require(valueLen < 64*1024, s"value is too large: $valueLen bytes")
-
-    // Check if key is a predefined key
-    val predefKeyNum =  // but if there are no predefined keys, skip the cost of hashing the key
-      if (schema.predefinedKeys.isEmpty) { -1 }
-      else {
-        val keyKey = RecordSchema.makeKeyKey(keyBytes, keyOffset, keyLen, keyHash)
-        schema.predefKeyNumMap.getOrElse(keyKey, -1)
-      }
-    val keyValueSize = if (predefKeyNum >= 0) { valueLen + 3 } else { keyLen + valueLen + 3 }
-    requireBytes(keyValueSize)
-    if (predefKeyNum >= 0) {
-      setByte(curBase, curRecEndOffset, (0x0C0 | predefKeyNum).toByte)
-      curRecEndOffset += 1
-    } else {
-      UTF8StringShort.copyByteArrayTo(keyBytes, keyOffset, keyLen, curBase, curRecEndOffset)
-      curRecEndOffset += keyLen + 1
-    }
-    UTF8StringMedium.copyByteArrayTo(valueBytes, valueOffset, valueLen, curBase, curRecEndOffset)
-    curRecEndOffset += valueLen + 2
-
-    // update map length, BR length
-    val newMapLen = curRecEndOffset - mapOffset - 2
-    require(newMapLen < 65536, s"Map entries cannot total more than 64KB, but is now $newMapLen")
-    setShort(curBase, mapOffset, newMapLen.toShort)
-    setInt(curBase, curRecordOffset, (curRecEndOffset - curRecordOffset - 4).toInt)
-  }
-
-  final def addMapKeyValue(key: Array[Byte], value: Array[Byte]): Unit =
-    addMapKeyValue(key, 0, key.size, value, 0, value.size)
-
-  /**
-   * An alternative to above for adding a known key with precomputed key hash
-   * along with a value, to the map, while updating the hash too.
-   * Saves computing the key hash twice.
-   * TODO: deprecate this.  We are switching to computing a hash for all keys at the same time.
-   */
-  final def addMapKeyValueHash(keyBytes: Array[Byte], keyHash: Int,
-                               valueBytes: Array[Byte], valueOffset: Int, valueLen: Int): Unit = {
-    addMapKeyValue(keyBytes, 0, keyBytes.size, valueBytes, valueOffset, valueLen, keyHash)
-    val valueHash = BinaryRegion.hasher32.hash(valueBytes, valueOffset, valueLen, BinaryRegion.Seed)
-    updatePartitionHash(combineHash(keyHash, valueHash))
-  }
-
-  /**
-   * Ends creation of a map field.  Recompute the hash for all fields at once.
-   * @param bulkHash if true (default), computes the hash for all key/values.
-   *                 Some users use the older alternate, sortAndComputeHashes() - then set this to false.
-   */
-  final def endMap(bulkHash: Boolean = true): Unit = {
-    if (bulkHash) {
-      val mapHash = BinaryRegion.hash32(curBase, mapOffset, (curRecEndOffset - mapOffset).toInt)
-      updatePartitionHash(mapHash)
-    }
-    mapOffset = -1L
-    fieldNo += 1
-  }
-
-  /**
-   * Adds an encoded map field directly from a byte array already in RecordBuilder wire format.
-   * Use MapEncoder.encode() to produce correctly encoded bytes.
-   */
-  final def addEncodedMap(mapBytes: Array[Byte]): Unit = {
-    val numBytes = mapBytes.length
-    require(numBytes < 65536, s"Map bytes too large: $numBytes")
-    startMap()
-    requireBytes(numBytes)
-    UnsafeUtils.unsafe.copyMemory(mapBytes, UnsafeUtils.arayOffset,
-                                  curBase, curRecEndOffset, numBytes)
-    curRecEndOffset += numBytes
-    // update map length and record length
-    setShort(curBase, mapOffset, numBytes.toShort)
-    setInt(curBase, curRecordOffset, (curRecEndOffset - curRecordOffset - 4).toInt)
-    endMap()
-  }
-
-  /**
-   * Ends the building of the current BinaryRecord.  Makes sures RecordContainer state is updated.
-   * Aligns the next record on a 4-byte/short word boundary.
-   * Returns the Long offset of the just finished BinaryRecord.  If the container is offheap, then this is the
-   * full NativePointer.  If it is onHeap, you will need to access the current container and get the base
-   * to form the (base, offset) pair needed to access the BinaryRecord.
-   */
-  final def endRecord(writeHash: Boolean = true): Long = {
-    val recordOffset = curRecordOffset
-
-    if (writeHash && firstPartField < Int.MaxValue) setInt(curBase, curRecordOffset + hashOffset, recHash)
-
-    // Bring RecordOffset up to endOffset w/ align.  Now the state is complete at end of a record again.
-    curRecEndOffset = align(curRecEndOffset)
-    curRecordOffset = curRecEndOffset
-    fieldNo = -1
-
-    // Update container length.  This is atomic so it is updated only when the record is complete.
-    val lastContainer = containers.last
-    lastContainer.updateLengthWithOffset(curRecEndOffset)
-    lastContainer.numRecords += 1
-
-    recordOffset
-  }
-
-  final def align(offset: Long): Long = (offset + 3) & ~3
 
   /**
    * Used only internally by RecordComparator etc. to shortcut create a new BR by copying bytes from an existing BR.
@@ -534,16 +124,16 @@ class RecordBuilder(memFactory: MemFactory,
 
 
   /**
-    * Returns all the full containers other than currentContainer as byte arrays.
-    * Assuming all of the containers except the last one is full,
-    * calls array() on all the non-last container excluding the currentContainer.
-    * The memFactory needs to be an on heap one otherwise UnsupportedOperationException will be thrown.
-    * The sequence of byte arrays can be for example sent to Kafka as a sequence of messages - one message
-    * per byte array.
-    * @param reset if true, clears out all the containers other than lastContainer.
-    *              Allows a producer of containers to obtain the
-    *              byte arrays for sending somewhere else, while clearing containers for the next batch.
-    */
+   * Returns all the full containers other than currentContainer as byte arrays.
+   * Assuming all of the containers except the last one is full,
+   * calls array() on all the non-last container excluding the currentContainer.
+   * The memFactory needs to be an on heap one otherwise UnsupportedOperationException will be thrown.
+   * The sequence of byte arrays can be for example sent to Kafka as a sequence of messages - one message
+   * per byte array.
+   * @param reset if true, clears out all the containers other than lastContainer.
+   *              Allows a producer of containers to obtain the
+   *              byte arrays for sending somewhere else, while clearing containers for the next batch.
+   */
   def nonCurrentContainerBytes(reset: Boolean = false): Seq[Array[Byte]] = {
     val bytes = allContainers.dropRight(1).map(_.array)
     if (reset) removeAndFreeContainers(containers.size - 1)
@@ -586,11 +176,11 @@ class RecordBuilder(memFactory: MemFactory,
    */
   def containerRemaining: Long = maxOffset - curRecEndOffset
 
-  private def requireBytes(numBytes: Int): Unit =
+  protected def requireBytes(numBytes: Int): Unit =
     // if container is none, allocate a new one, make sure it has enough space, reset length, update offsets
     if (containers.isEmpty) {
       newContainer()
-    // if we don't have enough space left, get a new container and move existing BR being written into new space
+      // if we don't have enough space left, get a new container and move existing BR being written into new space
     } else if (curRecEndOffset + numBytes > maxOffset) {
       val oldBase = curBase
       val recordNumBytes = curRecEndOffset - curRecordOffset
@@ -620,21 +210,13 @@ class RecordBuilder(memFactory: MemFactory,
     maxOffset = newOff + containerSize
   }
 
-  private def checkFieldNo(): Unit = require(fieldNo >= 0 && fieldNo < schema.numFields)
-
-  private def checkFieldAndMemory(bytesRequired: Int): Unit = {
-    checkFieldNo()
-    requireBytes(bytesRequired)
+  def postEndRecord(): Unit = {
+    // Update container length.  This is atomic so it is updated only when the record is complete.
+    val lastContainer = containers.last
+    lastContainer.updateLengthWithOffset(curRecEndOffset)
+    lastContainer.numRecords += 1
   }
 
-  private def updateFieldPointerAndLens(varFieldLen: Int): Unit = {
-    // update fixed field area, which is a 4-byte offset to the var field
-    setInt(curBase, curRecordOffset + schema.fieldOffset(fieldNo), (curRecEndOffset - curRecordOffset).toInt)
-    curRecEndOffset += varFieldLen
-
-    // update BinaryRecord length header as well
-    setInt(curBase, curRecordOffset, (curRecEndOffset - curRecordOffset).toInt - 4)
-  }
 }
 
 object RecordBuilder {

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilderBase.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilderBase.scala
@@ -249,6 +249,23 @@ abstract class RecordBuilderBase extends StrictLogging {
   }
 
   /**
+   * Adds an entire record from a BinaryRecord, with no boxing or allocations. The record must have the same
+   * schema as the current one.
+   */
+  final def addFromBr(base: Any, offset: Long): Long = {
+    checkPointers()
+    val numBytes = UnsafeUtils.getInt(base, offset)
+    requireBytes(numBytes + 4)
+    val recordOffset = curRecordOffset
+    UnsafeUtils.unsafe.copyMemory(base, offset, curBase, curRecEndOffset, numBytes + 4)
+    curRecEndOffset = align(curRecEndOffset + numBytes + 4)
+    curRecordOffset = curRecEndOffset
+    fieldNo = -1
+    postEndRecord()
+    recordOffset
+  }
+
+  /**
    * Adds an entire record from a RowReader, with no boxing, using builderAdders
    *
    * @return the offset or NativePointer if the memFactory is an offheap one, to the new BinaryRecord
@@ -342,6 +359,66 @@ abstract class RecordBuilderBase extends StrictLogging {
     setShort(curBase, mapOffset, 0)
     updateFieldPointerAndLens(2)
     // Don't update fieldNo, we'll be working on map for a while
+  }
+
+  /**
+   * Use key which is a UTF8StringShort, and value which is a UTF8StringMedium, to add a
+   * key-value pair to the map field started by startMap().
+   * This method is used to serialize RangeVectorKeys in arrow flight RPC path
+   *
+   * IMPORTANT: The encoding does not use pre-defined keys since this can
+   * travel across partitions which can potentially have different pre-defined
+   * keys during deployment roll outs.
+   *
+   * Hash is also not computed
+   */
+  final def addMapKeyValue(keyBase: Any, keyOffset: Long,
+                           valueBase: Any, valueOffset: Long): Unit = {
+    require(mapOffset > curRecordOffset, "illegal state, did you call startMap() first?")
+    val keyLen = UTF8StringShort.numBytes(keyBase, keyOffset)
+    val valLen = UTF8StringMedium.numBytes(valueBase, valueOffset)
+    require(keyLen < 192, s"key is too large: $keyLen bytes")
+    require(valLen < 64 * 1024, s"value is too large: $valLen bytes")
+    requireBytes(keyLen + valLen + 3)
+    UnsafeUtils.unsafe.copyMemory(keyBase, keyOffset, curBase, curRecEndOffset, keyLen + 1)
+    curRecEndOffset += keyLen + 1
+    UnsafeUtils.unsafe.copyMemory(valueBase, valueOffset, curBase, curRecEndOffset, valLen + 2)
+    curRecEndOffset += valLen + 2
+    val newMapLen = curRecEndOffset - mapOffset - 2
+    require(newMapLen < 65536, s"Map entries cannot total more than 64KB, but is now $newMapLen")
+    setShort(curBase, mapOffset, newMapLen.toShort)
+    setInt(curBase, curRecordOffset, (curRecEndOffset - curRecordOffset - 4).toInt)
+  }
+
+  /**
+   * Use key which is a ZCUTF8, and value which is a UTF8StringMedium, to add a
+   * key-value pair to the map field started by startMap().
+   * This method is used to serialize RangeVectorKeys in arrow flight RPC path
+   *
+   * IMPORTANT: The encoding does not use pre-defined keys since this can
+   * travel across partitions which can potentially have different pre-defined
+   * keys during deployment roll outs.
+   *
+   * Hash is also not computed
+   */
+  final def addMapKeyValue(key: ZCUTF8,
+                           valueBase: Any, valueOffset: Long): Unit = {
+    require(mapOffset > curRecordOffset, "illegal state, did you call startMap() first?")
+    val keyLen = key.numBytes
+    val valLen = UTF8StringMedium.numBytes(valueBase, valueOffset)
+    require(keyLen < 192, s"key is too large: $keyLen bytes")
+    require(valLen < 64 * 1024, s"value is too large: $valLen bytes")
+    requireBytes(keyLen + valLen + 3)
+    UnsafeUtils.setByte(curBase, curRecEndOffset, keyLen.toByte) // write key length as 1 byte for UTF8StringShort
+    curRecEndOffset += 1
+    UnsafeUtils.unsafe.copyMemory(key.base, key.offset, curBase, curRecEndOffset, keyLen)
+    curRecEndOffset += keyLen
+    UnsafeUtils.unsafe.copyMemory(valueBase, valueOffset, curBase, curRecEndOffset, valLen + 2)
+    curRecEndOffset += valLen + 2
+    val newMapLen = curRecEndOffset - mapOffset - 2
+    require(newMapLen < 65536, s"Map entries cannot total more than 64KB, but is now $newMapLen")
+    setShort(curBase, mapOffset, newMapLen.toShort)
+    setInt(curBase, curRecordOffset, (curRecEndOffset - curRecordOffset - 4).toInt)
   }
 
   /**

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilderBase.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordBuilderBase.scala
@@ -1,0 +1,469 @@
+package filodb.core.binaryrecord2
+
+import java.nio.charset.StandardCharsets
+
+import com.typesafe.scalalogging.StrictLogging
+import org.agrona.DirectBuffer
+import spire.syntax.cfor.cforRange
+
+import filodb.core.binaryrecord2.RecordBuilder.{combineHash, HASH_INIT}
+import filodb.core.metadata.{Column, PartitionSchema, Schema}
+import filodb.core.metadata.Column.ColumnType._
+import filodb.core.query.ColumnInfo
+import filodb.memory.{BinaryRegion, BinaryRegionLarge, UTF8StringMedium, UTF8StringShort}
+import filodb.memory.format.{RowReader, SeqRowReader, UnsafeUtils, ZeroCopyUTF8String => ZCUTF8}
+import filodb.memory.format.UnsafeUtils._
+import filodb.memory.format.vectors.Histogram
+
+abstract class RecordBuilderBase extends StrictLogging {
+
+  var schema: RecordSchema = _
+
+  protected var curBase: Any = UnsafeUtils.ZeroPointer
+  protected var fieldNo: Int = -1
+  protected var curRecordOffset: Long = -1L
+  protected var curRecEndOffset: Long = -1L
+  protected var maxOffset: Long = -1L
+  protected var mapOffset: Long = -1L
+  protected var recHash: Int = -1
+
+  var firstPartField = Int.MaxValue
+  private var hashOffset: Int = 0
+
+  private def updateFieldPointerAndLens(varFieldLen: Int): Unit = {
+    // update fixed field area, which is a 4-byte offset to the var field
+    setInt(curBase, curRecordOffset + schema.fieldOffset(fieldNo), (curRecEndOffset - curRecordOffset).toInt)
+    curRecEndOffset += varFieldLen
+
+    // update BinaryRecord length header as well
+    setInt(curBase, curRecordOffset, (curRecEndOffset - curRecordOffset).toInt - 4)
+  }
+
+  /**
+   * Called when current writing position is close to the end of the current container, and more bytes are
+   * needed to continue finishing current record. Implementation should allocate a new memory region,
+   * and set the offset and maxOffset to the new region. It should also copy the partially written record from the old
+   * region to the new region, so that the caller can continue writing the record.  If the new region cannot fit
+   * the partially written record and the new data, then an exception should be thrown.
+   * @param numBytes
+   */
+  protected def requireBytes(numBytes: Int): Unit
+
+  private def checkFieldAndMemory(bytesRequired: Int): Unit = {
+    checkFieldNo()
+    requireBytes(bytesRequired)
+  }
+
+
+  // startNewRecord when one uses a RecordSchema for say query results, or where schemaID is not needed.
+  final def startNewRecord(schema: RecordSchema): Unit = {
+    // TODO: use types to eliminate this check?
+    require(schema.partitionFieldStart.isEmpty, s"Cannot use schema $schema with no schemaID")
+    startNewRecord(schema, 0)
+  }
+
+  // startNewRecord for an ingestion schema.  Use this if creating an ingestion record, ensures right ID is used.
+  final def startNewRecord(schema: Schema): Unit =
+    startNewRecord(schema.ingestionSchema, schema.schemaHash)
+
+  final def startNewRecord(partSchema: PartitionSchema, schemaID: Int): Unit =
+    startNewRecord(partSchema.binSchema, schemaID)
+
+  /**
+   * Start building a new BinaryRecord with a possibly new schema.
+   * This must be called after a previous endRecord() or when the builder just started.
+   * NOTE: it's probably better to use an alternative startNewRecord with one of the schema types.
+   * @param recSchema the RecordSchema to use for this record
+   * @param schemaID the schemaID to use.  It may not be the same as the schema of the recSchema - for example
+   *        for partition keys.  However for ingestion records it would be the same.
+   */
+  private[core] final def startNewRecord(recSchema: RecordSchema, schemaID: Int): Unit = {
+    checkPointers()
+
+    // Set schema, hashoffset, and write schema ID if needed
+    setSchema(recSchema)
+    requireBytes(schema.variableAreaStart)
+
+    if (recSchema.partitionFieldStart.isDefined) { setShort(curBase, curRecordOffset + 4, schemaID.toShort) }
+
+    // write length header and update RecEndOffset
+    setInt(curBase, curRecordOffset, schema.variableAreaStart - 4)
+    curRecEndOffset = curRecordOffset + schema.variableAreaStart
+
+    fieldNo = 0
+    recHash = HASH_INIT
+  }
+
+  private[binaryrecord2] def setSchema(newSchema: RecordSchema): Unit = if (newSchema != schema) {
+    schema = newSchema
+    hashOffset = newSchema.fieldOffset(newSchema.numFields)
+    firstPartField = schema.partitionFieldStart.getOrElse(Int.MaxValue)
+  }
+
+
+  /**
+   * If somehow the state is inconsistent, and only a partial record is written,
+   * rewind the curRecordOffset back to the curRecEndOffset.  In other words, rewind the write pointer
+   * back to the end of previous record.  Partially written data is lost, but state is consistent again.
+   */
+  def rewind(): Unit = {
+    curRecEndOffset = curRecordOffset
+  }
+
+  // Check that we are at end of a record.  If a partial record is written, just rewind so state is not inconsistent.
+  private def checkPointers(): Unit = {
+    if (curRecEndOffset != curRecordOffset) {
+      logger.warn(s"Partial record was written, perhaps exception occurred.  Rewinding to end of previous record.")
+      rewind()
+    }
+  }
+
+
+  protected def checkFieldNo(): Unit = require(fieldNo >= 0 && fieldNo < schema.numFields)
+
+  /**
+   * Adds an integer to the record.  This must be called in the right order or the data might be corrupted.
+   * Also this must be called between startNewRecord and endRecord.
+   * Calling this method after all fields of a record has been filled will lead to an error.
+   */
+  final def addInt(data: Int): Unit = {
+    checkFieldNo()
+    setInt(curBase, curRecordOffset + schema.fieldOffset(fieldNo), data)
+    fieldNo += 1
+  }
+
+  /**
+   * Adds a Long to the record.  This must be called in the right order or the data might be corrupted.
+   * Also this must be called between startNewRecord and endRecord.
+   * Calling this method after all fields of a record has been filled will lead to an error.
+   */
+  final def addLong(data: Long): Unit = {
+    checkFieldNo()
+    setLong(curBase, curRecordOffset + schema.fieldOffset(fieldNo), data)
+    fieldNo += 1
+  }
+
+  /**
+   * Adds a Double to the record.  This must be called in the right order or the data might be corrupted.
+   * Also this must be called between startNewRecord and endRecord.
+   * Calling this method after all fields of a record has been filled will lead to an error.
+   */
+  final def addDouble(data: Double): Unit = {
+    checkFieldNo()
+    setDouble(curBase, curRecordOffset + schema.fieldOffset(fieldNo), data)
+    fieldNo += 1
+  }
+
+  /**
+   * Adds a string or raw bytes to the record.  They must fit in within 64KB.
+   * The variable length area of the BinaryRecord will be extended.
+   */
+  final def addString(bytes: Array[Byte]): Unit =
+    addBlob(bytes, UnsafeUtils.arayOffset, bytes.size)
+
+  final def addString(s: String): Unit = addString(s.getBytes(StandardCharsets.UTF_8))
+
+  final def addBlob(base: Any, offset: Long, numBytes: Int): Unit = {
+    require(numBytes < 65536, s"bytes too large ($numBytes bytes) for addBlob")
+    checkFieldAndMemory(numBytes + 2)
+    UnsafeUtils.setShort(curBase, curRecEndOffset, numBytes.toShort) // length of blob
+    UnsafeUtils.unsafe.copyMemory(base, offset, curBase, curRecEndOffset + 2, numBytes)
+    updateFieldPointerAndLens(numBytes + 2)
+    if (fieldNo >= firstPartField) recHash = combineHash(recHash, BinaryRegion.hash32(base, offset, numBytes))
+    fieldNo += 1
+  }
+
+  final def addBlob(strPtr: ZCUTF8): Unit = addBlob(strPtr.base, strPtr.offset, strPtr.numBytes)
+
+  // Adds a blob from another buffer which already has the length bytes as the first two bytes
+  // For example: buffers created by BinaryHistograms.  OR, a UTF8String medium.
+  final def addBlob(buf: DirectBuffer): Unit = {
+    val numBytes = buf.getShort(0).toInt
+    require(numBytes < buf.capacity)
+    addBlob(buf.byteArray, buf.addressOffset + 2, numBytes)
+  }
+
+  /**
+   * Adds fields of a Partition Key Binary Record into the record builder as column values in
+   * the same order. Typically used for the downsampling use case where we copy partition key from
+   * the TimeSeriesPartition into the ingest record for the downsample data.
+   *
+   * This also updates the hash for this record. OK since partKeys are added at the very end
+   * of the record.
+   */
+  final def addPartKeyRecordFields(base: Any, offset: Long, partKeySchema: RecordSchema): Unit = {
+    var id = 0
+    partKeySchema.columns.foreach {
+      case ColumnInfo(_, MapColumn, _, _) => addBlobFromBr(base, offset, id, partKeySchema); id += 1
+      case ColumnInfo(_, StringColumn, _, _) => addBlobFromBr(base, offset, id, partKeySchema); id += 1
+      case ColumnInfo(_, LongColumn, _, _) => addLongFromBr(base, offset, id, partKeySchema); id += 1
+      case ColumnInfo(_, DoubleColumn, _, _) => addDoubleFromBr(base, offset, id, partKeySchema); id += 1
+      case _ => ???
+    }
+    // finally copy the partition hash over
+    recHash = partKeySchema.partitionHash(base, offset)
+  }
+
+  private def addBlobFromBr(base: Any, offset: Long, col: Int, schema: RecordSchema): Unit = {
+    val blobDataOffset = schema.blobOffset(base, offset, col)
+    val blobNumBytes = schema.blobNumBytes(base, offset, col)
+    addBlob(base, blobDataOffset, blobNumBytes)
+  }
+
+  /**
+   * IMPORTANT: Internal method, does not update hash values for the data.
+   * If this method is used, then caller needs to also update the partitionHash manually.
+   */
+  private def addLargeBlobFromBr(base: Any, offset: Long, col: Int, schema: RecordSchema): Unit = {
+    val strDataOffset = schema.utf8StringOffset(base, offset, col)
+    addMap(base, strDataOffset + 4, BinaryRegionLarge.numBytes(base, strDataOffset))
+  }
+
+  private def addLongFromBr(base: Any, offset: Long, col: Int, schema: RecordSchema): Unit = {
+    addLong(schema.getLong(base, offset, col))
+  }
+
+  private def addDoubleFromBr(base: Any, offset: Long, col: Int, schema: RecordSchema): Unit = {
+    addDouble(schema.getDouble(base, offset, col))
+  }
+
+  /**
+   * A SLOW but FLEXIBLE method to add data to the current field.  Boxes for sure but can take any data.
+   * Relies on passing in an object (Any) and using match, lots of allocations here.
+   * PLEASE don't use it in high performance code / hot paths.  Meant for ease of testing.
+   */
+  def addSlowly(item: Any): Unit = {
+    (schema.columnTypes(fieldNo), item) match {
+      case (IntColumn, i: Int) => addInt(i)
+      case (LongColumn, l: Long) => addLong(l)
+      case (TimestampColumn, l: Long) => addLong(l)
+      case (DoubleColumn, d: Double) => addDouble(d)
+      case (StringColumn, s: String) => addString(s)
+      case (StringColumn, a: Array[Byte]) => addString(a)
+      case (StringColumn, z: ZCUTF8) => addBlob(z)
+      case (MapColumn, m: Map[ZCUTF8, ZCUTF8] @unchecked) => addMap(m)
+      case (HistogramColumn, h: Histogram) => addBlob(h.serialize())
+      case (other: Column.ColumnType, v) =>
+        throw new UnsupportedOperationException(s"Column type of $other and value of class ${v.getClass}")
+    }
+  }
+
+  /**
+   * Adds an entire record from a RowReader, with no boxing, using builderAdders
+   *
+   * @return the offset or NativePointer if the memFactory is an offheap one, to the new BinaryRecord
+   */
+  final def addFromReader(row: RowReader, schema: RecordSchema, schemID: Int): Long = {
+    startNewRecord(schema, schemID)
+    cforRange {
+      0 until schema.numFields
+    } { pos =>
+      schema.builderAdders(pos)(row, this)
+    }
+    endRecord()
+  }
+
+  final def addFromReader(row: RowReader, schema: Schema): Long =
+    addFromReader(row, schema.ingestionSchema, schema.schemaHash)
+
+  // Really only for testing. Very slow.  Only for partition keys
+  def partKeyFromObjects(schema: Schema, parts: Any*): Long =
+    addFromReader(SeqRowReader(parts.toSeq), schema.partKeySchema, schema.schemaHash)
+
+  /**
+   * IMPORTANT: Internal method, does not update hash values for the map key/values individually.
+   * If this method is used, then caller needs to also update the partitionHash manually.
+   */
+  private def addMap(base: Any, offset: Long, numBytes: Int): Unit = {
+    require(numBytes < 65536, s"bytes too large ($numBytes bytes) for addMap")
+    checkFieldAndMemory(numBytes + 2)
+    UnsafeUtils.setShort(curBase, curRecEndOffset, numBytes.toShort) // length of blob
+    UnsafeUtils.unsafe.copyMemory(base, offset, curBase, curRecEndOffset + 2, numBytes)
+    updateFieldPointerAndLens(numBytes + 2)
+    fieldNo += 1
+  }
+
+  /**
+   * Sorts and adds keys and values from a map.  The easiest way to add a map to a BinaryRecord.
+   */
+  def addMap(map: Map[ZCUTF8, ZCUTF8]): Unit = {
+    startMap()
+    map.toSeq.sortBy(_._1).foreach { case (k, v) =>
+      addMapKeyValue(k.bytes, v.bytes)
+    }
+    endMap()
+  }
+
+  /**
+   * Encodes a Java TreeMap directly into the map field without Scala collection conversion.
+   * TreeMap is already sorted by key, so no re-sorting needed.
+   *
+   * This avoids the overhead of:
+   *   - convertToScalaImmutableMap (Stream, Tuple2, HashMap construction)
+   *   - Scala Map.toSeq.sortBy (TreeMap is already sorted)
+   *   - ZeroCopyUTF8String wrapping
+   *
+   * Produces the same wire format as addMap(Map[ZCUTF8, ZCUTF8]) — identical bytes,
+   * same predefined key handling, same partition hash.
+   *
+   * Usage from Java:
+   * TreeMap<String, String> tags = new TreeMap<>();
+   * tags.put("_ns_", "myapp");
+   * tags.put("_ws_", "demo");
+   * builder.startNewRecord(schema);
+   * // ... add other fields ...
+   * builder.encodeMapFrom(tags);
+   * builder.endRecord();
+   */
+  final def encodeMapFrom(tags: java.util.TreeMap[String, String]): Unit = {
+    startMap()
+    val iter = tags.entrySet().iterator()
+    while (iter.hasNext) {
+      val entry = iter.next()
+      val keyBytes = entry.getKey.getBytes(StandardCharsets.UTF_8)
+      val valBytes = entry.getValue.getBytes(StandardCharsets.UTF_8)
+      addMapKeyValue(keyBytes, 0, keyBytes.length, valBytes, 0, valBytes.length)
+    }
+    endMap()
+  }
+
+  final def updatePartitionHash(newHash: Int): Unit = {
+    recHash = combineHash(recHash, newHash)
+  }
+
+  /**
+   * Low-level function to start adding a map field.  Must be followed by addMapKeyValue() in sorted order of
+   * keys (UTF8 byte sort).  Might want to use one of the higher level functions.
+   */
+  final def startMap(): Unit = {
+    require(mapOffset == -1L)
+    checkFieldAndMemory(2) // 2 bytes for map length header
+    mapOffset = curRecEndOffset
+    setShort(curBase, mapOffset, 0)
+    updateFieldPointerAndLens(2)
+    // Don't update fieldNo, we'll be working on map for a while
+  }
+
+  /**
+   * Adds a single key-value pair to the map field started by startMap().
+   * Takes care of matching and translating predefined keys into short codes.
+   * Keys must be < 60KB and values must be < 64KB
+   * Hash is not computed or added for you - it must be separately added by you!
+   *
+   * IMPORTANT: MapEncoder.encode() replicates this encoding logic. If the wire format
+   * changes here (predefined key codes, UTF8StringShort/Medium encoding, byte order),
+   * MapEncoder must be updated to match.
+   */
+  final def addMapKeyValue(keyBytes: Array[Byte], keyOffset: Int, keyLen: Int,
+                           valueBytes: Array[Byte], valueOffset: Int, valueLen: Int,
+                           keyHash: Int = 7): Unit = {
+    require(mapOffset > curRecordOffset, "illegal state, did you call startMap() first?")
+    // check key size, must be < 60KB
+    require(keyLen < 192, s"key is too large: ${keyLen} bytes")
+    require(valueLen < 64 * 1024, s"value is too large: $valueLen bytes")
+
+    // Check if key is a predefined key
+    val predefKeyNum = // but if there are no predefined keys, skip the cost of hashing the key
+      if (schema.predefinedKeys.isEmpty) {
+        -1
+      }
+      else {
+        val keyKey = RecordSchema.makeKeyKey(keyBytes, keyOffset, keyLen, keyHash)
+        schema.predefKeyNumMap.getOrElse(keyKey, -1)
+      }
+    val keyValueSize = if (predefKeyNum >= 0) {
+      valueLen + 3
+    } else {
+      keyLen + valueLen + 3
+    }
+    requireBytes(keyValueSize)
+    if (predefKeyNum >= 0) {
+      setByte(curBase, curRecEndOffset, (0x0C0 | predefKeyNum).toByte)
+      curRecEndOffset += 1
+    } else {
+      UTF8StringShort.copyByteArrayTo(keyBytes, keyOffset, keyLen, curBase, curRecEndOffset)
+      curRecEndOffset += keyLen + 1
+    }
+    UTF8StringMedium.copyByteArrayTo(valueBytes, valueOffset, valueLen, curBase, curRecEndOffset)
+    curRecEndOffset += valueLen + 2
+
+    // update map length, BR length
+    val newMapLen = curRecEndOffset - mapOffset - 2
+    require(newMapLen < 65536, s"Map entries cannot total more than 64KB, but is now $newMapLen")
+    setShort(curBase, mapOffset, newMapLen.toShort)
+    setInt(curBase, curRecordOffset, (curRecEndOffset - curRecordOffset - 4).toInt)
+  }
+
+  final def addMapKeyValue(key: Array[Byte], value: Array[Byte]): Unit =
+    addMapKeyValue(key, 0, key.size, value, 0, value.size)
+
+  /**
+   * An alternative to above for adding a known key with precomputed key hash
+   * along with a value, to the map, while updating the hash too.
+   * Saves computing the key hash twice.
+   * TODO: deprecate this.  We are switching to computing a hash for all keys at the same time.
+   */
+  final def addMapKeyValueHash(keyBytes: Array[Byte], keyHash: Int,
+                               valueBytes: Array[Byte], valueOffset: Int, valueLen: Int): Unit = {
+    addMapKeyValue(keyBytes, 0, keyBytes.size, valueBytes, valueOffset, valueLen, keyHash)
+    val valueHash = BinaryRegion.hasher32.hash(valueBytes, valueOffset, valueLen, BinaryRegion.Seed)
+    updatePartitionHash(combineHash(keyHash, valueHash))
+  }
+
+  /**
+   * Ends creation of a map field.  Recompute the hash for all fields at once.
+   *
+   * @param bulkHash if true (default), computes the hash for all key/values.
+   *                 Some users use the older alternate, sortAndComputeHashes() - then set this to false.
+   */
+  final def endMap(bulkHash: Boolean = true): Unit = {
+    if (bulkHash) {
+      val mapHash = BinaryRegion.hash32(curBase, mapOffset, (curRecEndOffset - mapOffset).toInt)
+      updatePartitionHash(mapHash)
+    }
+    mapOffset = -1L
+    fieldNo += 1
+  }
+
+  /**
+   * Adds an encoded map field directly from a byte array already in RecordBuilder wire format.
+   * Use MapEncoder.encode() to produce correctly encoded bytes.
+   */
+  final def addEncodedMap(mapBytes: Array[Byte]): Unit = {
+    val numBytes = mapBytes.length
+    require(numBytes < 65536, s"Map bytes too large: $numBytes")
+    startMap()
+    requireBytes(numBytes)
+    UnsafeUtils.unsafe.copyMemory(mapBytes, UnsafeUtils.arayOffset,
+      curBase, curRecEndOffset, numBytes)
+    curRecEndOffset += numBytes
+    // update map length and record length
+    setShort(curBase, mapOffset, numBytes.toShort)
+    setInt(curBase, curRecordOffset, (curRecEndOffset - curRecordOffset - 4).toInt)
+    endMap()
+  }
+  final def align(offset: Long): Long = (offset + 3) & ~3
+
+  /**
+   * Ends the building of the current BinaryRecord.  Makes sures RecordContainer state is updated.
+   * Aligns the next record on a 4-byte/short word boundary.
+   * Returns the Long offset of the just finished BinaryRecord.  If the container is offheap, then this is the
+   * full NativePointer.  If it is onHeap, you will need to access the current container and get the base
+   * to form the (base, offset) pair needed to access the BinaryRecord.
+   */
+  final def endRecord(writeHash: Boolean = true): Long = {
+    val recordOffset = curRecordOffset
+
+    if (writeHash && firstPartField < Int.MaxValue) setInt(curBase, curRecordOffset + hashOffset, recHash)
+
+    // Bring RecordOffset up to endOffset w/ align.  Now the state is complete at end of a record again.
+    curRecEndOffset = align(curRecEndOffset)
+    curRecordOffset = curRecEndOffset
+    fieldNo = -1
+
+    postEndRecord()
+    recordOffset
+  }
+
+  def postEndRecord(): Unit
+}

--- a/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/RecordSchema.scala
@@ -78,24 +78,24 @@ final class RecordSchema(val columns: Seq[ColumnInfo],
   // with no boxing or extra allocations involved
   val builderAdders = columnTypes.zipWithIndex.map {
     case (Column.ColumnType.LongColumn, colNo) =>
-      (row: RowReader, builder: RecordBuilder) => builder.addLong(row.getLong(colNo))
+      (row: RowReader, builder: RecordBuilderBase) => builder.addLong(row.getLong(colNo))
     case (Column.ColumnType.TimestampColumn, colNo) =>
-      (row: RowReader, builder: RecordBuilder) => builder.addLong(row.getLong(colNo))
+      (row: RowReader, builder: RecordBuilderBase) => builder.addLong(row.getLong(colNo))
     case (Column.ColumnType.DoubleColumn, colNo) =>
-      (row: RowReader, builder: RecordBuilder) => builder.addDouble(row.getDouble(colNo))
+      (row: RowReader, builder: RecordBuilderBase) => builder.addDouble(row.getDouble(colNo))
     case (Column.ColumnType.HistogramColumn, colNo) =>
-      (row: RowReader, builder: RecordBuilder) => builder.addBlob(row.getHistogram(colNo).serialize())
+      (row: RowReader, builder: RecordBuilderBase) => builder.addBlob(row.getHistogram(colNo).serialize())
     case (Column.ColumnType.IntColumn, colNo) =>
-      (row: RowReader, builder: RecordBuilder) => builder.addInt(row.getInt(colNo))
+      (row: RowReader, builder: RecordBuilderBase) => builder.addInt(row.getInt(colNo))
     case (Column.ColumnType.StringColumn, colNo) =>
       // TODO: we REALLY need a better API than ZeroCopyUTF8String as it creates so much garbage
-      (row: RowReader, builder: RecordBuilder) => builder.addBlob(row.filoUTF8String(colNo))
+      (row: RowReader, builder: RecordBuilderBase) => builder.addBlob(row.filoUTF8String(colNo))
     case (Column.ColumnType.BinaryRecordColumn, colNo) =>
-      (row: RowReader, builder: RecordBuilder) =>
+      (row: RowReader, builder: RecordBuilderBase) =>
         builder.addBlob(row.getBlobBase(colNo), row.getBlobOffset(colNo), row.getBlobNumBytes(colNo))
     case (t: Column.ColumnType, colNo) =>
       // TODO: add more efficient methods
-      (row: RowReader, builder: RecordBuilder) => builder.addSlowly(row.getAny(colNo))
+      (row: RowReader, builder: RecordBuilderBase) => builder.addSlowly(row.getAny(colNo))
   }.toArray
 
   def numColumns: Int = columns.length

--- a/core/src/main/scala/filodb.core/binaryrecord2/SingleRecordBuilder.scala
+++ b/core/src/main/scala/filodb.core/binaryrecord2/SingleRecordBuilder.scala
@@ -1,0 +1,78 @@
+package filodb.core.binaryrecord2
+
+import filodb.memory.format.UnsafeUtils.unsafe
+
+/**
+ * A RowBuilder that writes a single BinaryRecord directly into a pre-allocated memory region,
+ * with no container management overhead. Supports both on-heap (base = Array[Byte]) and off-heap
+ * (base = UnsafeUtils.ZeroPointer, offset = native address) memory.
+ *
+ * Call reset(newBase, newOffset, newCapacity) to repoint the builder at a new memory region
+ * for each successive record, enabling zero-allocation reuse.
+ *
+ * Intended for callers that own the destination buffer — e.g. writing BinaryRecords directly
+ * into an Arrow VarBinaryVector's off-heap data buffer to avoid the on-heap RecordBuilder →
+ * Arrow copy present in the current ArrowSerializedRangeVectorOps flow.
+ *
+ * endRecord() returns the starting offset of the completed record. The caller can derive
+ * record length via BinaryRegionLarge.numBytes(base, recordOffset) (content bytes, excluding
+ * the 4-byte length header), with aligned total size = (numBytes + 7) & ~3.
+ */
+class SingleRecordBuilder(initialBase: Any, initialOffset: Long, initialCapacity: Int)
+                         (allocateNewBuf: => (Any, Long, Int))
+    extends RecordBuilderBase {
+
+  reset(initialBase, initialOffset, initialCapacity)
+
+  /**
+   * Repoints the builder to a new memory region. Must be called before startNewRecord()
+   * for each new record.
+   *
+   * @param newBase     base pointer for the destination memory
+   *                    (Array[Byte] for on-heap; UnsafeUtils.ZeroPointer for off-heap)
+   * @param newOffset   byte offset within newBase where the record will start
+   * @param newCapacity available bytes starting at newOffset
+   */
+  def reset(newBase: Any, newOffset: Long, newCapacity: Int): Unit = {
+    curBase         = newBase
+    curRecordOffset = newOffset
+    curRecEndOffset = newOffset
+    maxOffset       = newOffset + newCapacity
+    fieldNo         = -1
+    mapOffset       = -1L
+    recHash         = -1
+  }
+
+  protected def requireBytes(numBytes: Int): Unit = {
+    if (curRecEndOffset + numBytes > maxOffset) {
+      val oldBase = curBase
+      val recordNumBytes = curRecEndOffset - curRecordOffset
+      val oldOffset = curRecordOffset
+      val (newBase, newOffset, newCapacity) = allocateNewBuf
+      curBase         = newBase
+      curRecordOffset = newOffset
+      curRecEndOffset = newOffset
+      maxOffset       = newOffset + newCapacity
+
+      logger.trace(s"Moving $recordNumBytes bytes from end of old container to new container")
+      require(newCapacity > (recordNumBytes + numBytes),
+        s"The intermediate or final result is too big. Please try to add more query filters or time range.")
+      unsafe.copyMemory(oldBase, oldOffset, curBase, curRecordOffset, recordNumBytes)
+      if (mapOffset != -1L) {
+        require(mapOffset >= oldOffset,
+          s"mapOffset=$mapOffset < record start=$oldOffset; invariant violated in RowBuilder")
+        mapOffset = curRecordOffset + (mapOffset - oldOffset)
+      }
+      curRecEndOffset = curRecordOffset + recordNumBytes
+    }
+  }
+
+  // Caller owns the memory; no container bookkeeping.
+  def postEndRecord(): Unit = ()
+
+  /**
+   * Offset where the next record should start — the 4-byte-aligned end of the record just written.
+   * Valid after endRecord(). Equal to recordEndOffset.
+   */
+  def nextRecordOffset: Long = curRecordOffset
+}

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -231,7 +231,7 @@ final case class RangeParams(startSecs: Long, stepSecs: Long, endSecs: Long)
  * @param endMs the end timestamp in ms
  */
 final case class RepeatValueVector(rv: RangeVector,
-                              startMs: Long, stepMs: Long, endMs: Long) extends RangeVector with StrictLogging {
+                              startMs: Long, stepMs: Long, endMs: Long) extends RangeVector {
   override lazy val outputRange: Option[RvRange] = Some(RvRange(startMs, stepMs, endMs))
   override lazy val numRows: Option[Int] = Some((endMs - startMs) / math.max(1, stepMs) + 1).map(_.toInt)
 

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -19,6 +19,7 @@ import filodb.core.store._
 import filodb.memory.{BinaryRegionLarge, MemFactory, UTF8StringMedium, UTF8StringShort}
 import filodb.memory.data.ChunkMap
 import filodb.memory.format.{RowReader, UnsafeUtils, ZeroCopyUTF8String => UTF8Str}
+import filodb.memory.format.ZeroCopyUTF8String.StringToUTF8
 import filodb.memory.format.vectors.Histogram
 
 // scalastyle:off number.of.types
@@ -35,6 +36,27 @@ trait RangeVectorKey extends java.io.Serializable {
   def schemaNames: Seq[String]
   def keySize: Int
   override def toString: String = s"/shard:${sourceShards.mkString(",")}/$labelValues"
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case other: RangeVectorKey =>
+          this.labelValues == other.labelValues
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = {
+    this.labelValues.hashCode()
+  }
+
+  /**
+   * Add contents of the range vector key as a BR into a RecordBuilder.
+   * The schema used should be BrMapRangeVectorKey.schema, which has a single map column with no predefined keys.
+   * The map will contain all the key-value pairs of the RangeVectorKey.
+   * This is used for serializing the key into a BinaryRecord for sending over the wire.
+   * @param rb the RecordBuilder to write the key into.
+   */
+  def writeToMapBr(rb: RecordBuilderBase): Unit
 }
 
 class SeqMapConsumer extends MapItemConsumer {
@@ -90,6 +112,53 @@ final case class PartitionRangeVectorKey(partKeyData: Either[ReadablePartition, 
     }.toMap
   }
   override def toString: String = s"/shard:$sourceShard/${partSchema.stringify(partBase, partOffset)} [grp$groupNum]"
+
+  def writeToMapBr(rb: RecordBuilderBase): Unit = {
+    rb.startNewRecord(BrMapRangeVectorKey.schema)
+    rb.startMap()
+    partKeyCols.zipWithIndex.foreach { case (c, pos) =>
+      c.colType match {
+        case StringColumn =>
+          val key = c.name.utf8
+          val vRelOffset = partSchema.getStringOffset(partBase, partOffset, pos)
+          rb.addMapKeyValue(key, partBase, partOffset + vRelOffset)
+
+        case MapColumn =>
+          partSchema.consumeMapItems(partBase, partOffset, pos, new MapItemConsumer {
+            def consume(keyBase: Any, keyOffset: Long, valueBase: Any, valueOffset: Long, index: Int): Unit = {
+              rb.addMapKeyValue(keyBase, keyOffset, valueBase, valueOffset)
+            }
+          })
+        case _ => throw new UnsupportedOperationException(s"Column type ${c.colType} not supported in writeToMapBr" +
+        s" - we dont have part keys with long or int columns yet, so we skip implementing this for now")
+      }
+    }
+    rb.endMap()
+    rb.endRecord(false)
+  }
+}
+
+final case class BrMapRangeVectorKey(base: Any, offset: Long) extends RangeVectorKey {
+  lazy val labelValues: Map[UTF8Str, UTF8Str] = {
+    val consumer = new SeqMapConsumer
+    BrMapRangeVectorKey.schema.consumeMapItems(base, offset, 0, consumer)
+    consumer.pairs.toMap
+  }
+  override def sourceShards: Seq[Int] = Nil
+  override def partIds: Seq[Int] = Nil
+  override def schemaNames: Seq[String] = Nil
+  def keySize: Int = BinaryRegionLarge.numBytes(base, offset)
+
+  // Copy entire record
+  def writeToMapBr(rb: RecordBuilderBase): Unit = {
+    rb.addFromBr(base, offset)
+  }
+}
+
+object BrMapRangeVectorKey {
+  // Fixed schema for the single-map-column BinaryRecord that backs BrMapRangeVectorKey.
+  // All writeToMapBr callers must use this schema (no predefined keys).
+  val schema = new RecordSchema(Seq(ColumnInfo("labels", MapColumn)))
 }
 
 final case class CustomRangeVectorKey(labelValues: Map[UTF8Str, UTF8Str],
@@ -101,6 +170,11 @@ final case class CustomRangeVectorKey(labelValues: Map[UTF8Str, UTF8Str],
     labelValues.foldLeft(0) { case (s, e) =>
       s + e._1.numBytes + e._2.numBytes
     }
+  }
+  def writeToMapBr(rb: RecordBuilderBase): Unit = {
+    rb.startNewRecord(BrMapRangeVectorKey.schema)
+    rb.addMap(labelValues)
+    rb.endRecord(false)
   }
 }
 

--- a/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/BinaryRecordSpec.scala
@@ -781,4 +781,80 @@ class BinaryRecordSpec extends AnyFunSpec with Matchers with BeforeAndAfter with
     // not equal, since some other shard key is different
     hashNoMetricShardKey should not equal otherHash
   }
+
+  describe("SingleRecordBuilder and new addMapKeyValue overloads") {
+    val mapOnlySchema = new RecordSchema(Seq(ColumnInfo("labels", ColumnType.MapColumn)))
+
+    def readMapPairs(base: Any, offset: Long): Seq[(String, String)] = {
+      val buf = new collection.mutable.ArrayBuffer[(String, String)]
+      mapOnlySchema.consumeMapItems(base, offset, 0, new MapItemConsumer {
+        def consume(kb: Any, ko: Long, vb: Any, vo: Long, idx: Int): Unit = {
+          val k = new ZCUTF8(kb, ko + 1, UTF8StringShort.numBytes(kb, ko)).asNewString
+          val v = new ZCUTF8(vb, vo + 2, UTF8StringMedium.numBytes(vb, vo)).asNewString
+          buf += (k -> v)
+        }
+      })
+      buf.sortBy(_._1).toSeq
+    }
+
+    // Source record written once; shared across all three tests.
+    val srcBuf = new Array[Byte](1024)
+    val srcSrb = new SingleRecordBuilder(srcBuf, UnsafeUtils.arayOffset, 1024)(
+      throw new IllegalStateException("source record too large"))
+    srcSrb.startNewRecord(mapOnlySchema)
+    srcSrb.startMap()
+    Seq(ZCUTF8("__name__") -> ZCUTF8("cpu_load"),
+        ZCUTF8("dc")       -> ZCUTF8("us-west"),
+        ZCUTF8("job")      -> ZCUTF8("api-server")).sortBy(_._1).foreach {
+      case (k, v) => srcSrb.addMapKeyValue(k.bytes, v.bytes)
+    }
+    srcSrb.endMap()
+    val srcRecOff = srcSrb.endRecord(false)
+
+    val expectedPairs = Seq("__name__" -> "cpu_load", "dc" -> "us-west", "job" -> "api-server")
+
+    it("addMapKeyValue(Any, Long, Any, Long) should produce the same record as the Array[Byte] overload") {
+      val dst = new RecordBuilder(MemFactory.onHeapFactory)
+      dst.startNewRecord(mapOnlySchema)
+      dst.startMap()
+      mapOnlySchema.consumeMapItems(srcBuf, srcRecOff, 0, new MapItemConsumer {
+        def consume(kb: Any, ko: Long, vb: Any, vo: Long, idx: Int): Unit =
+          dst.addMapKeyValue(kb, ko, vb, vo)
+      })
+      dst.endMap()
+      val dstOff  = dst.endRecord()
+      val dstBase = dst.allContainers.head.base
+
+      readMapPairs(dstBase, dstOff) shouldEqual expectedPairs
+      mapOnlySchema.equals(srcBuf, srcRecOff, dstBase, dstOff) shouldBe true
+    }
+
+    it("addMapKeyValue(ZCUTF8, Any, Long) should produce the same record as the Array[Byte] overload") {
+      val dst = new RecordBuilder(MemFactory.onHeapFactory)
+      dst.startNewRecord(mapOnlySchema)
+      dst.startMap()
+      mapOnlySchema.consumeMapItems(srcBuf, srcRecOff, 0, new MapItemConsumer {
+        def consume(kb: Any, ko: Long, vb: Any, vo: Long, idx: Int): Unit = {
+          val key = new ZCUTF8(kb, ko + 1, UTF8StringShort.numBytes(kb, ko))
+          dst.addMapKeyValue(key, vb, vo)
+        }
+      })
+      dst.endMap()
+      val dstOff  = dst.endRecord()
+      val dstBase = dst.allContainers.head.base
+
+      readMapPairs(dstBase, dstOff) shouldEqual expectedPairs
+      mapOnlySchema.equals(srcBuf, srcRecOff, dstBase, dstOff) shouldBe true
+    }
+
+    it("addFromBr should produce a byte-identical copy of the source record") {
+      val dstBuf = new Array[Byte](1024)
+      val dstSrb = new SingleRecordBuilder(dstBuf, UnsafeUtils.arayOffset, 1024)(
+        throw new IllegalStateException("destination record too large"))
+      dstSrb.addFromBr(srcBuf, srcRecOff)
+
+      mapOnlySchema.equals(srcBuf, srcRecOff, dstBuf, UnsafeUtils.arayOffset) shouldBe true
+      readMapPairs(dstBuf, UnsafeUtils.arayOffset) shouldEqual expectedPairs
+    }
+  }
 }

--- a/core/src/test/scala/filodb.core/binaryrecord2/RecordBuilderSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/RecordBuilderSpec.scala
@@ -1,0 +1,1129 @@
+package filodb.core.binaryrecord2
+
+import java.nio.charset.StandardCharsets
+
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import filodb.core.MachineMetricsData
+import filodb.core.metadata.Column.ColumnType
+import filodb.core.query.ColumnInfo
+import filodb.memory._
+import filodb.memory.format.{SeqRowReader, UnsafeUtils, ZeroCopyUTF8String => ZCUTF8}
+
+/**
+ * Comprehensive unit tests for RecordBuilder designed as a refactoring safety net.
+ *
+ * These tests verify behavior across:
+ *  - Constructor and container lifecycle
+ *  - All field-addition methods (addInt, addLong, addDouble, addString, addBlob, addMap, etc.)
+ *  - Hash computation (partition hashes written/not written, values)
+ *  - Container management (rollover, reuseOneContainer, reset, rewind, removeAndFreeContainers)
+ *  - High-level builders (addFromReader, partKeyFromObjects, addSlowly, addPartKeyRecordFields)
+ *  - Serialization (optimalContainerBytes, nonCurrentContainerBytes)
+ *  - Companion-object utilities (combineHash, sortAndComputeHashes, shardKeyHash,
+ *                                partitionKeyHash, combineHashExcluding, trimShardColumn)
+ */
+class RecordBuilderSpec extends AnyFunSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll {
+  import MachineMetricsData._
+  import RecordBuilder.ContainerHeaderLen
+
+  // --- Simple schemas for focused field-type tests ---
+  val intLongSchema = new RecordSchema(Seq(
+    ColumnInfo("i", ColumnType.IntColumn),
+    ColumnInfo("l", ColumnType.LongColumn)
+  ))
+
+  val longStrSchema = new RecordSchema(Seq(
+    ColumnInfo("ts", ColumnType.LongColumn),
+    ColumnInfo("s", ColumnType.StringColumn)
+  ))
+
+  val doubleSchema = new RecordSchema(Seq(
+    ColumnInfo("d", ColumnType.DoubleColumn)
+  ))
+
+  // Partition key schema: single string, partition starts at field 0
+  val partStrSchema = new RecordSchema(
+    Seq(ColumnInfo("series", ColumnType.StringColumn)),
+    partitionFieldStart = Some(0)
+  )
+
+  // Non-partition schema with a map field
+  val longMapSchema = new RecordSchema(Seq(
+    ColumnInfo("ts", ColumnType.LongColumn),
+    ColumnInfo("tags", ColumnType.MapColumn)
+  ))
+
+  val nativeMem = new NativeMemoryManager(20 * 1024 * 1024)
+
+  override def afterAll(): Unit = nativeMem.shutdown()
+
+  // ==================== 1. Constructor ====================
+
+  describe("RecordBuilder constructor") {
+    it("should throw when containerSize is below MinContainerSize") {
+      intercept[IllegalArgumentException] {
+        new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize - 1)
+      }
+    }
+
+    it("should have no containers and no currentContainer on startup (default)") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.allContainers shouldBe empty
+      builder.currentContainer shouldBe None
+    }
+
+    it("containerRemaining should be 0 when no container is allocated") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.containerRemaining shouldEqual 0
+    }
+
+    it("reuseOneContainer=true should allocate one container immediately") {
+      val builder = new RecordBuilder(
+        MemFactory.onHeapFactory, RecordBuilder.MinContainerSize, reuseOneContainer = true)
+      builder.allContainers should have length 1
+      builder.currentContainer shouldBe defined
+      builder.lastContainer.base should not equal null
+    }
+
+    it("lastContainer should throw when no containers are allocated") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      intercept[Exception] { builder.lastContainer }
+    }
+
+    it("make() factory should produce a usable builder") {
+      val builder = RecordBuilder.make(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
+      addToBuilder(builder, linearMultiSeries().take(1))
+      builder.allContainers should have length 1
+      builder.lastContainer.countRecords() shouldEqual 1
+    }
+  }
+
+  // ==================== 2. Record lifecycle ====================
+
+  describe("Record lifecycle") {
+    it("addInt before startNewRecord should throw") {
+      intercept[IllegalArgumentException] {
+        new RecordBuilder(MemFactory.onHeapFactory).addInt(1)
+      }
+    }
+
+    it("addLong before startNewRecord should throw") {
+      intercept[IllegalArgumentException] {
+        new RecordBuilder(MemFactory.onHeapFactory).addLong(1L)
+      }
+    }
+
+    it("addDouble before startNewRecord should throw") {
+      intercept[IllegalArgumentException] {
+        new RecordBuilder(MemFactory.onHeapFactory).addDouble(1.0)
+      }
+    }
+
+    it("addString before startNewRecord should throw") {
+      intercept[IllegalArgumentException] {
+        new RecordBuilder(MemFactory.onHeapFactory).addString("foo")
+      }
+    }
+
+    it("adding a field beyond the schema field count should throw") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(longStrSchema)
+      builder.addLong(1L)
+      builder.addString("a")
+      intercept[IllegalArgumentException] { builder.addLong(2L) }
+    }
+
+    it("endRecord should increment numRecords in the container") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(longStrSchema)
+      builder.addLong(1L); builder.addString("a")
+      builder.endRecord()
+      builder.lastContainer.numRecords shouldEqual 1
+
+      builder.startNewRecord(longStrSchema)
+      builder.addLong(2L); builder.addString("b")
+      builder.endRecord()
+      builder.lastContainer.numRecords shouldEqual 2
+    }
+
+    it("endRecord should align successive record offsets to a 4-byte boundary") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(longStrSchema)
+      builder.addLong(1L); builder.addString("abc")   // 3-byte string
+      val off1 = builder.endRecord()
+
+      builder.startNewRecord(longStrSchema)
+      builder.addLong(2L); builder.addString("de")   // 2-byte string
+      val off2 = builder.endRecord()
+
+      (off2 - off1) % 4 shouldEqual 0
+    }
+
+    it("startNewRecord(RecordSchema) should require schema with no partitionFieldStart") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      // partStrSchema has partitionFieldStart=Some(0) – must use the schemaID overload
+      intercept[IllegalArgumentException] {
+        builder.startNewRecord(partStrSchema)
+      }
+    }
+
+    it("startNewRecord(Schema) should write the ingestion schemaHash into the record") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      addToBuilder(builder, linearMultiSeries().take(1))
+      val off = builder.lastContainer.allOffsets(0)
+      RecordSchema.schemaID(builder.lastContainer.base, off) shouldEqual schema1.schemaHash
+    }
+
+    it("startNewRecord(partSchema, schemaID) should write the supplied schemaID") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(schema1.partKeySchema, 12345)
+      builder.addString("myMetric")
+      val off = builder.endRecord()
+      RecordSchema.schemaID(builder.lastContainer.base, off) shouldEqual 12345
+    }
+  }
+
+  // ==================== 3. addInt ====================
+
+  describe("addInt") {
+    it("should write and read back a typical int value") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(intLongSchema)
+      builder.addInt(42); builder.addLong(0L)
+      val off = builder.endRecord()
+      intLongSchema.getInt(builder.lastContainer.base, off, 0) shouldEqual 42
+    }
+
+    it("should correctly round-trip Int.MinValue and Int.MaxValue") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+
+      builder.startNewRecord(intLongSchema)
+      builder.addInt(Int.MinValue); builder.addLong(0L)
+      val off1 = builder.endRecord()
+      intLongSchema.getInt(builder.lastContainer.base, off1, 0) shouldEqual Int.MinValue
+
+      builder.startNewRecord(intLongSchema)
+      builder.addInt(Int.MaxValue); builder.addLong(0L)
+      val off2 = builder.endRecord()
+      intLongSchema.getInt(builder.lastContainer.base, off2, 0) shouldEqual Int.MaxValue
+    }
+
+    it("addSlowly should dispatch Int correctly") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(intLongSchema)
+      builder.addSlowly(77: Int)
+      builder.addSlowly(0L)
+      val off = builder.endRecord()
+      intLongSchema.getInt(builder.lastContainer.base, off, 0) shouldEqual 77
+    }
+  }
+
+  // ==================== 4. addLong / addDouble ====================
+
+  describe("addLong") {
+    it("should round-trip Long.MinValue and Long.MaxValue") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+
+      builder.startNewRecord(longStrSchema)
+      builder.addLong(Long.MinValue); builder.addString("x")
+      val off1 = builder.endRecord()
+      longStrSchema.getLong(builder.lastContainer.base, off1, 0) shouldEqual Long.MinValue
+
+      builder.startNewRecord(longStrSchema)
+      builder.addLong(Long.MaxValue); builder.addString("y")
+      val off2 = builder.endRecord()
+      longStrSchema.getLong(builder.lastContainer.base, off2, 0) shouldEqual Long.MaxValue
+    }
+
+    it("addSlowly should dispatch Long correctly") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(longStrSchema)
+      builder.addSlowly(12345L); builder.addSlowly("test")
+      val off = builder.endRecord()
+      longStrSchema.getLong(builder.lastContainer.base, off, 0) shouldEqual 12345L
+    }
+  }
+
+  describe("addDouble") {
+    it("should write and read back an arbitrary double") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(doubleSchema)
+      builder.addDouble(3.14159)
+      val off = builder.endRecord()
+      doubleSchema.getDouble(builder.lastContainer.base, off, 0) shouldEqual 3.14159 +- 1e-5
+    }
+
+    it("should preserve Double.NaN") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(doubleSchema)
+      builder.addDouble(Double.NaN)
+      val off = builder.endRecord()
+      doubleSchema.getDouble(builder.lastContainer.base, off, 0).isNaN shouldBe true
+    }
+
+    it("should preserve Double.PositiveInfinity and NegativeInfinity") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+
+      builder.startNewRecord(doubleSchema)
+      builder.addDouble(Double.PositiveInfinity)
+      val off1 = builder.endRecord()
+      doubleSchema.getDouble(builder.lastContainer.base, off1, 0) shouldEqual Double.PositiveInfinity
+
+      builder.startNewRecord(doubleSchema)
+      builder.addDouble(Double.NegativeInfinity)
+      val off2 = builder.endRecord()
+      doubleSchema.getDouble(builder.lastContainer.base, off2, 0) shouldEqual Double.NegativeInfinity
+    }
+
+    it("addSlowly should dispatch Double correctly") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(doubleSchema)
+      builder.addSlowly(2.718: Double)
+      val off = builder.endRecord()
+      doubleSchema.getDouble(builder.lastContainer.base, off, 0) shouldEqual 2.718 +- 1e-3
+    }
+
+    it("addSlowly should throw UnsupportedOperationException for mismatched type") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(doubleSchema)
+      // Passing Int to a DoubleColumn field: no pattern matches → UnsupportedOperationException
+      intercept[UnsupportedOperationException] {
+        builder.addSlowly(3: Int)
+      }
+    }
+  }
+
+  // ==================== 5. addString and addBlob ====================
+
+  describe("addString and addBlob") {
+    it("addString(String) should write and read back UTF-8 text") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(longStrSchema)
+      builder.addLong(1L); builder.addString("hello world")
+      val off = builder.endRecord()
+      longStrSchema.asJavaString(builder.lastContainer.base, off, 1) shouldEqual "hello world"
+    }
+
+    it("addString(Array[Byte]) should write and read back raw bytes") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      val bytes = "こんにちは".getBytes(StandardCharsets.UTF_8)
+      builder.startNewRecord(longStrSchema)
+      builder.addLong(1L); builder.addString(bytes)
+      val off = builder.endRecord()
+      longStrSchema.asJavaString(builder.lastContainer.base, off, 1) shouldEqual "こんにちは"
+    }
+
+    it("addSlowly should dispatch String correctly") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(longStrSchema)
+      builder.addSlowly(1L); builder.addSlowly("mystring")
+      val off = builder.endRecord()
+      longStrSchema.asJavaString(builder.lastContainer.base, off, 1) shouldEqual "mystring"
+    }
+
+    it("addString should throw for strings of 65536 bytes or more") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(longStrSchema); builder.addLong(1L)
+      intercept[IllegalArgumentException] { builder.addString("x" * 65536) }
+    }
+
+    it("addBlob(base, offset, numBytes) should write and read back correctly") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      val bytes = "blob data".getBytes(StandardCharsets.UTF_8)
+      builder.startNewRecord(longStrSchema)
+      builder.addLong(5L); builder.addBlob(bytes, UnsafeUtils.arayOffset, bytes.length)
+      val off = builder.endRecord()
+      longStrSchema.asJavaString(builder.lastContainer.base, off, 1) shouldEqual "blob data"
+    }
+
+    it("addBlob(ZCUTF8) should write and read back correctly") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(longStrSchema)
+      builder.addLong(1L); builder.addBlob(ZCUTF8("zcutf8test"))
+      val off = builder.endRecord()
+      longStrSchema.asJavaString(builder.lastContainer.base, off, 1) shouldEqual "zcutf8test"
+    }
+
+    it("addBlob(DirectBuffer) should read the 2-byte length prefix and write the body") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      val data = "directbuf".getBytes(StandardCharsets.UTF_8)
+      // buffer layout: [2-byte length][data bytes]
+      val bufArr = new Array[Byte](2 + data.length)
+      UnsafeUtils.unsafe.putShort(bufArr, UnsafeUtils.arayOffset, data.length.toShort)
+      System.arraycopy(data, 0, bufArr, 2, data.length)
+      val buf = new org.agrona.concurrent.UnsafeBuffer(bufArr)
+
+      builder.startNewRecord(longStrSchema)
+      builder.addLong(1L); builder.addBlob(buf)
+      val off = builder.endRecord()
+      longStrSchema.asJavaString(builder.lastContainer.base, off, 1) shouldEqual "directbuf"
+    }
+
+    it("string fields that are partition key fields should update partition hash") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+
+      builder.startNewRecord(partStrSchema, 1)
+      builder.addString("series-A")
+      val off1 = builder.endRecord()
+
+      builder.startNewRecord(partStrSchema, 1)
+      builder.addString("series-B")
+      val off2 = builder.endRecord()
+
+      val base = builder.lastContainer.base
+      partStrSchema.partitionHash(base, off1) should not equal partStrSchema.partitionHash(base, off2)
+      partStrSchema.partitionHash(base, off1) should not equal RecordBuilder.HASH_INIT
+    }
+
+    it("identical partition-key strings should produce identical hashes") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+
+      builder.startNewRecord(partStrSchema, 1); builder.addString("same")
+      val off1 = builder.endRecord()
+      builder.startNewRecord(partStrSchema, 1); builder.addString("same")
+      val off2 = builder.endRecord()
+
+      val base = builder.lastContainer.base
+      partStrSchema.partitionHash(base, off1) shouldEqual partStrSchema.partitionHash(base, off2)
+    }
+
+    it("non-partition string fields should NOT affect the partition hash field") {
+      // longStrSchema has no partition, so no hash is written; record should still be readable
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(longStrSchema); builder.addLong(9L); builder.addString("nohash")
+      val off = builder.endRecord()
+      longStrSchema.getLong(builder.lastContainer.base, off, 0) shouldEqual 9L
+    }
+  }
+
+  // ==================== 6. Map field operations ====================
+
+  describe("Map field operations") {
+    it("startMap called twice without endMap should throw") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(longMapSchema); builder.addLong(1L)
+      builder.startMap()
+      intercept[IllegalArgumentException] { builder.startMap() }
+    }
+
+    it("addMapKeyValue without calling startMap should throw") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(longMapSchema); builder.addLong(1L)
+      intercept[IllegalArgumentException] {
+        builder.addMapKeyValue("k".getBytes, "v".getBytes)
+      }
+    }
+
+    it("addMapKeyValue should throw for keys >= 192 bytes") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(longMapSchema); builder.addLong(1L); builder.startMap()
+      intercept[IllegalArgumentException] {
+        builder.addMapKeyValue(Array.fill(192)(65.toByte), "v".getBytes)
+      }
+    }
+
+    it("addMapKeyValue should throw for values >= 64KB") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(longMapSchema); builder.addLong(1L); builder.startMap()
+      intercept[IllegalArgumentException] {
+        builder.addMapKeyValue("k".getBytes, Array.fill(65536)(65.toByte))
+      }
+    }
+
+    it("addMap(Map[ZCUTF8, ZCUTF8]) should sort keys before encoding") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(longMapSchema)
+      builder.addLong(100L)
+      builder.addMap(Map(
+        ZCUTF8("zoo")   -> ZCUTF8("v1"),
+        ZCUTF8("apple") -> ZCUTF8("v2"),
+        ZCUTF8("mango") -> ZCUTF8("v3")
+      ))
+      val off = builder.endRecord()
+
+      val keys   = new collection.mutable.ArrayBuffer[String]
+      val values = new collection.mutable.ArrayBuffer[String]
+      longMapSchema.consumeMapItems(builder.lastContainer.base, off, 1, new MapItemConsumer {
+        def consume(kb: Any, ko: Long, vb: Any, vo: Long, idx: Int): Unit = {
+          keys   += UTF8StringShort.toString(kb, ko)
+          values += UTF8StringMedium.toString(vb, vo)
+        }
+      })
+      keys   shouldEqual Seq("apple", "mango", "zoo")
+      values shouldEqual Seq("v2", "v3", "v1")
+    }
+
+    it("encodeMapFrom(TreeMap) should produce identical map content as addMapKeyValue loop") {
+      val tags = new java.util.TreeMap[String, String]()
+      tags.put("__name__", "cpu_usage")
+      tags.put("instance", "host:9090")
+      tags.put("job", "myapp")
+
+      def buildWithManualLoop(): (RecordBuilder, Long) = {
+        val b = new RecordBuilder(MemFactory.onHeapFactory)
+        b.startNewRecord(longMapSchema); b.addLong(1L)
+        b.startMap()
+        tags.entrySet().forEach(e => b.addMapKeyValue(e.getKey.getBytes, e.getValue.getBytes))
+        b.endMap()
+        (b, b.endRecord())
+      }
+
+      def buildWithEncodeFrom(): (RecordBuilder, Long) = {
+        val b = new RecordBuilder(MemFactory.onHeapFactory)
+        b.startNewRecord(longMapSchema); b.addLong(1L)
+        b.encodeMapFrom(tags)
+        (b, b.endRecord())
+      }
+
+      def readItems(b: RecordBuilder, off: Long): Seq[(String, String)] = {
+        val buf = new collection.mutable.ArrayBuffer[(String, String)]
+        longMapSchema.consumeMapItems(b.lastContainer.base, off, 1, new MapItemConsumer {
+          def consume(kb: Any, ko: Long, vb: Any, vo: Long, idx: Int): Unit =
+            buf += UTF8StringShort.toString(kb, ko) -> UTF8StringMedium.toString(vb, vo)
+        })
+        buf.toSeq
+      }
+
+      val (b1, off1) = buildWithManualLoop()
+      val (b2, off2) = buildWithEncodeFrom()
+      readItems(b1, off1) shouldEqual readItems(b2, off2)
+    }
+
+    it("addEncodedMap should produce the same partition hash as addMapKeyValue loop") {
+      val tags = new java.util.TreeMap[String, String]()
+      tags.put("job", "prometheus"); tags.put("instance", "host:9090")
+
+      def addFields(b: RecordBuilder): Unit = {
+        b.startNewRecord(schema2)
+        b.addLong(1L); b.addDouble(1.0); b.addDouble(2.0); b.addDouble(3.0); b.addLong(10L)
+        b.addString("s1")
+      }
+
+      val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+      addFields(b1)
+      b1.startMap()
+      tags.entrySet().forEach(e => b1.addMapKeyValue(e.getKey.getBytes, e.getValue.getBytes))
+      b1.endMap()
+      val off1 = b1.endRecord()
+
+      val encoded = MapEncoder.encode(tags, schema2.ingestionSchema)
+      val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+      addFields(b2); b2.addEncodedMap(encoded)
+      val off2 = b2.endRecord()
+
+      schema2.ingestionSchema.partitionHash(b1.lastContainer.base, off1) shouldEqual
+        schema2.ingestionSchema.partitionHash(b2.lastContainer.base, off2)
+    }
+
+    it("addMapKeyValueHash should update the partition hash (non-initial value)") {
+      val partSchema = schema2.partKeySchema  // [series:string, tags:map]
+      val keyBytes = "job".getBytes(StandardCharsets.UTF_8)
+      val valBytes = "prometheus".getBytes(StandardCharsets.UTF_8)
+      val keyHash  = BinaryRegion.hash32(keyBytes)
+
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.startNewRecord(partSchema, schema2.schemaHash)
+      builder.addString("s1")
+      builder.startMap()
+      builder.addMapKeyValueHash(keyBytes, keyHash, valBytes, 0, valBytes.length)
+      builder.endMap(bulkHash = false)
+      val off = builder.endRecord()
+
+      partSchema.partitionHash(builder.lastContainer.base, off) should not equal RecordBuilder.HASH_INIT
+    }
+
+    it("endMap(bulkHash=false) should leave hash from addMapKeyValueHash unmodified") {
+      val partSchema = schema2.partKeySchema
+      val keyBytes = "job".getBytes(StandardCharsets.UTF_8)
+      val valBytes = "prometheus".getBytes(StandardCharsets.UTF_8)
+      val keyHash  = BinaryRegion.hash32(keyBytes)
+
+      // bulkHash=false means endMap does NOT re-hash the map bytes
+      val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+      b1.startNewRecord(partSchema, schema2.schemaHash); b1.addString("s1")
+      b1.startMap()
+      b1.addMapKeyValueHash(keyBytes, keyHash, valBytes, 0, valBytes.length)
+      b1.endMap(bulkHash = false)
+      val off1 = b1.endRecord()
+
+      // Same data, bulkHash=true: endMap re-computes hash from raw bytes
+      val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+      b2.startNewRecord(partSchema, schema2.schemaHash); b2.addString("s1")
+      b2.startMap()
+      b2.addMapKeyValue(keyBytes, valBytes)
+      b2.endMap(bulkHash = true)
+      val off2 = b2.endRecord()
+
+      // Both records are valid (non-initial hash) even though the two strategies differ
+      partSchema.partitionHash(b1.lastContainer.base, off1) should not equal RecordBuilder.HASH_INIT
+      partSchema.partitionHash(b2.lastContainer.base, off2) should not equal RecordBuilder.HASH_INIT
+    }
+
+    it("updatePartitionHash should combine the supplied value into the current hash") {
+      val b1 = new RecordBuilder(MemFactory.onHeapFactory)
+      b1.startNewRecord(partStrSchema, 1); b1.addString("series")
+      val offNoUpdate = b1.endRecord()
+
+      val b2 = new RecordBuilder(MemFactory.onHeapFactory)
+      b2.startNewRecord(partStrSchema, 1); b2.addString("series")
+      b2.updatePartitionHash(12345)
+      val offWithUpdate = b2.endRecord()
+
+      val base1 = b1.lastContainer.base
+      val base2 = b2.lastContainer.base
+      // Updating with an extra value must change the hash
+      partStrSchema.partitionHash(base1, offNoUpdate) should not equal
+        partStrSchema.partitionHash(base2, offWithUpdate)
+    }
+  }
+
+  // ==================== 7. Container rollover ====================
+
+  describe("Container rollover") {
+    val recordSize    = 64   // bytes per record for schema1 (linearMultiSeries)
+    val maxNumRecords = (RecordBuilder.MinContainerSize - ContainerHeaderLen) / recordSize
+
+    it("should create a second container when the first fills up") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
+      addToBuilder(builder, linearMultiSeries().take(maxNumRecords))
+      builder.allContainers should have length 1
+
+      addToBuilder(builder, linearMultiSeries().take(1))
+      builder.allContainers should have length 2
+    }
+
+    it("reuseOneContainer should reset instead of allocating a new container") {
+      val builder = new RecordBuilder(
+        MemFactory.onHeapFactory, RecordBuilder.MinContainerSize, reuseOneContainer = true)
+      addToBuilder(builder, linearMultiSeries().take(maxNumRecords))
+      builder.allContainers should have length 1
+
+      addToBuilder(builder, linearMultiSeries().take(1))
+      // Container is reused, not grown
+      builder.allContainers should have length 1
+      // Only the one record added after reset should be present
+      builder.lastContainer.countRecords() shouldEqual 1
+    }
+
+    it("a partial record in progress should be moved to the new container on rollover") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
+      // Fill up all records so only ~48 bytes remain — not enough for an 80-byte record
+      addToBuilder(builder, linearMultiSeries().take(maxNumRecords))
+
+      // Start a new record that spans across the old and new container
+      builder.startNewRecord(schema1)
+      builder.addLong(99999L)
+      builder.addDouble(1.0); builder.addDouble(2.0); builder.addDouble(3.0)
+      builder.addLong(5L)
+      builder.addString("cross-boundary-record")
+      val off = builder.endRecord()
+
+      builder.allContainers should have length 2
+      // The completed record lives in the new container
+      schema1.ingestionSchema.getLong(builder.lastContainer.base, off, 0) shouldEqual 99999L
+    }
+  }
+
+  // ==================== 8. reset and rewind ====================
+
+  describe("reset") {
+    it("reset should clear records and leave an empty container") {
+      val builder = new RecordBuilder(nativeMem, RecordBuilder.MinContainerSize)
+      addToBuilder(builder, linearMultiSeries().take(5))
+      builder.lastContainer.isEmpty shouldBe false
+
+      builder.optimalContainerBytes(reset = true)
+
+      builder.allContainers should have length 1
+      builder.lastContainer.isEmpty shouldBe true
+      builder.lastContainer.numBytes shouldEqual RecordBuilder.EmptyNumBytes
+    }
+
+    it("reset(skipTime=false) should update the container timestamp") {
+      val builder = new RecordBuilder(nativeMem)
+      addToBuilder(builder, linearMultiSeries().take(3))
+      val tsBefore = builder.lastContainer.timestamp
+
+      Thread.sleep(100L)
+      builder.reset(skipTime = false)
+
+      builder.lastContainer.timestamp should be > tsBefore
+    }
+
+    it("reset(skipTime=true) should NOT update the container timestamp") {
+      val builder = new RecordBuilder(nativeMem)
+      addToBuilder(builder, linearMultiSeries().take(3))
+      val tsBefore = builder.lastContainer.timestamp
+
+      Thread.sleep(50L)
+      builder.reset(skipTime = true)
+
+      builder.lastContainer.timestamp shouldEqual tsBefore
+    }
+  }
+
+  describe("rewind") {
+    it("rewind should discard a partial record and allow a new complete record") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      addToBuilder(builder, linearMultiSeries().take(2))
+
+      // Start a partial record and deliberately rewind
+      builder.startNewRecord(schema1)
+      builder.addLong(99L)
+      builder.rewind()
+
+      // Now add a proper record
+      builder.startNewRecord(schema1)
+      builder.addLong(1L); builder.addDouble(1.0); builder.addDouble(2.0)
+      builder.addDouble(3.0); builder.addLong(5L); builder.addString("after-rewind")
+      builder.endRecord()
+
+      // Partial record must not appear in count
+      builder.lastContainer.countRecords() shouldEqual 3
+    }
+
+    it("startNewRecord auto-rewinds when called after a partial record") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      addToBuilder(builder, linearMultiSeries().take(2))
+
+      // Partial record: only addLong, no endRecord
+      builder.startNewRecord(schema1)
+      builder.addLong(77L)
+      // Don't call endRecord – call startNewRecord which will auto-rewind
+
+      builder.startNewRecord(schema1)
+      builder.addLong(1L); builder.addDouble(1.0); builder.addDouble(2.0)
+      builder.addDouble(3.0); builder.addLong(5L); builder.addString("clean-record")
+      builder.endRecord()
+
+      builder.lastContainer.countRecords() shouldEqual 3
+    }
+  }
+
+  // ==================== 9. Container bytes ====================
+
+  describe("optimalContainerBytes and nonCurrentContainerBytes") {
+    val recordSize    = 64
+    val maxNumRecords = (RecordBuilder.MinContainerSize - ContainerHeaderLen) / recordSize
+
+    it("optimalContainerBytes should return full + trimmed last container bytes") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
+      addToBuilder(builder, linearMultiSeries().take(maxNumRecords + 1))
+      builder.allContainers should have length 2
+
+      val bytes = builder.optimalContainerBytes()
+      bytes should have length 2
+      bytes.head.length shouldEqual RecordBuilder.MinContainerSize
+      bytes.last.length should be < RecordBuilder.MinContainerSize
+    }
+
+    it("optimalContainerBytes(reset=true) should reset state to one empty container") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
+      addToBuilder(builder, linearMultiSeries().take(maxNumRecords + 1))
+
+      builder.optimalContainerBytes(reset = true)
+
+      builder.allContainers should have length 1
+      builder.lastContainer.isEmpty shouldBe true
+    }
+
+    it("optimalContainerBytes should return empty seq when no records have been written") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.optimalContainerBytes() shouldBe empty
+    }
+
+    it("nonCurrentContainerBytes should return only completed (non-current) containers") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
+      addToBuilder(builder, linearMultiSeries().take(maxNumRecords + 1))
+      builder.allContainers should have length 2
+
+      val bytes = builder.nonCurrentContainerBytes()
+      bytes should have length 1
+      bytes.head.length shouldEqual RecordBuilder.MinContainerSize
+    }
+
+    it("nonCurrentContainerBytes(reset=true) should remove non-current containers") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
+      addToBuilder(builder, linearMultiSeries().take(maxNumRecords + 1))
+
+      builder.nonCurrentContainerBytes(reset = true)
+
+      builder.allContainers should have length 1
+    }
+
+    it("optimalContainerBytes should throw UnsupportedOperationException for off-heap containers") {
+      // off-heap: trimmedArray works for the last container, but .array (called on non-last
+      // containers by optimalContainerBytes) throws — so we need 2+ containers
+      val builder = new RecordBuilder(nativeMem, RecordBuilder.MinContainerSize)
+      addToBuilder(builder, linearMultiSeries().take(maxNumRecords + 1))
+      builder.allContainers should have length 2
+      intercept[UnsupportedOperationException] { builder.optimalContainerBytes() }
+    }
+  }
+
+  // ==================== 10. removeAndFreeContainers ====================
+
+  describe("removeAndFreeContainers") {
+    val recordSize    = 64
+    val maxNumRecords = (RecordBuilder.MinContainerSize - ContainerHeaderLen) / recordSize
+
+    it("should remove the first N containers") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
+      addToBuilder(builder, linearMultiSeries().take(maxNumRecords * 2 + 1))
+      builder.allContainers should have length 3
+
+      builder.removeAndFreeContainers(1)
+      builder.allContainers should have length 2
+
+      builder.removeAndFreeContainers(1)
+      builder.allContainers should have length 1
+    }
+
+    it("should do nothing when numContainers is 0") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
+      addToBuilder(builder, linearMultiSeries().take(3))
+      val before = builder.allContainers.length
+      builder.removeAndFreeContainers(0)
+      builder.allContainers should have length before
+    }
+
+    it("should reset all state when all containers are removed") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
+      addToBuilder(builder, linearMultiSeries().take(3))
+      builder.allContainers should have length 1
+      builder.removeAndFreeContainers(1)
+      builder.allContainers shouldBe empty
+    }
+
+    it("should throw when numContainers exceeds the number of available containers") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
+      addToBuilder(builder, linearMultiSeries().take(3))
+      intercept[IllegalArgumentException] { builder.removeAndFreeContainers(10) }
+    }
+  }
+
+  // ==================== 11. High-level builders ====================
+
+  describe("addFromReader") {
+    it("addFromReader(row, RecordSchema, schemaID) should build a complete record") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      val row = SeqRowReader(Seq(1000L, "hello"))
+      val off = builder.addFromReader(row, longStrSchema, 0)
+      longStrSchema.getLong(builder.lastContainer.base, off, 0) shouldEqual 1000L
+      longStrSchema.asJavaString(builder.lastContainer.base, off, 1) shouldEqual "hello"
+    }
+
+    it("addFromReader(row, Schema) should use ingestionSchema and write schemaHash") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      val row = SeqRowReader(Seq[Any](100L, 1.0, 2.0, 3.0, 10L, "series-test"))
+      val off = builder.addFromReader(row, schema1)
+      schema1.ingestionSchema.getLong(builder.lastContainer.base, off, 0) shouldEqual 100L
+      RecordSchema.schemaID(builder.lastContainer.base, off) shouldEqual schema1.schemaHash
+    }
+  }
+
+  describe("partKeyFromObjects") {
+    it("should build a partition key record from vararg objects") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      val off = builder.partKeyFromObjects(schema1, "myMetric")
+      RecordSchema.schemaID(builder.lastContainer.base, off) shouldEqual schema1.schemaHash
+      schema1.partKeySchema.asJavaString(builder.lastContainer.base, off, 0) shouldEqual "myMetric"
+    }
+
+    it("different metric names should produce different partition hashes") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      val off1 = builder.partKeyFromObjects(schema1, "metric-A")
+      val off2 = builder.partKeyFromObjects(schema1, "metric-B")
+      val base = builder.lastContainer.base
+      schema1.partKeySchema.partitionHash(base, off1) should not equal
+        schema1.partKeySchema.partitionHash(base, off2)
+    }
+  }
+
+  describe("addPartKeyRecordFields") {
+    it("should copy partition fields from an existing partition key into the new ingestion record") {
+      // Build a standalone partition key
+      val pkBuilder = new RecordBuilder(MemFactory.onHeapFactory)
+      val pkOff     = pkBuilder.partKeyFromObjects(schema1, "myMetric")
+      val pkBase    = pkBuilder.lastContainer.base
+
+      // Build an ingestion record, copying the partition fields from the partition key
+      val ingestBuilder = new RecordBuilder(MemFactory.onHeapFactory)
+      ingestBuilder.startNewRecord(schema1)
+      ingestBuilder.addLong(500L)
+      ingestBuilder.addDouble(1.0); ingestBuilder.addDouble(2.0); ingestBuilder.addDouble(3.0)
+      ingestBuilder.addLong(5L)
+      ingestBuilder.addPartKeyRecordFields(pkBase, pkOff, schema1.partKeySchema)
+      val ingestOff = ingestBuilder.endRecord()
+
+      val ingestBase = ingestBuilder.lastContainer.base
+      // The series field should match what was in the partition key
+      schema1.ingestionSchema.asJavaString(ingestBase, ingestOff, 5) shouldEqual "myMetric"
+      // Partition hash in ingestion record should match hash from standalone partition key
+      schema1.ingestionSchema.partitionHash(ingestBase, ingestOff) shouldEqual
+        schema1.partKeySchema.partitionHash(pkBase, pkOff)
+    }
+  }
+
+  // ==================== 12. align ====================
+
+  describe("align") {
+    it("should return the offset unchanged when already 4-byte aligned") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.align(0L)  shouldEqual 0L
+      builder.align(4L)  shouldEqual 4L
+      builder.align(8L)  shouldEqual 8L
+      builder.align(100L) shouldEqual 100L
+    }
+
+    it("should round up to the next 4-byte boundary") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      builder.align(1L) shouldEqual 4L
+      builder.align(2L) shouldEqual 4L
+      builder.align(3L) shouldEqual 4L
+      builder.align(5L) shouldEqual 8L
+      builder.align(6L) shouldEqual 8L
+      builder.align(7L) shouldEqual 8L
+      builder.align(101L) shouldEqual 104L
+    }
+  }
+
+  // ==================== 13. containerRemaining ====================
+
+  describe("containerRemaining") {
+    it("should decrease as records are added") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
+      addToBuilder(builder, linearMultiSeries().take(1))
+      val after1 = builder.containerRemaining
+      addToBuilder(builder, linearMultiSeries().take(1))
+      val after2 = builder.containerRemaining
+      after2 should be < after1
+    }
+
+    it("should be positive but less than containerSize after adding a record") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory, RecordBuilder.MinContainerSize)
+      addToBuilder(builder, linearMultiSeries().take(1))
+      builder.containerRemaining should be > 0L
+      builder.containerRemaining should be < RecordBuilder.MinContainerSize.toLong
+    }
+  }
+
+  // ==================== 14. Container metadata ====================
+
+  describe("Container metadata") {
+    it("container version should equal RecordBuilder.Version") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      addToBuilder(builder, linearMultiSeries().take(1))
+      builder.lastContainer.version shouldEqual RecordBuilder.Version
+      builder.lastContainer.isCurrentVersion shouldBe true
+    }
+
+    it("container timestamp should be set to the current time at creation") {
+      val before  = System.currentTimeMillis
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      addToBuilder(builder, linearMultiSeries().take(1))
+      val after = System.currentTimeMillis
+      builder.lastContainer.timestamp should be >= before
+      builder.lastContainer.timestamp should be <= after
+    }
+
+    it("isEmpty should reflect whether any records have been committed") {
+      val builder = new RecordBuilder(
+        MemFactory.onHeapFactory, RecordBuilder.MinContainerSize, reuseOneContainer = true)
+      builder.lastContainer.isEmpty shouldBe true
+      addToBuilder(builder, linearMultiSeries().take(1))
+      builder.lastContainer.isEmpty shouldBe false
+    }
+
+    it("currentContainer and allContainers should agree") {
+      val builder = new RecordBuilder(MemFactory.onHeapFactory)
+      addToBuilder(builder, linearMultiSeries().take(1))
+      builder.currentContainer shouldEqual Some(builder.lastContainer)
+      builder.allContainers should contain(builder.lastContainer)
+    }
+  }
+
+  // ==================== 15. RecordBuilder companion: combineHash ====================
+
+  describe("RecordBuilder.combineHash") {
+    it("should compute 31 * h1 + h2") {
+      RecordBuilder.combineHash(7, 100)  shouldEqual (31 * 7 + 100)
+      RecordBuilder.combineHash(0, 0)    shouldEqual 0
+      RecordBuilder.combineHash(1, 0)    shouldEqual 31
+      RecordBuilder.combineHash(0, 1)    shouldEqual 1
+      RecordBuilder.combineHash(100, 200) shouldEqual (31 * 100 + 200)
+    }
+
+    it("combineHash is not commutative") {
+      RecordBuilder.combineHash(1, 2) should not equal RecordBuilder.combineHash(2, 1)
+    }
+  }
+
+  // ==================== 16. RecordBuilder companion: sortAndComputeHashes ====================
+
+  describe("RecordBuilder.sortAndComputeHashes") {
+    import collection.JavaConverters._
+
+    it("should sort pairs by key and produce one hash per pair") {
+      val pairs  = new java.util.ArrayList(Seq("zoo" -> "v1", "apple" -> "v2", "mango" -> "v3").asJava)
+      val hashes = RecordBuilder.sortAndComputeHashes(pairs)
+      pairs.asScala.map(_._1) shouldEqual Seq("apple", "mango", "zoo")
+      hashes.length shouldEqual 3
+    }
+
+    it("should produce distinct hashes for distinct key-value pairs") {
+      val pairs  = new java.util.ArrayList(Seq("a" -> "1", "b" -> "2", "c" -> "3").asJava)
+      val hashes = RecordBuilder.sortAndComputeHashes(pairs)
+      hashes.toSet.size shouldEqual 3
+    }
+
+    it("should produce the same hash for the same key-value pair across calls") {
+      val p1 = new java.util.ArrayList(Seq("k" -> "v").asJava)
+      val p2 = new java.util.ArrayList(Seq("k" -> "v").asJava)
+      RecordBuilder.sortAndComputeHashes(p1)(0) shouldEqual
+        RecordBuilder.sortAndComputeHashes(p2)(0)
+    }
+
+    it("should produce different hashes for the same key with different values") {
+      val p1 = new java.util.ArrayList(Seq("job" -> "prometheus").asJava)
+      val p2 = new java.util.ArrayList(Seq("job" -> "thanos").asJava)
+      RecordBuilder.sortAndComputeHashes(p1)(0) should not equal
+        RecordBuilder.sortAndComputeHashes(p2)(0)
+    }
+  }
+
+  // ==================== 17. RecordBuilder companion: combineHashExcluding ====================
+
+  describe("RecordBuilder.combineHashExcluding") {
+    import collection.JavaConverters._
+
+    it("should include all pairs when excludeKeys is empty") {
+      val pairs  = new java.util.ArrayList(Seq("a" -> "1", "b" -> "2").asJava)
+      val hashes = RecordBuilder.sortAndComputeHashes(pairs)
+      val h1 = RecordBuilder.combineHashExcluding(pairs, hashes, Set.empty)
+      val h2 = RecordBuilder.combineHashExcluding(pairs, hashes, Set("nonexistent"))
+      h1 shouldEqual h2
+    }
+
+    it("should exclude specified keys from the combined hash") {
+      val pairs  = new java.util.ArrayList(Seq("a" -> "1", "le" -> "0.5", "b" -> "2").asJava)
+      val hashes = RecordBuilder.sortAndComputeHashes(pairs)
+      val hashAll    = RecordBuilder.combineHashExcluding(pairs, hashes, Set.empty)
+      val hashNoLe   = RecordBuilder.combineHashExcluding(pairs, hashes, Set("le"))
+      hashAll should not equal hashNoLe
+
+      // Excluding "le" should equal a hash computed without "le" in the first place
+      val pairsNoLe  = new java.util.ArrayList(Seq("a" -> "1", "b" -> "2").asJava)
+      val hashesNoLe = RecordBuilder.sortAndComputeHashes(pairsNoLe)
+      RecordBuilder.combineHashExcluding(pairsNoLe, hashesNoLe, Set.empty) shouldEqual hashNoLe
+    }
+  }
+
+  // ==================== 18. RecordBuilder companion: shardKeyHash ====================
+
+  describe("RecordBuilder.shardKeyHash") {
+    val metric   = "host_cpu_load"
+    val job      = "prometheus"
+    val metricHash = BinaryRegion.hash32(metric.getBytes(StandardCharsets.UTF_8))
+    val jobHash    = BinaryRegion.hash32(job.getBytes(StandardCharsets.UTF_8))
+
+    it("metric-only shard key hash should equal 7*31 + metricHash") {
+      RecordBuilder.shardKeyHash(Nil, "__name__", metric) shouldEqual (7 * 31 + metricHash)
+    }
+
+    it("should combine shard-key values and metric in left-to-right order") {
+      val expected = (7 * 31 + jobHash) * 31 + metricHash
+      RecordBuilder.shardKeyHash(Seq(job), "__name__", metric) shouldEqual expected
+    }
+
+    it("with a targetSchema that excludes metric, metric should be omitted") {
+      val tsNoMetric = Seq("job")
+      RecordBuilder.shardKeyHash(Seq(job), "__name__", metric, tsNoMetric) shouldEqual
+        (31 * 7 + jobHash)
+    }
+
+    it("with a targetSchema that includes metric, metric should be included") {
+      val tsWithMetric = Seq("job", "__name__")
+      RecordBuilder.shardKeyHash(Seq(job), "__name__", metric, tsWithMetric) shouldEqual
+        ((7 * 31 + jobHash) * 31 + metricHash)
+    }
+
+    it("empty targetSchema should behave like includeMetric=true (default)") {
+      RecordBuilder.shardKeyHash(Nil, "__name__", metric, Seq.empty) shouldEqual
+        (7 * 31 + metricHash)
+    }
+  }
+
+  // ==================== 19. RecordBuilder companion: partitionKeyHash ====================
+
+  describe("RecordBuilder.partitionKeyHash") {
+    val labels = Map(
+      "__name__" -> "host_cpu_load",
+      "dc"       -> "AWS-USE",
+      "instance" -> "0123892E342342A90",
+      "job"      -> "prometheus"
+    )
+    val nonShardKeys = labels.filter(kv => kv._1 != "job" && kv._1 != "__name__")
+    val shardKeys    = labels.filter(kv => kv._1 == "job" || kv._1 == "__name__")
+
+    it("should produce a non-HASH_INIT result when non-shard keys exist") {
+      val h = RecordBuilder.partitionKeyHash(
+        nonShardKeys, shardKeys, Seq.empty, "__name__", labels("__name__"))
+      h should not equal RecordBuilder.HASH_INIT
+    }
+
+    it("with targetSchema, should sort and use the specified labels") {
+      val instanceHash = BinaryRegion.hash32(labels("instance").getBytes(StandardCharsets.UTF_8))
+      val jobHash      = BinaryRegion.hash32(labels("job").getBytes(StandardCharsets.UTF_8))
+      val expected = (7 * 31 + instanceHash) * 31 + jobHash
+      RecordBuilder.partitionKeyHash(
+        nonShardKeys, shardKeys, Seq("job", "instance"), "__name__", labels("__name__")) shouldEqual expected
+    }
+
+    it("should ignore the metric label when it is present in nonShardKeyLabelPair") {
+      val metricName  = "metric"
+      val metricValue = "my-metric"
+      val nonShard    = Map("nonShard1" -> "ns1")
+      val shardK      = Map("shard1"    -> "s1")
+      val targetSchema = Seq("shard1", "nonShard1")
+
+      val h1 = RecordBuilder.partitionKeyHash(nonShard, shardK, targetSchema, metricName, metricValue)
+      val h2 = RecordBuilder.partitionKeyHash(
+        nonShard + (metricName -> metricValue), shardK, targetSchema, metricName, metricValue)
+      h1 shouldEqual h2
+    }
+  }
+  
+  describe("RecordBuilder.trimShardColumn") {
+    val opts = schema1.options
+
+    it("should trim _bucket suffix") {
+      RecordBuilder.trimShardColumn(opts, "__name__", "heap_usage_bucket") shouldEqual "heap_usage"
+    }
+
+    it("should trim _sum suffix") {
+      RecordBuilder.trimShardColumn(opts, "__name__", "heap_usage_sum") shouldEqual "heap_usage"
+    }
+
+    it("should trim _count suffix") {
+      RecordBuilder.trimShardColumn(opts, "__name__", "heap_usage_count") shouldEqual "heap_usage"
+    }
+
+    it("should not modify metric names without a matching suffix") {
+      RecordBuilder.trimShardColumn(opts, "__name__", "heap_usage")       shouldEqual "heap_usage"
+      RecordBuilder.trimShardColumn(opts, "__name__", "heap_usage_total") shouldEqual "heap_usage_total"
+    }
+
+    it("should not trim for a column that has no configured suffixes") {
+      RecordBuilder.trimShardColumn(opts, "job", "prometheus_bucket") shouldEqual "prometheus_bucket"
+    }
+
+    it("should trim only the last matching suffix (rightmost match)") {
+      // "heap_usage_sum_count" → trim "_count" → "heap_usage_sum"
+      RecordBuilder.trimShardColumn(opts, "__name__", "heap_usage_sum_count") shouldEqual "heap_usage_sum"
+    }
+  }
+}

--- a/core/src/test/scala/filodb.core/binaryrecord2/SingleRecordBuilderSpec.scala
+++ b/core/src/test/scala/filodb.core/binaryrecord2/SingleRecordBuilderSpec.scala
@@ -1,0 +1,107 @@
+package filodb.core.binaryrecord2
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import filodb.core.metadata.Column.ColumnType
+import filodb.core.query.ColumnInfo
+import filodb.memory.BinaryRegionLarge
+import filodb.memory.format.{SeqRowReader, UnsafeUtils}
+
+class SingleRecordBuilderSpec extends AnyFunSpec with Matchers {
+
+  val schema = new RecordSchema(Seq(
+    ColumnInfo("ts",  ColumnType.LongColumn),
+    ColumnInfo("val", ColumnType.DoubleColumn),
+    ColumnInfo("s",   ColumnType.StringColumn)
+  ))
+
+  describe("SingleRecordBuilder") {
+    it("should write a record into on-heap memory and read back all fields") {
+      val buf     = new Array[Byte](1024)
+      val base    = buf
+      val offset  = UnsafeUtils.arayOffset
+      val builder = new SingleRecordBuilder(base, offset, buf.length)( {
+        throw new IllegalStateException("Should not have needed to grow buffer")
+      })
+
+      val startOff = builder.addFromReader(SeqRowReader(Seq(1234L, 3.14, "hello")), schema, 0)
+
+      schema.getLong(base, startOff, 0)      shouldEqual 1234L
+      schema.getDouble(base, startOff, 1)    shouldEqual 3.14
+      schema.asJavaString(base, startOff, 2) shouldEqual "hello"
+
+      val recordLen = (BinaryRegionLarge.numBytes(base, startOff) + 7) & ~3
+      builder.nextRecordOffset shouldEqual startOff + recordLen
+    }
+
+    it("should write two successive records after reset, both readable independently") {
+      val buf     = new Array[Byte](1024)
+      val base    = buf
+      val offset  = UnsafeUtils.arayOffset
+      val builder = new SingleRecordBuilder(base, offset, buf.length)( {
+        throw new IllegalStateException("Should not have needed to grow buffer")
+      })
+
+      val off1 = builder.addFromReader(SeqRowReader(Seq(1L, 1.1, "first")), schema, 0)
+      val next = builder.nextRecordOffset
+      builder.reset(base, next, (UnsafeUtils.arayOffset + buf.length - next).toInt)
+
+      val off2 = builder.addFromReader(SeqRowReader(Seq(2L, 2.2, "second")), schema, 0)
+
+      schema.getLong(base, off1, 0)      shouldEqual 1L
+      schema.asJavaString(base, off1, 2) shouldEqual "first"
+      schema.getLong(base, off2, 0)      shouldEqual 2L
+      schema.asJavaString(base, off2, 2) shouldEqual "second"
+    }
+
+    it("should spill a partial record to a new buffer when variable-length data exceeds remaining capacity") {
+      // Schema fixed area: 4 header + 8 Long + 8 Double + 4 String-ptr = 24 bytes.
+      // Initial capacity is 30 bytes: fits the fixed area (24 bytes) but not a 13-byte string
+      // (needs 15 bytes in the variable area), so the spill fires inside addString.
+      // After the spill, the partially-written fixed area is copied to buf2 and the
+      // string is appended there, producing a complete, readable record.
+      val buf1 = Array.fill[Byte](256)(0)
+      val buf2 = Array.fill[Byte](256)(0)
+      var spillCount = 0
+
+      val builder = new SingleRecordBuilder(buf1, UnsafeUtils.arayOffset, 30)({
+        spillCount += 1
+        (buf2, UnsafeUtils.arayOffset, buf2.length)
+      })
+
+      val recOff = builder.addFromReader(SeqRowReader(Seq(99L, 1.5, "hello, world!")), schema, 0)
+
+      spillCount                           shouldEqual 1
+      recOff                               shouldEqual UnsafeUtils.arayOffset
+      schema.getLong(buf2, recOff, 0)      shouldEqual 99L
+      schema.getDouble(buf2, recOff, 1)    shouldEqual 1.5
+      schema.asJavaString(buf2, recOff, 2) shouldEqual "hello, world!"
+      // fixed(24) + length-short(2) + content(13) = 39 bytes, aligned to 40
+      builder.nextRecordOffset             shouldEqual UnsafeUtils.arayOffset + 40
+    }
+
+    it("should spill on the very first requireBytes call when constructed with zero capacity") {
+      // Matches the production pattern in ArrowSerializedRangeVectorOps where the
+      // SingleRecordBuilder is created with (ZeroPointer, 0L, 0) so that the first
+      // requireBytes call always spills into the allocateNewBuf-supplied buffer.
+      // Here we use on-heap arrays so the zero-byte copyMemory is safely a no-op.
+      val buf1 = Array.fill[Byte](256)(0)
+      val buf2 = Array.fill[Byte](256)(0)
+      var spillCount = 0
+
+      val builder = new SingleRecordBuilder(buf1, UnsafeUtils.arayOffset, 0)({
+        spillCount += 1
+        (buf2, UnsafeUtils.arayOffset, buf2.length)
+      })
+
+      val recOff = builder.addFromReader(SeqRowReader(Seq(7L, 2.0, "hi")), schema, 0)
+
+      spillCount                           shouldEqual 1
+      recOff                               shouldEqual UnsafeUtils.arayOffset
+      schema.getLong(buf2, recOff, 0)      shouldEqual 7L
+      schema.getDouble(buf2, recOff, 1)    shouldEqual 2.0
+      schema.asJavaString(buf2, recOff, 2) shouldEqual "hi"
+    }
+  }
+}

--- a/core/src/test/scala/filodb.core/query/QueryUtilsSpec.scala
+++ b/core/src/test/scala/filodb.core/query/QueryUtilsSpec.scala
@@ -4,6 +4,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
+import filodb.core.binaryrecord2.RecordBuilderBase
 import filodb.core.metadata.Column.ColumnType
 
 class QueryUtilsSpec extends AnyFunSpec with Matchers{
@@ -23,6 +24,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
       def partIds = Nil
       def schemaNames = Nil
       def keySize: Int = size
+      def writeToMapBr(rb: RecordBuilderBase): Unit = {}
     }
 
     // Minimal RangeVector with configurable numRows, outputRange, keySize

--- a/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
+++ b/core/src/test/scala/filodb.core/query/RangeVectorSpec.scala
@@ -6,6 +6,8 @@ import filodb.memory.format.{SeqRowReader, ZeroCopyUTF8String}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
+import filodb.core.binaryrecord2.RecordBuilderBase
+
 
 class RangeVectorSpec  extends AnyFunSpec with Matchers {
   val now = System.currentTimeMillis()
@@ -25,6 +27,7 @@ class RangeVectorSpec  extends AnyFunSpec with Matchers {
       def partIds: Seq[Int] = Nil
       def schemaNames: Seq[String] = Nil
       def keySize: Int = 0
+      def writeToMapBr(rb: RecordBuilderBase): Unit = {}
     }
 
     override def outputRange: Option[RvRange] = None

--- a/grpc/src/main/protobuf/query_service.proto
+++ b/grpc/src/main/protobuf/query_service.proto
@@ -1152,6 +1152,22 @@ message RemoteExecPlan {
   QueryContext queryContext  = 2;
 }
 
+message FlightResultHeader {
+  ResultSchema resultSchema = 1;
+}
+
+message FlightResultFooter {
+  QueryResultStats queryStats  = 1;
+  optional Throwable throwable = 2;
+}
+
+message FlightMetadata {
+  oneof content {
+    FlightResultHeader header = 1;
+    FlightResultFooter footer = 2;
+  }
+}
+
 service RemoteExec {
 
   rpc exec(Request) returns (Response);

--- a/grpc/src/main/protobuf/range_vector.proto
+++ b/grpc/src/main/protobuf/range_vector.proto
@@ -139,3 +139,18 @@ message RvRange {
   int64 endMs = 2;
   int64 step = 3;
 }
+
+// RvKey holds the range-vector key and output range for a data-row block in an Arrow Flight VSR stream.
+message RvKey {
+  RangeVectorKey key       = 1;
+  optional RvRange rvRange = 2;
+}
+
+// RvMetadata is the header row written before each RV in an Arrow Flight VSR stream.
+// Exactly one of srv (formulated-rows RV) or rvKey (key for following data rows) is set.
+message RvMetadata {
+  oneof payload {
+    SerializableRangeVector srv = 1;
+    RvKey rvKey                 = 2;
+  }
+}

--- a/grpc/src/main/protobuf/range_vector.proto
+++ b/grpc/src/main/protobuf/range_vector.proto
@@ -142,7 +142,7 @@ message RvRange {
 
 // RvKey holds the range-vector key and output range for a data-row block in an Arrow Flight VSR stream.
 message RvKey {
-  RangeVectorKey key       = 1;
+  bytes rvKey              = 1;
   optional RvRange rvRange = 2;
 }
 

--- a/jmh/src/main/scala/filodb.jmh/FlightRpcBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/FlightRpcBenchmark.scala
@@ -27,12 +27,14 @@ import filodb.core.metadata.Schemas
 import filodb.core.query._
 import filodb.core.store.StoreConfig
 import filodb.http.PromQLGrpcServer
+import filodb.prometheus.ast.TimeStepParams
+import filodb.prometheus.parse.Parser
 import filodb.query.{QueryError, QueryResult}
 import filodb.query.exec._
 import filodb.timeseries.TestTimeseriesProducer
 
 /**
- * JMH benchmark comparing two PromQL multi-partition query execution paths:
+ * JMH benchmark comparing two PromQL single and multi-partition query execution paths:
  *
  *   A. Flight path  — PromQLGrpcServer (flight-multi-partition-service-enabled=true)
  *                     → FiloDBMultiPartitionFlightProducer
@@ -60,10 +62,10 @@ import filodb.timeseries.TestTimeseriesProducer
  * Run with:
  *   sbt "jmh/jmh:run -rf json -i 5 -wi 3 -f 1 \
  *     -jvmArgsAppend -Xmx6g \
- *     filodb.jmh.FlightMultiPartitionBenchmark"
+ *     filodb.jmh.FlightRpcBenchmark"
  */
 @State(Scope.Benchmark)
-class FlightMultiPartitionBenchmark extends StrictLogging {
+class FlightRpcBenchmark extends StrictLogging {
 
   {
     import ch.qos.logback.classic.encoder.PatternLayoutEncoder
@@ -280,23 +282,28 @@ class FlightMultiPartitionBenchmark extends StrictLogging {
   private val queryStart = startTime / 1000 + (7 * 60)
   private val queryEnd   = queryStart + queryIntervalMin * 60
 
-  private val spreadProvider = StaticSpreadProvider(SpreadChange(0, spread))
+  private val spreadProvider       = StaticSpreadProvider(SpreadChange(0, spread))
 
-  private val flightSucceeded = new AtomicInteger(0)
-  private val flightFailed    = new AtomicInteger(0)
-  private val akkaSucceeded   = new AtomicInteger(0)
-  private val akkaFailed      = new AtomicInteger(0)
+  // Pre-parsed once; LogicalPlan is immutable so safe to share across concurrent materialize() calls.
+  private val singlePartLogicalPlan = Parser.queryRangeToLogicalPlan(
+    promQL, TimeStepParams(queryStart, queryStep, queryEnd))
+
+  private val flightSucceeded   = new AtomicInteger(0)
+  private val flightFailed      = new AtomicInteger(0)
+  private val akkaSucceeded     = new AtomicInteger(0)
+  private val akkaFailed        = new AtomicInteger(0)
+  private val flightSpSucceeded = new AtomicInteger(0)
+  private val flightSpFailed    = new AtomicInteger(0)
+  private val akkaSpSucceeded   = new AtomicInteger(0)
+  private val akkaSpFailed      = new AtomicInteger(0)
 
   // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------
-  private def mkFlightCtx(): QueryContext = QueryContext(
+  private def mkCtx(): QueryContext = QueryContext(
     origQueryParams = PromQlQueryParams(promQL, queryStart, queryStep, queryEnd),
     plannerParams   = PlannerParams(spreadOverride = Some(spreadProvider), queryTimeoutMillis = 60000))
 
-  private def mkAkkaCtx(): QueryContext = QueryContext(
-    origQueryParams = PromQlQueryParams(promQL, queryStart, queryStep, queryEnd),
-    plannerParams   = PlannerParams(spreadOverride = Some(spreadProvider), queryTimeoutMillis = 60000))
 
   // -------------------------------------------------------------------------
   // Teardown
@@ -312,8 +319,12 @@ class FlightMultiPartitionBenchmark extends StrictLogging {
     cluster.shutdown()
     logger.info(s"Flight  — succeeded: ${flightSucceeded.get}  failed: ${flightFailed.get}")
     logger.info(s"Akka    — succeeded: ${akkaSucceeded.get}    failed: ${akkaFailed.get}")
-    if (flightFailed.get > 0) throw new RuntimeException(s"${flightFailed.get} flight queries failed")
-    if (akkaFailed.get  > 0) throw new RuntimeException(s"${akkaFailed.get} akka queries failed")
+    logger.info(s"Flight SP — succeeded: ${flightSpSucceeded.get}  failed: ${flightSpFailed.get}")
+    logger.info(s"Akka   SP — succeeded: ${akkaSpSucceeded.get}    failed: ${akkaSpFailed.get}")
+    if (flightFailed.get   > 0) throw new RuntimeException(s"${flightFailed.get} flight queries failed")
+    if (akkaFailed.get     > 0) throw new RuntimeException(s"${akkaFailed.get} akka queries failed")
+    if (flightSpFailed.get > 0) throw new RuntimeException(s"${flightSpFailed.get} flight SP queries failed")
+    if (akkaSpFailed.get   > 0) throw new RuntimeException(s"${akkaSpFailed.get} akka SP queries failed")
   }
 
   // =========================================================================
@@ -339,7 +350,7 @@ class FlightMultiPartitionBenchmark extends StrictLogging {
     val flightAlloc = new FlightAllocator(invocAllocator)
     try {
       val tasks = (0 until numQueries).map { _ =>
-        val ctx          = mkFlightCtx()
+        val ctx          = mkCtx()
         val querySession = QuerySession(ctx, queryConfig, flightAllocator = Some(flightAlloc))
         val remoteExec   = PromQLFlightRemoteExec(
           queryContext            = ctx,
@@ -378,7 +389,7 @@ class FlightMultiPartitionBenchmark extends StrictLogging {
   @OperationsPerInvocation(50)
   def akkaGrpcMultiPartitionQuery(): Unit = {
     val tasks = (0 until numQueries).map { _ =>
-      val ctx          = mkAkkaCtx()
+      val ctx          = mkCtx()
       val querySession = QuerySession(ctx, queryConfig)
       val remoteExec   = PromQLGrpcRemoteExec(
         channel                 = akkaGrpcChannel,
@@ -408,7 +419,7 @@ class FlightMultiPartitionBenchmark extends StrictLogging {
   @BenchmarkMode(Array(Mode.SampleTime))
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   def flightSingleQueryLatency(): Unit = {
-    val ctx            = mkFlightCtx()
+    val ctx            = mkCtx()
     val singleAlloc    = flightRootAllocator.newChildAllocator(
       s"flight-single-${System.nanoTime()}", 0, 50_000_000L)
     val flightAlloc    = new FlightAllocator(singleAlloc)
@@ -444,7 +455,7 @@ class FlightMultiPartitionBenchmark extends StrictLogging {
   @BenchmarkMode(Array(Mode.SampleTime))
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   def akkaSingleQueryLatency(): Unit = {
-    val ctx          = mkAkkaCtx()
+    val ctx          = mkCtx()
     val querySession = QuerySession(ctx, queryConfig)
     val remoteExec   = PromQLGrpcRemoteExec(
       channel                 = akkaGrpcChannel,
@@ -465,4 +476,118 @@ class FlightMultiPartitionBenchmark extends StrictLogging {
         .runToFuture,
       60.seconds)
   }
+
+  // =========================================================================
+  // Throughput benchmark — Flight single-partition path (bypasses PromQLGrpcServer)
+  //
+  // Directly materializes ExecPlan via flightPlanner (spread=0 → 1 shard) and
+  // dispatches it.  The root ExecPlan carries a FlightPlanDispatcher targeting
+  // 127.0.0.1:38824, so the plan goes straight to
+  // FiloDBSinglePartitionFlightProducer → TimeSeriesMemStore.
+  // =========================================================================
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime, Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  @OperationsPerInvocation(50)
+  def flightSinglePartitionQuery(): Unit = {
+    val invocAllocator = flightRootAllocator.newChildAllocator(
+      s"flight-sp-bench-${System.nanoTime()}", 0, 200_000_000L)
+    val flightAlloc = new FlightAllocator(invocAllocator)
+    try {
+      val tasks = (0 until numQueries).map { _ =>
+        val ctx          = mkCtx()
+        val querySession = QuerySession(ctx, queryConfig, flightAllocator = Some(flightAlloc))
+        val execPlan     = flightPlanner.materialize(singlePartLogicalPlan, ctx)
+        execPlan.dispatcher
+          .dispatch(ExecPlanWithClientParams(execPlan, ClientParams(60000), querySession),
+            UnsupportedChunkSource())
+          .map {
+            case _: QueryResult => flightSpSucceeded.incrementAndGet()
+            case e: QueryError  => flightSpFailed.incrementAndGet(); e.t.printStackTrace()
+          }
+      }
+      Await.result(monix.eval.Task.parSequenceUnordered(tasks).runToFuture, 120.seconds)
+    } finally {
+      flightAlloc.close()
+    }
+  }
+
+  // =========================================================================
+  // Throughput benchmark — Akka single-partition path (bypasses PromQLGrpcServer)
+  //
+  // Directly materializes ExecPlan via akkaPlanner (spread=0 → 1 shard) and
+  // dispatches it.  Leaf plans carry ActorPlanDispatcher → QueryActor →
+  // TimeSeriesMemStore.
+  // =========================================================================
+  @Benchmark
+  @BenchmarkMode(Array(Mode.AverageTime, Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  @OperationsPerInvocation(50)
+  def akkaSinglePartitionQuery(): Unit = {
+    val tasks = (0 until numQueries).map { _ =>
+      val ctx          = mkCtx()
+      val querySession = QuerySession(ctx, queryConfig)
+      val execPlan     = akkaPlanner.materialize(singlePartLogicalPlan, ctx)
+      execPlan.dispatcher
+        .dispatch(ExecPlanWithClientParams(execPlan, ClientParams(60000), querySession),
+          UnsupportedChunkSource())
+        .map {
+          case _: QueryResult => akkaSpSucceeded.incrementAndGet()
+          case _: QueryError  => akkaSpFailed.incrementAndGet()
+        }
+    }
+    Await.result(monix.eval.Task.parSequenceUnordered(tasks).runToFuture, 120.seconds)
+  }
+
+  // =========================================================================
+  // Latency benchmark — Flight single-partition path (SampleTime, no queuing)
+  // =========================================================================
+  @Benchmark
+  @BenchmarkMode(Array(Mode.SampleTime))
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  def flightSinglePartitionLatency(): Unit = {
+    val ctx         = mkCtx()
+    val singleAlloc = flightRootAllocator.newChildAllocator(
+      s"flight-sp-single-${System.nanoTime()}", 0, 50_000_000L)
+    val flightAlloc = new FlightAllocator(singleAlloc)
+    try {
+      val querySession = QuerySession(ctx, queryConfig, flightAllocator = Some(flightAlloc))
+      val execPlan     = flightPlanner.materialize(singlePartLogicalPlan, ctx)
+      Await.result(
+        execPlan.dispatcher
+          .dispatch(ExecPlanWithClientParams(execPlan, ClientParams(60000), querySession),
+            UnsupportedChunkSource())
+          .map {
+            case _: QueryResult => flightSpSucceeded.incrementAndGet()
+            case _: QueryError  => flightSpFailed.incrementAndGet()
+          }
+          .runToFuture,
+        60.seconds)
+    } finally {
+      flightAlloc.close()
+    }
+  }
+
+  // =========================================================================
+  // Latency benchmark — Akka single-partition path (SampleTime, no queuing)
+  // =========================================================================
+  @Benchmark
+  @BenchmarkMode(Array(Mode.SampleTime))
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  def akkaSinglePartitionLatency(): Unit = {
+    val ctx          = mkCtx()
+    val querySession = QuerySession(ctx, queryConfig)
+    val execPlan     = akkaPlanner.materialize(singlePartLogicalPlan, ctx)
+    Await.result(
+      execPlan.dispatcher
+        .dispatch(ExecPlanWithClientParams(execPlan, ClientParams(60000), querySession),
+          UnsupportedChunkSource())
+        .map {
+          case _: QueryResult => akkaSpSucceeded.incrementAndGet()
+          case _: QueryError  => akkaSpFailed.incrementAndGet()
+        }
+        .runToFuture,
+      60.seconds)
+  }
+
 }

--- a/jmh/src/main/scala/filodb.jmh/PopulateRvIntoVsrBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/PopulateRvIntoVsrBenchmark.scala
@@ -1,0 +1,108 @@
+package filodb.jmh
+
+import java.util.concurrent.TimeUnit
+
+import ch.qos.logback.classic.{Level, Logger}
+import org.apache.arrow.memory.RootAllocator
+import org.openjdk.jmh.annotations.{Level => JMHLevel, _}
+
+import filodb.coordinator.flight.ArrowSerializedRangeVectorOps
+import filodb.coordinator.flight.ArrowSerializedRangeVectorOps.VsrPopulationState
+import filodb.core.metadata.Column.ColumnType
+import filodb.core.query._
+import filodb.memory.format.{ZeroCopyUTF8String => UTF8Str}
+
+/**
+ * Measures ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs across four workloads:
+ *
+ *   smallRv        —  100 rows, single VSR (lightweight query response)
+ *   mediumRv       — 1 000 rows, single VSR (typical dense time series)
+ *   largeRvMultiVsr — maxNumRows + 100 rows, spills into a second VSR
+ *   multiSeriesRvs  — 100 RVs × 50 rows  (multi-series query result)
+ *
+ * Run with:
+ *   jmh/jmh:run -i 5 -wi 5 -f1 -t1 .*PopulateRvIntoVsr.*
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+class PopulateRvIntoVsrBenchmark {
+
+  org.slf4j.LoggerFactory.getLogger("filodb").asInstanceOf[Logger].setLevel(Level.ERROR)
+
+  private val allocator  = new RootAllocator(Long.MaxValue)
+  private val queryStats = QueryStats()
+
+  private val resSchema = new ResultSchema(Seq(
+    ColumnInfo("time", ColumnType.TimestampColumn),
+    ColumnInfo("value", ColumnType.DoubleColumn)
+  ), 1)
+  private val recSchema = resSchema.toRecordSchema
+
+  private val baseKey = CustomRangeVectorKey(Map(
+    UTF8Str("metric") -> UTF8Str("bench_metric"),
+    UTF8Str("host")   -> UTF8Str("server1")
+  ))
+
+  private val smallRvData     = makeData(100)
+  private val mediumRvData    = makeData(1_000)
+  private val largeRvData     = makeData(ArrowSerializedRangeVectorOps.maxNumRows + 100)
+  private val multiSeriesRvs  = (1 to 100).map { i =>
+    buildRv(makeData(50), CustomRangeVectorKey(Map(UTF8Str("host") -> UTF8Str(s"server$i"))))
+  }
+
+  private val smallRv      = buildRv(smallRvData, baseKey)
+  private val mediumRv     = buildRv(mediumRvData, baseKey)
+  private val largeRv      = buildRv(largeRvData, baseKey)
+
+  private def makeData(numRows: Int): IndexedSeq[(Long, Double)] =
+    (1 to numRows).map(i => (i.toLong * 60_000L, i.toDouble))
+
+  private def buildRv(samples: IndexedSeq[(Long, Double)], rvKey: RangeVectorKey): RangeVector = {
+    val range = RvRange(samples.head._1, 60_000L, samples.last._1)
+    new RangeVector {
+      import NoCloseCursor._
+      override def key: RangeVectorKey          = rvKey
+      override def rows(): RangeVectorCursor    = samples.map(r => new TransientRow(r._1, r._2)).iterator
+      override def outputRange: Option[RvRange] = Some(range)
+    }
+  }
+
+  // VsrPopulationState is mutable and accumulates VSRs; reset per invocation.
+  private var state: VsrPopulationState = _
+
+  @Setup(JMHLevel.Invocation)
+  def resetState(): Unit = state = VsrPopulationState()
+
+  @TearDown(JMHLevel.Invocation)
+  def freeVsrs(): Unit =
+    (state.finishedVsrs ++ Option(state.currentVsr)).foreach(_.close())
+
+  @TearDown(JMHLevel.Trial)
+  def closeAllocator(): Unit = allocator.close()
+
+  @Benchmark
+  def smallRvVsr(): Unit =
+    ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
+      smallRv, recSchema, "bench", queryStats, allocator, state)
+
+  @Benchmark
+  def mediumRvVsr(): Unit =
+    ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
+      mediumRv, recSchema, "bench", queryStats, allocator, state)
+
+  @Benchmark
+  def largeRvMultiVsr(): Unit =
+    ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
+      largeRv, recSchema, "bench", queryStats, allocator, state)
+
+  @Benchmark
+  def multiSeriesRvsVsr(): Unit =
+    multiSeriesRvs.foreach { rv =>
+      ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
+        rv, recSchema, "bench", queryStats, allocator, state)
+    }
+}

--- a/query/src/test/scala/filodb/query/exec/HistogramQuantileMapperSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/HistogramQuantileMapperSpec.scala
@@ -87,7 +87,7 @@ class HistogramQuantileMapperSpec extends AnyFunSpec with Matchers with ScalaFut
       IteratorBackedRangeVector(histBuckets2(i), rv.map(s => new TransientRow(s._1, s._2.toDouble)).toIterator, None)
     }
 
-    val expectedResult = Seq(histKey2 -> quantile50Result, histKey1 -> quantile50Result)
+    val expectedResult = Seq(histKey1 -> quantile50Result, histKey2 -> quantile50Result)
     calculateAndVerify(0.5, histRvs, expectedResult)
   }
 

--- a/query/src/test/scala/filodb/query/exec/rangefn/SortFunctionSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/SortFunctionSpec.scala
@@ -161,11 +161,11 @@ class SortFunctionSpec extends AnyFunSpec with Matchers with ScalaFutures {
    )
    val resultAgg = resultObs2.toListL.runToFuture.futureValue
    resultAgg.size shouldEqual 2
-   resultAgg.flatMap(_.rows().map(_.getDouble(1)).toList) shouldEqual(List(5.0, 1.0))
+   resultAgg.flatMap(_.rows().map(_.getDouble(1)).toList) shouldEqual(List(1.0, 5.0))
    
-   val sortFunctionMapper = exec.SortFunctionMapper(SortFunctionId.Sort)
+   val sortFunctionMapper = exec.SortFunctionMapper(SortFunctionId.SortDesc)
    val resultObs = sortFunctionMapper(resultObs2, querySession, 1000, resultSchema, Nil)
    val resultRows = resultObs.toListL.runToFuture.futureValue.flatMap(_.rows().map(_.getDouble(1)).toList)
-   resultRows.shouldEqual(List(1.0, 5.0))
+   resultRows.shouldEqual(List(5.0, 1.0))
  }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

This PR achieves two things:
* Eliminates the on-heap RecordBuilder → Arrow copy in populateRvContentsIntoVsrs. A new SingleRecordBuilder writes BinaryRecords directly into the Arrow VarBinaryVector's off-heap data buffer. This avoids heap allocation in the hot path and improves performance in the arrow flight rpc path
* Migrates flight metadata (header, footer, RV metadata) from Kryo to Protobuf, removing the RvMetadata/RespHeader/RespFooter Kryo-registered classes. This fixes tech debt of using kryo for cross-partition calls.


Refactor of RecordBuilder was done very carefully:
* extensive unit tests were added, refactor was done without any semantic edits to code, thus RecordBuilder(new) + RecordBuilderBase == RecordBuilder(old)
* old tests were rerun to ensure none failed

