### PR TITLE
fix(query): handle samplesScanned proto field

### DIFF
--- a/query/src/main/scala/filodb/query/ProtoConverters.scala
+++ b/query/src/main/scala/filodb/query/ProtoConverters.scala
@@ -428,6 +428,7 @@ object ProtoConverters {
       builder.setDataBytesScanned(stat.dataBytesScanned.get())
       builder.setTimeSeriesScanned(stat.timeSeriesScanned.get())
       builder.setCpuNanos(stat.cpuNanos.get())
+      builder.setSamplesScanned(stat.samplesScanned.get())
       builder.build()
     }
   }
@@ -439,6 +440,7 @@ object ProtoConverters {
       stat.dataBytesScanned.addAndGet(statGrpc.getDataBytesScanned)
       stat.resultBytes.addAndGet(statGrpc.getResultBytes)
       stat.cpuNanos.addAndGet(statGrpc.getCpuNanos)
+      stat.samplesScanned.addAndGet(statGrpc.getSamplesScanned)
       stat
     }
   }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Currently, `ProtoConverters` does not handle the `samplesScanned` field of `QueryStats`. This means the field is silently dropped when `QueryStats` is sent between partitions.

**New behavior :**
This PR adds `samplesScanned` handling to `ProtoConverters`. The field will now be correctly sent between partitions.