### PR TITLE
maint: add PRB actions/cache

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -19,6 +19,17 @@ jobs:
       with:
         java-version: '11'
         distribution: 'adopt'
+    - name: Cache SBT dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.ivy2/cache
+          ~/.sbt/boot
+          ~/.sbt/launchers
+          ~/.coursier/cache
+        key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt', '**/project/Dependencies.scala', '**/project/plugins.sbt', '**/project/build.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-sbt-
     - name: Install Rust Toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Currently, PRB dependencies are not cached. This causes `429` (rate-limiting) errors.


**New behavior :**

Add PRB dependency caches.

```
  Fix: Added actions/cache@v4 caching four directories:
  - ~/.ivy2/cache — Ivy/SBT resolved artifact cache (the main one)
  - ~/.sbt/boot — SBT launcher and Scala runtime downloads
  - ~/.sbt/launchers — SBT launcher JARs
  - ~/.coursier/cache — Coursier artifact cache (SBT 1.x uses Coursier under the hood)

  Cache key is a hash of the four build definition files (build.sbt, Dependencies.scala, plugins.sbt, build.properties). The key changes only when dependencies actually
  change, so most PRB runs will get a full cache hit. The restore-keys fallback means even a partial hit (e.g., after adding one new dep) avoids downloading the unchanged
  majority.
```


**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: