### PR TITLE
fix(index): Fixing name collision for label tags in tantivy index (#2219)

### DIFF
--- a/core/src/rust/filodb_core/src/query_parser.rs
+++ b/core/src/rust/filodb_core/src/query_parser.rs
@@ -176,6 +176,97 @@ fn value_with_prefix(prefix: &str, value: &str) -> String {
     )
 }
 
+/// Resolve a field name to a (Field, prefix) pair, handling JSON map columns.
+///
+/// When the field name matches the JSON (map) column itself, we treat it as a
+/// subfield lookup within that JSON column rather than a direct field query.
+/// This handles the case where a label has the same name as the map column
+/// (e.g., a label "tags" inside a map column also named "tags").
+///
+/// # Why this is needed
+///
+/// ```text
+///   Indexed columns:
+///     ┌────────────┐  ┌────────────┐  ┌────────────┐
+///     │   _ws_     │  │   _ns_     │  │  __name__  │  ← real indexed columns
+///     └────────────┘  └────────────┘  └────────────┘
+///
+///   JSON map column (the "default field"):
+///     ┌─────────────────────────────────────────────┐
+///     │   tags  (JSON column)                       │
+///     │                                             │
+///     │   { "instance": "i-001",                    │
+///     │     "job": "node",                          │
+///     │     "tags": "some-value"  ← LABEL named     │
+///     │   }                          same as column │
+///     └─────────────────────────────────────────────┘
+///
+///   Query: tags="some-value"
+///
+///   Behavior WITHOUT this function
+///   ----------------------------------------
+///         schema.find_field_with_default("tags", Some(json_field))
+///                │
+///                │ "tags" IS an indexed field name (the JSON column itself!)
+///                │ So it returns the JSON column directly with empty prefix
+///                │
+///                ▼
+///         returns (json_field, "")         ← prefix = empty
+///                │
+///                ▼
+///         value_with_prefix("", "some-value") → "some-value"
+///                │
+///                ▼
+///         TermQuery: search json_field for literal value "some-value"
+///                │
+///                ▼
+///         ✗ WRONG — searches the entire JSON blob for literal "some-value"
+///            misses documents where "tags" subfield = "some-value"
+///
+///         Behavior WITH this function
+///       ----------------------------------------
+///         schema.find_field_with_default("tags", Some(json_field))
+///                │
+///                │ Returns (json_field, "")
+///                ▼
+///
+///         resolve_field_with_default checks:
+///            prefix.is_empty() && default_field == Some(field)
+///            ↑                    ↑
+///            "no prefix"          "and the field IS the default JSON field"
+///            │
+///            │ This means: the user's field name matches the JSON column name
+///            │             → they actually want a subfield lookup
+///            │
+///            ▼
+///         returns (json_field, "tags")     ← prefix = the field name itself
+///                │
+///                ▼
+///         value_with_prefix("tags", "some-value") → "tags\0ssome-value"
+///                │
+///                ▼
+///         TermQuery: search json_field for "tags\0ssome-value"
+///                │
+///                ▼
+///         ✓ CORRECT — finds documents where the "tags" subfield in JSON = "some-value"
+/// ```
+fn resolve_field_with_default<'a>(
+    schema: &'a Schema,
+    default_field: Option<Field>,
+    field_name: &'a str,
+) -> Option<(Field, &'a str)> {
+    let (field, prefix) = schema.find_field_with_default(field_name, default_field)?;
+
+    // If the resolved field is the default JSON field and the prefix is empty,
+    // it means the field name matched the JSON column name directly. Treat the
+    // field name as a subfield path within the JSON column instead.
+    if prefix.is_empty() && default_field == Some(field) {
+        Some((field, field_name))
+    } else {
+        Some((field, prefix))
+    }
+}
+
 /// Build a query using a specified field and value, handling JSON
 /// fields
 ///
@@ -194,7 +285,7 @@ fn query_with_field_and_value<T>(
 where
     T: FnOnce(Field, &str) -> Result<Box<dyn Query>, TantivyError>,
 {
-    let Some((field, prefix)) = schema.find_field_with_default(field, default_field) else {
+    let Some((field, prefix)) = resolve_field_with_default(schema, default_field, field) else {
         // If it's an invalid field then map to an empty query, which will emulate Lucene's behavior
         return Ok(Box::new(EmptyQuery));
     };
@@ -251,7 +342,7 @@ fn parse_term_in_query<'a>(
     for _ in 0..term_count {
         let (input, text) = parse_string(next_input)?;
 
-        if let Some((field, prefix)) = schema.find_field_with_default(&column, default_field) {
+        if let Some((field, prefix)) = resolve_field_with_default(schema, default_field, &column) {
             terms.push(Term::from_field_text(
                 field,
                 &value_with_prefix(prefix, &text),
@@ -311,12 +402,17 @@ fn parse_long_range_query<'a>(
 #[cfg(test)]
 mod tests {
     use bytes::BufMut;
-    use tantivy::{collector::DocSetCollector, query::Occur};
-    use tantivy_utils::field_constants::PART_ID;
+    use tantivy::{
+        collector::DocSetCollector,
+        query::Occur,
+        schema::{JsonObjectOptions, TextFieldIndexing, FAST, INDEXED, STORED, STRING},
+        Index, TantivyDocument,
+    };
+    use tantivy_utils::field_constants::{self, PART_ID};
 
     use tantivy_utils::test_utils::{
-        build_test_schema, COL1_NAME, COL2_NAME, JSON_ATTRIBUTE1_NAME, JSON_ATTRIBUTE2_NAME,
-        JSON_COL_NAME,
+        build_test_schema, TestIndex, COL1_NAME, COL2_NAME, JSON_ATTRIBUTE1_NAME,
+        JSON_ATTRIBUTE2_NAME, JSON_COL_NAME,
     };
 
     use super::*;
@@ -994,5 +1090,204 @@ mod tests {
         let err = parse_long_range_query(&buf, &index.schema, None).expect_err("Should fail");
 
         assert_eq!(format!("{err}"), "Parsing Error: Nom(Eof)");
+    }
+
+    /// Build a test index where the JSON column has an attribute with the same name
+    /// as the JSON column itself (e.g., json_col.json_col = "collision_value").
+    /// This reproduces the bug where a label "tags" inside a MapColumn also named "tags"
+    /// would fail to match when filtered.
+    #[allow(clippy::unwrap_used)]
+    fn build_map_column_collision_schema() -> TestIndex {
+        use tantivy::schema::SchemaBuilder;
+
+        let mut builder = SchemaBuilder::new();
+
+        builder.add_text_field(COL1_NAME, STRING | FAST);
+        builder.add_i64_field(field_constants::PART_ID, INDEXED | FAST);
+        builder.add_i64_field(field_constants::START_TIME, INDEXED | FAST);
+        builder.add_i64_field(field_constants::END_TIME, INDEXED | FAST);
+        builder.add_bytes_field(field_constants::PART_KEY, INDEXED | FAST | STORED);
+        builder.add_json_field(
+            JSON_COL_NAME,
+            JsonObjectOptions::default()
+                .set_indexing_options(TextFieldIndexing::default().set_tokenizer("raw"))
+                .set_fast(Some("raw")),
+        );
+
+        let schema = builder.build();
+        let index = Index::create_in_ram(schema.clone());
+
+        {
+            let mut writer = index.writer::<TantivyDocument>(50_000_000).unwrap();
+
+            // Document where JSON column has an attribute with the SAME name as the column
+            let doc = TantivyDocument::parse_json(
+                &schema,
+                &format!(
+                    r#"{{
+                    "col1": "ABC",
+                    "__partIdDv__": 1,
+                    "__startTime__": 1000,
+                    "__endTime__": 2000,
+                    "__partKey__": "QUE=",
+                    "{JSON_COL_NAME}": {{
+                        "{JSON_COL_NAME}": "collision_value",
+                        "other_attr": "other"
+                    }}
+                }}"#
+                ),
+            )
+            .unwrap();
+
+            writer.add_document(doc).unwrap();
+
+            // Document without the collision attribute
+            let doc = TantivyDocument::parse_json(
+                &schema,
+                &format!(
+                    r#"{{
+                    "col1": "DEF",
+                    "__partIdDv__": 2,
+                    "__startTime__": 1000,
+                    "__endTime__": 2000,
+                    "__partKey__": "QkI=",
+                    "{JSON_COL_NAME}": {{
+                        "other_attr": "something"
+                    }}
+                }}"#
+                ),
+            )
+            .unwrap();
+
+            writer.add_document(doc).unwrap();
+            writer.commit().unwrap();
+        }
+
+        let reader = index.reader().unwrap();
+        let searcher = reader.searcher();
+        let json_field = schema.get_field(JSON_COL_NAME).unwrap();
+
+        TestIndex {
+            schema,
+            searcher,
+            json_field,
+        }
+    }
+
+    #[test]
+    fn test_parse_equals_map_column_name_collision() {
+        let index = build_map_column_collision_schema();
+
+        let mut buf = vec![];
+
+        // Filter on the JSON column name itself (e.g., tags="collision_value")
+        let filter = "collision_value";
+
+        buf.put_u16_le(JSON_COL_NAME.len() as u16);
+        buf.put_slice(JSON_COL_NAME.as_bytes());
+        buf.put_u16_le(filter.len() as u16);
+        buf.put_slice(filter.as_bytes());
+
+        let (_, query) = parse_equals_query(&buf, &index.schema, Some(index.json_field))
+            .expect("Should succeed");
+
+        let unboxed = query.downcast_ref::<TermQuery>().unwrap();
+
+        // Should resolve to the JSON field with the column name as prefix
+        assert_eq!(
+            unboxed.term().field(),
+            index.schema.get_field(JSON_COL_NAME).unwrap()
+        );
+        assert_eq!(
+            unboxed.term().value().as_str().unwrap(),
+            format!("{JSON_COL_NAME}\0s{filter}")
+        );
+
+        let collector = DocSetCollector;
+        let results = index
+            .searcher
+            .search(&query, &collector)
+            .expect("Should succeed");
+
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_regex_map_column_name_collision() {
+        let index = build_map_column_collision_schema();
+
+        let mut buf = vec![];
+
+        let filter = "collision.*";
+
+        buf.put_u16_le(JSON_COL_NAME.len() as u16);
+        buf.put_slice(JSON_COL_NAME.as_bytes());
+        buf.put_u16_le(filter.len() as u16);
+        buf.put_slice(filter.as_bytes());
+
+        let (_, query) =
+            parse_regex_query(&buf, &index.schema, Some(index.json_field)).expect("Should succeed");
+
+        let collector = DocSetCollector;
+        let results = index
+            .searcher
+            .search(&query, &collector)
+            .expect("Should succeed");
+
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_term_in_map_column_name_collision() {
+        let index = build_map_column_collision_schema();
+
+        let mut buf = vec![];
+
+        let filter1 = "collision_value";
+        let filter2 = "nonexistent";
+
+        buf.put_u16_le(JSON_COL_NAME.len() as u16);
+        buf.put_slice(JSON_COL_NAME.as_bytes());
+        buf.put_u16_le(2u16); // 2 terms
+        buf.put_u16_le(filter1.len() as u16);
+        buf.put_slice(filter1.as_bytes());
+        buf.put_u16_le(filter2.len() as u16);
+        buf.put_slice(filter2.as_bytes());
+
+        let (_, query) = parse_term_in_query(&buf, &index.schema, Some(index.json_field))
+            .expect("Should succeed");
+
+        let collector = DocSetCollector;
+        let results = index
+            .searcher
+            .search(&query, &collector)
+            .expect("Should succeed");
+
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_prefix_map_column_name_collision() {
+        let index = build_map_column_collision_schema();
+
+        let mut buf = vec![];
+
+        let filter = "collision";
+
+        buf.put_u16_le(JSON_COL_NAME.len() as u16);
+        buf.put_slice(JSON_COL_NAME.as_bytes());
+        buf.put_u16_le(filter.len() as u16);
+        buf.put_slice(filter.as_bytes());
+
+        let (_, query) = parse_prefix_query(&buf, &index.schema, Some(index.json_field))
+            .expect("Should succeed");
+
+        let collector = DocSetCollector;
+        let results = index
+            .searcher
+            .search(&query, &collector)
+            .expect("Should succeed");
+
+        assert_eq!(results.len(), 1);
     }
 }

--- a/core/src/rust/filodb_core/src/reader.rs
+++ b/core/src/rust/filodb_core/src/reader.rs
@@ -274,7 +274,16 @@ fn query_label_values(
         .find_field_with_default(&field, handle.default_field);
 
     if let Some((f, prefix)) = field_and_prefix {
-        if !prefix.is_empty() {
+        // When the field name resolves directly to the JSON (map) column and it
+        // IS the default field, treat the field name as a subfield path within
+        // the JSON column. This handles labels that share a name with the map column.
+        let is_map_column_self_ref = prefix.is_empty() && handle.default_field == Some(f);
+
+        if is_map_column_self_ref {
+            let field_name = handle.schema.get_field_entry(f).name();
+            let subfield = field.clone();
+            field = format!("{field_name}.{subfield}");
+        } else if !prefix.is_empty() {
             let field_name = handle.schema.get_field_entry(f).name();
             field = format!("{field_name}.{prefix}");
         }

--- a/core/src/test/scala/filodb.core/memstore/PartKeyTantivyIndexSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/PartKeyTantivyIndexSpec.scala
@@ -142,4 +142,62 @@ class PartKeyTantivyIndexSpec extends AnyFunSpec with Matchers with BeforeAndAft
       -1, -1, -1, -1, -1, -1, -1, 127, // Long.MAX_VALUE
       0) // End boolean
   }
+
+  it("should filter correctly when a label has the same name as the map column") {
+    import filodb.core.MachineMetricsData
+    import filodb.memory.format.ZeroCopyUTF8String.StringToUTF8
+
+    // dataset2 has partition schema: Seq("series:string", "tags:map")
+    // This reproduces the production schema where the MapColumn is named "tags"
+    val ds = MachineMetricsData.dataset2
+    val tmpDir = java.nio.file.Files.createTempDirectory("part-key-tantivy-map-collision-test").toFile
+    val mapIndex = new PartKeyTantivyIndex(ds.ref, ds.schema.partition, 0, 1.hour.toMillis, Some(tmpDir))
+
+    try {
+      mapIndex.reset()
+      mapIndex.refreshReadersBlocking()
+
+      // Create a partition key where the map includes a "tags" entry (same name as the MapColumn)
+      val tagsMap = Map("tags".utf8 -> "b1.metal".utf8,
+                        "cell".utf8 -> "A".utf8,
+                        "region".utf8 -> "us-central-2".utf8)
+      val seriesName = "test_metric"
+
+      partBuilder.partKeyFromObjects(ds.schema, seriesName, tagsMap)
+      val container = partBuilder.allContainers.head
+      val partKeyAddr = container.allOffsets(0)
+      val partKeyBytes = ds.partKeySchema.asByteArray(container.base, partKeyAddr)
+
+      val start = System.currentTimeMillis()
+      mapIndex.addPartKey(partKeyBytes, 0, start)()
+      mapIndex.refreshReadersBlocking()
+
+      val end = System.currentTimeMillis()
+
+      // Filtering by "cell" (a regular label, not colliding with MapColumn name) should work
+      val cellFilter = Seq(ColumnFilter("cell", Equals("A")))
+      val cellResults = mapIndex.partIdsFromFilters(cellFilter, start, end)
+      cellResults.length shouldEqual 1
+
+      // Filtering by "tags" (same name as the MapColumn) should also work
+      val tagsFilter = Seq(ColumnFilter("tags", Equals("b1.metal")))
+      val tagsResults = mapIndex.partIdsFromFilters(tagsFilter, start, end)
+      tagsResults.length shouldEqual 1
+
+      // Filtering by "tags" with a non-matching value should return no results
+      val tagsMissFilter = Seq(ColumnFilter("tags", Equals("nonexistent")))
+      val tagsMissResults = mapIndex.partIdsFromFilters(tagsMissFilter, start, end)
+      tagsMissResults.length shouldEqual 0
+
+      // Filtering by "tags" with regex should also work
+      val tagsRegexFilter = Seq(ColumnFilter("tags", EqualsRegex("b1\\..*")))
+      val tagsRegexResults = mapIndex.partIdsFromFilters(tagsRegexFilter, start, end)
+      tagsRegexResults.length shouldEqual 1
+
+    } finally {
+      mapIndex.closeIndex()
+      tmpDir.listFiles().foreach(_.delete())
+      tmpDir.delete()
+    }
+  }
 }


### PR DESCRIPTION
 Description:                                                                                                                                                                                             
                                                                                                                                                                                                           
  ## Summary                                                                                                                                                                                               
  - Fixes a bug where filtering by a label whose name matches the MapColumn name                                                                                                                           
    (e.g., `tags="b1.metal"` when the partition schema MapColumn is also named "tags")                                                                                                                     
    returns no data in the Tantivy index                                                                                                                                                                   
  - The root cause is Tantivy's `find_field_with_default` resolving the field name to                                                                                                                      
    the JSON field itself with an empty prefix, producing an incorrect query term                                                                                                                          
  - Group-by (`by (tags)`) was unaffected because it reads from partition key binary data                                                                                                                  
    directly, bypassing the index                                                                                                                                                                          
                                                                                                                                                                                                           
  ## Changes                                                                                                                                                                                               
  - Added `resolve_field_with_default()` in `query_parser.rs` that detects when a field                                                                                                                    
    name collides with the JSON column name and treats it as a subfield path                                                                                                                               
  - Applied the fix to equals, regex, prefix, and term-in query paths                                                                                                                                      
  - Applied equivalent fix in `reader.rs` for label value lookups                                                                                                                                          
                                                                                                                                                                                                           
  ## Test plan                                                                                                                                                                                             
  - [x] Rust unit tests: equals, regex, term-in, prefix with map column name collision                                                                                                                     
  - [x] Scala integration test: end-to-end indexing + querying with `tags:map` schema                                                                                                                      
  - [ ] Verify on deployment with `part-key-index-type = tantivy` that `tags="value"`                                                                                                                      
        filters now return correct results