### PR TITLE
perf(query): prevent allocations during QueryStats updates

### DIFF
--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 
 import scala.collection.concurrent.TrieMap
-import scala.collection.mutable.SortedSet
+import scala.collection.mutable.{ArrayBuffer, SortedSet}
 import scala.concurrent.duration._
 
 import com.typesafe.scalalogging.StrictLogging
@@ -402,16 +402,162 @@ case class Stat() {
 
 case class QueryStats() {
 
-  val stat = TrieMap[Seq[String], Stat]()
+  private val stat = TrieMap[Seq[String], Stat]()
+
+  /**
+   * Stores all stats keys.
+   * Useful if e.g. keys need frequent iteration but Iterator
+   *   allocations should be prevented.
+   * Also useful for efficient size() calculation (as opposed to TrieMap.size(),
+   *   which allocates an Object on the heap and has some computation overhead).
+   */
+  private val keyBuffer = ArrayBuffer[Seq[String]]()
+
+  /**
+   * Set true if Nil is ever added as a key.
+   * Useful in cases where this needs to be known efficiently
+   *   (e.g. while samples-scanned counters are updated.)
+   */
+  @volatile private var containsNilKeyFlag = false
+
+  private val lock = new AnyRef
 
   override def toString: String = stat.toString()
 
-  def add(s: QueryStats): Unit = {
-    s.stat.foreach(kv => stat.getOrElseUpdate(kv._1, Stat()).add(kv._2))
+  /**
+   * Inserts a [[Stat]] into the [[QueryStats]].
+   * Overwrites existing value (if the argument key already exists).
+   * @param forceBufferAdd true to always add the key to the key buffer,
+   *   regardless of whether-or-not the trie already contains it.
+   *   "true" assumes the caller has already confirmed the key should be added.
+   */
+  private def putInternal(key: Seq[String],
+                          value: Stat,
+                          forceBufferAdd: Boolean = false): Unit = {
+    if (key.isEmpty) {
+      containsNilKeyFlag = true
+    }
+    lock.synchronized {
+      if (forceBufferAdd || !stat.contains(key)) {
+        keyBuffer.addOne(key)
+      }
+      stat.put(key, value)
+    }
   }
 
+  // scalastyle:off null
+  // NOTE: getOrElse(..., null) is used to avoid Option allocations.
+  /**
+   * Either returns the currently-stored [[Stat]] or returns a new,
+   *   empty one and adds it to the trie.
+   */
+  private def getOrAddEmptyStat(key: Seq[String]): Stat = {
+    // Two checks to avoid using `synchronized` for every call...
+    // First check: is the key already in the trie?
+    // If it is: just return its value.
+    val firstStat = stat.getOrElse(key, null)
+    if (firstStat == null) {
+      // Otherwise, grab the lock.
+      lock.synchronized {
+        // Second check: was it added just before we acquired the lock?
+        // If not, add it; else return its value.
+        val secondStat = stat.getOrElse(key, null)
+        if (secondStat == null) {
+          val newStat = Stat()
+          putInternal(key, newStat, forceBufferAdd = true)
+          newStat
+        } else secondStat
+      }
+    } else firstStat
+  }
+  // scalastyle:on null
+
+  /**
+   * Add the argument [[QueryStats]] counters to this [[QueryStats]]' counters.
+   */
+  def add(s: QueryStats): Unit = {
+    s.foreach(kv => getOrAddEmptyStat(kv._1).add(kv._2))
+  }
+
+  /**
+   * Returns all keys in the [[QueryStats]].
+   * NOTE: not intended to be performant.
+   */
+  def keys(): Seq[Seq[String]] = {
+    keyBuffer.clone().toSeq
+  }
+
+  /**
+   * Adds the (key, value) pair to the [[QueryStats]].
+   */
+  def put(key: Seq[String], value: Stat): Unit = {
+    putInternal(key, value)
+  }
+
+  /**
+   * Returns the value (if it exists).
+   */
+  def get(key: Seq[String]): Option[Stat] = {
+    stat.get(key)
+  }
+
+  /**
+   * Returns the count of elements in the [[QueryStats]].
+   */
+  def size(): Int = {
+    keyBuffer.size
+  }
+
+  /**
+   * Returns true iff the [[QueryStats]] contains Nil as a key.
+   * Useful in cases where this needs to be known efficiently
+   *   (e.g. while samples-scanned counters are updated.)
+   */
+  def containsNilKey(): Boolean = {
+    containsNilKeyFlag
+  }
+
+  /**
+   * Applies a mapper function to all entries of the [[QueryStats]].
+   */
+  def map[T](function: ((Seq[String], Stat)) => T): Iterable[T] = {
+    stat.map(function)
+  }
+
+  /**
+   * Zero-allocation foreach variant.
+   * Intended for high-performance scenarios where efficient
+   *   key processing is required.
+   *
+   * *** NOT THREAD-SAFE!!! ***
+   * Concurrent modification behavior is undefined!
+   */
+  def foreachKey(consumer: Seq[String] => Unit): Unit = {
+    // NOTE: `while` avoids a Range allocation.
+    var i = 0
+    while (i < keyBuffer.size) {
+      consumer.apply(keyBuffer(i))
+      i += 1
+    }
+  }
+
+  /**
+   * Standard-fare foreach that applies a consumer to
+   *   every entry of the [[QueryStats]].
+   */
+  def foreach(consumer: ((Seq[String], Stat)) => Unit): Unit = {
+    stat.foreach(consumer)
+  }
+
+  /**
+   * Clear all entries from the [[QueryStats]].
+   */
   def clear(): Unit = {
-    stat.clear()
+    lock.synchronized {
+      stat.clear()
+      keyBuffer.clear()
+      containsNilKeyFlag = false
+    }
   }
 
   /**
@@ -422,7 +568,7 @@ case class QueryStats() {
    */
   def getTimeSeriesScannedCounter(group: Seq[String] = Nil): AtomicLong = {
     val theNs = if (group.isEmpty && stat.size == 1) stat.head._1 else group
-    stat.getOrElseUpdate(theNs, Stat()).timeSeriesScanned
+    getOrAddEmptyStat(theNs).timeSeriesScanned
   }
 
   /**
@@ -433,7 +579,7 @@ case class QueryStats() {
    */
   def getDataBytesScannedCounter(group: Seq[String] = Nil): AtomicLong = {
     val theNs = if (group.isEmpty && stat.size == 1) stat.head._1 else group
-    stat.getOrElseUpdate(theNs, Stat()).dataBytesScanned
+    getOrAddEmptyStat(theNs).dataBytesScanned
   }
 
   /**
@@ -444,7 +590,7 @@ case class QueryStats() {
    */
   def getSamplesScannedCounter(group: Seq[String] = Nil): AtomicLong = {
     val theNs = if (group.isEmpty && stat.size == 1) stat.head._1 else group
-    stat.getOrElseUpdate(theNs, Stat()).samplesScanned
+    getOrAddEmptyStat(theNs).samplesScanned
   }
 
   /**
@@ -455,7 +601,7 @@ case class QueryStats() {
    */
   def getResultBytesCounter(group: Seq[String] = Nil): AtomicLong = {
     val theNs = if (group.isEmpty && stat.size == 1) stat.head._1 else group
-    stat.getOrElseUpdate(theNs, Stat()).resultBytes
+    getOrAddEmptyStat(theNs).resultBytes
   }
 
   /**
@@ -467,7 +613,7 @@ case class QueryStats() {
    */
   def getCpuNanosCounter(group: Seq[String] = Nil): AtomicLong = {
     val theNs = if (group.isEmpty && stat.size == 1) stat.head._1 else group
-    stat.getOrElseUpdate(theNs, Stat()).cpuNanos
+    getOrAddEmptyStat(theNs).cpuNanos
   }
 
   def totalCpuNanos: Long = stat.valuesIterator.map(_.cpuNanos.get()).sum

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -449,11 +449,12 @@ case class QueryStats() {
    *   an error will be thrown if this is "true" but the entry does not exist.
    */
   private def getNullableStat(key: Seq[String],
-                              entryConfirmedExists: Boolean = false): Stat = {
+                              entryConfirmedExists: Boolean = false,
+                              acquireReadLock: Boolean = true): Stat = {
     // NOTE: cannot acquire the lock after the first "return null"
     //   short-circuit; if clear() is called just after we get the
     //   index, we will access an index that does not exist!
-    readLock.lock()
+    if (acquireReadLock) readLock.lock()
     try {
       val index = getNullableIndex(key, entryConfirmedExists)
       if (index == null) {
@@ -461,7 +462,7 @@ case class QueryStats() {
       }
       entries(index)._2
     } finally {
-      readLock.unlock()
+      if (acquireReadLock) readLock.unlock()
     }
   }
   // scalastyle:on null
@@ -560,53 +561,64 @@ case class QueryStats() {
     Option(getNullableStat(key))
   }
 
+  // NOTE: Safe to be called from samples-scanned infrastructure;
+  //   all QueryStats entries are added by the time any samples-scanned-
+  //   tracking method is called.
   /**
    * Returns the count of elements in the [[QueryStats]].
+   *
+   * *** THREAD-SAFETY NOTE ***
+   * This method *can* be called concurrently with any other that
+   *   does not add/remove [[QueryStats]] entries.
+   * It *cannot* be called concurrently with any method that
+   *   adds/removes [[QueryStats]] entries.
    */
-  def size(): Int = {
-    readLock.lock()
-    try {
-      entries.size
-    } finally {
-      readLock.unlock()
-    }
+  def unsafeSize(): Int = {
+    entries.size
   }
 
+  // NOTE: Safe to be called from samples-scanned infrastructure;
+  //   all QueryStats entries are added by the time any samples-scanned-
+  //   tracking method is called.
   /**
    * Adds a total sample count to the argument [[QueryStats]]; the total is divided
    *   evenly across all samples-scanned counters.
    * NOTE: if Nil is the only [[QueryStats]] key, all samples are counted
    *   against it. If Nil exists with other keys, samples are divided
    *   among the non-Nil keys only.
+   *
+   * *** THREAD-SAFETY NOTE ***
+   * This method *can* be called concurrently with itself or any other method
+   *   that does not add/remove [[QueryStats]] entries.
+   * It *cannot* be called concurrently with any method
+   *   that adds/removes [[QueryStats]] entries.
    */
-  def addSamplesScanned(totalSampleCount: Long): Unit = {
-    readLock.lock()
-    try {
-      // QueryStats keys are updated for all except Nil *unless* Nil
-      //   is the only entry. Nil is sometimes added to QueryStats as a default.
-      val hasSingleEmptyKey = size() == 1 && containsNilKey
-      if (hasSingleEmptyKey) {
-        getNullableStat(Nil, entryConfirmedExists = true)
-          .samplesScanned.addAndGet(totalSampleCount)
-        return
-      }
+  def unsafeAddSamplesScanned(totalSampleCount: Long): Unit = {
+    // NOTE: this method is called O(num_series) times; it must be super efficient.
+    //   No locks are acquired below, and allocations are skipped wherever possible.
 
-      val nonNilKeyCount = size() - (if (containsNilKey) 1 else 0)
-      val samplesPerCounter = Math.ceil(
-        totalSampleCount.asInstanceOf[Double] / nonNilKeyCount
-      ).asInstanceOf[Long]
+    // QueryStats keys are updated for all except Nil *unless* Nil
+    //   is the only entry. Nil is sometimes added to QueryStats as a default.
+    val hasSingleEmptyKey = unsafeSize() == 1 && containsNilKey
+    if (hasSingleEmptyKey) {
+      getNullableStat(Nil, entryConfirmedExists = true, acquireReadLock = false)
+        .samplesScanned.addAndGet(totalSampleCount)
+      return
+    }
 
-      // NOTE: `while` avoids a Range allocation.
-      var i = 0
-      while (i < entries.size) {
-        val (key, stat) = entries(i)
-        if (key.nonEmpty) {
-          stat.samplesScanned.addAndGet(samplesPerCounter)
-        }
-        i += 1
+    val nonNilKeyCount = unsafeSize() - (if (containsNilKey) 1 else 0)
+    val samplesPerCounter = Math.ceil(
+      totalSampleCount.asInstanceOf[Double] / nonNilKeyCount
+    ).asInstanceOf[Long]
+
+    // NOTE: `while` avoids a Range allocation.
+    var i = 0
+    while (i < unsafeSize()) {
+      val (key, stat) = entries(i)
+      if (key.nonEmpty) {
+        stat.samplesScanned.addAndGet(samplesPerCounter)
       }
-    } finally {
-      readLock.unlock()
+      i += 1
     }
   }
 

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -424,7 +424,14 @@ case class QueryStats() {
   private val readLock = lock.readLock()
   private val writeLock = lock.writeLock()
 
-  override def toString: String = entries.toString()
+  override def toString: String = {
+    readLock.lock()
+    try {
+      entries.toString()
+    } finally {
+      readLock.unlock()
+    }
+  }
 
   // scalastyle:off null
   // NOTE: null is used to avoid Option allocations.

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -417,7 +417,7 @@ case class QueryStats() {
    * Useful in cases where this needs to be known efficiently
    *   (e.g. while samples-scanned counters are updated).
    **/
-  @volatile private var containsNilKeyFlag = false;
+  @volatile private var containsNilKey = false;
 
   private val lock = new AnyRef
 
@@ -465,7 +465,7 @@ case class QueryStats() {
                           value: Stat,
                           entryConfirmedNotPresent: Boolean = false): Unit = {
     if (key.isEmpty) {
-      containsNilKeyFlag = true
+      containsNilKey = true
     }
     lock.synchronized {
       if (entryConfirmedNotPresent || !keyToEntryIndex.contains(key)) {
@@ -507,20 +507,25 @@ case class QueryStats() {
 
   /**
    * Add the argument [[QueryStats]]' counters to this [[QueryStats]]' counters.
+   *
+   * *** NOT THREAD-SAFE!!! ***
+   * Concurrent modification of *argument* [[QueryStats]] gives undefined behavior!
+   * This [[QueryStats]] may be concurrently modified.
    */
   def add(s: QueryStats): Unit = {
-    lock.synchronized {
-      // Lock is required to prevent concurrent modification while
-      //   iterating entries; foreach is not thread-safe.
-      s.foreach(kv => getOrAddEmptyStat(kv._1).add(kv._2))
+    var i = 0
+    while (i < s.entries.size) {
+      val (key, value) = s.entries(i)
+      getOrAddEmptyStat(key).add(value)
+      i += 1
     }
   }
 
   /**
    * Returns all keys in the [[QueryStats]].
-   * NOTE: not intended to be performant and only exists to support tests.
+   * NOTE: not intended to be highly performant.
    *
-   * * *** NOT THREAD-SAFE!!! ***
+   * *** NOT THREAD-SAFE!!! ***
    * Concurrent modification behavior is undefined!
    */
   def keys(): Seq[Seq[String]] = {
@@ -532,18 +537,6 @@ case class QueryStats() {
    */
   def put(key: Seq[String], value: Stat): Unit = {
     putInternal(key, value)
-  }
-
-  /**
-   * Returns true iff Nil is a key of the [[QueryStats]].
-   * Useful in cases where this needs to be known efficiently
-   *   (e.g. while samples-scanned counters are updated).
-   *
-   * *** NOT THREAD-SAFE!!! ***
-   * Concurrent modification behavior is undefined!
-   * */
-  def containsNilKey(): Boolean = {
-    containsNilKeyFlag
   }
 
   /**
@@ -564,24 +557,61 @@ case class QueryStats() {
   }
 
   /**
-   * Zero-allocation foreach variant.
-   * Intended for high-performance scenarios where efficient
-   *   key processing is required.
+   * Adds a total sample count to the argument [[QueryStats]]; the total is divided
+   *   evenly across all samples-scanned counters.
+   * NOTE: if Nil is the only [[QueryStats]] key, all samples are counted
+   *   against it. If Nil exists with other keys, samples are divided
+   *   among the non-Nil keys only.
    *
    * *** NOT THREAD-SAFE!!! ***
    * Concurrent modification behavior is undefined!
    */
-  def foreach(consumer: ((Seq[String], Stat)) => Unit): Unit = {
+  def addSamplesScanned(totalSampleCount: Long): Unit = {
+    // QueryStats keys are updated for all except Nil *unless* Nil
+    //   is the only entry. Nil is sometimes added to QueryStats as a default.
+    val hasSingleEmptyKey = size() == 1 && containsNilKey
+    if (hasSingleEmptyKey) {
+      getNullableStat(Nil, entryConfirmedExists = true)
+        .samplesScanned.addAndGet(totalSampleCount)
+      return
+    }
+
+    val nonNilKeyCount = size() - (if (containsNilKey) 1 else 0)
+    val samplesPerCounter = Math.ceil(
+      totalSampleCount.asInstanceOf[Double] / nonNilKeyCount
+    ).asInstanceOf[Long]
+
     // NOTE: `while` avoids a Range allocation.
     var i = 0
     while (i < entries.size) {
-      consumer.apply(entries(i))
+      val (key, stat) = entries(i)
+      if (key.nonEmpty) {
+        stat.samplesScanned.addAndGet(samplesPerCounter)
+      }
       i += 1
     }
   }
 
+   /**
+    * Zero-allocation foreach variant.
+    * Intended for high-performance scenarios where efficient
+    *   key processing is required.
+    *
+    * *** NOT THREAD-SAFE!!! ***
+    * Concurrent modification behavior is undefined!
+    */
+   def foreach(consumer: ((Seq[String], Stat)) => Unit): Unit = {
+     // NOTE: `while` avoids a Range allocation.
+     var i = 0
+     while (i < entries.size) {
+       consumer.apply(entries(i))
+       i += 1
+     }
+   }
+
   /**
    * Applies a mapper function to all entries of the [[QueryStats]].
+   * NOTE: not intended to be highly performant.
    *
    * *** NOT THREAD-SAFE!!! ***
    * Concurrent modification behavior is undefined!
@@ -597,7 +627,7 @@ case class QueryStats() {
     lock.synchronized {
       entries.clear()
       keyToEntryIndex.clear()
-      containsNilKeyFlag = false
+      containsNilKey = false
     }
   }
 

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -2,6 +2,7 @@ package filodb.core.query
 
 import java.util.UUID
 import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
+import java.util.concurrent.locks.ReentrantReadWriteLock
 
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.{ArrayBuffer, SortedSet}
@@ -419,7 +420,9 @@ case class QueryStats() {
    **/
   @volatile private var containsNilKey = false;
 
-  private val lock = new AnyRef
+  private val lock = new ReentrantReadWriteLock()
+  private val readLock = lock.readLock()
+  private val writeLock = lock.writeLock()
 
   override def toString: String = entries.toString()
 
@@ -432,6 +435,7 @@ case class QueryStats() {
    */
   private def getNullableIndex(key: Seq[String],
                                entryConfirmedExists: Boolean = false): Integer = {
+    // No locks required; keyToEntryIndex is a thread-safe data structure.
     if (entryConfirmedExists || keyToEntryIndex.contains(key)) keyToEntryIndex(key) else null
   }
   // scalastyle:on null
@@ -446,11 +450,19 @@ case class QueryStats() {
    */
   private def getNullableStat(key: Seq[String],
                               entryConfirmedExists: Boolean = false): Stat = {
-    val index = getNullableIndex(key, entryConfirmedExists)
-    if (index == null) {
-      return null
+    // NOTE: cannot acquire the lock after the first "return null"
+    //   short-circuit; if clear() is called just after we get the
+    //   index, we will access an index that does not exist!
+    readLock.lock()
+    try {
+      val index = getNullableIndex(key, entryConfirmedExists)
+      if (index == null) {
+        return null
+      }
+      entries(index)._2
+    } finally {
+      readLock.unlock()
     }
-    entries(index)._2
   }
   // scalastyle:on null
 
@@ -464,10 +476,12 @@ case class QueryStats() {
   private def putInternal(key: Seq[String],
                           value: Stat,
                           entryConfirmedNotPresent: Boolean = false): Unit = {
-    if (key.isEmpty) {
-      containsNilKey = true
-    }
-    lock.synchronized {
+
+    writeLock.lock()
+    try {
+      if (key.isEmpty) {
+        containsNilKey = true
+      }
       if (entryConfirmedNotPresent || !keyToEntryIndex.contains(key)) {
         entries.addOne((key, value))
         keyToEntryIndex.put(key, entries.size - 1)
@@ -476,6 +490,8 @@ case class QueryStats() {
         val index = getNullableIndex(key, entryConfirmedExists = true)
         entries(index) = (key, value)
       }
+    } finally {
+      writeLock.unlock()
     }
   }
 
@@ -483,53 +499,51 @@ case class QueryStats() {
    * Either returns the currently-stored [[Stat]] or returns a new,
    *   empty one that is stored against the argument key.
    */
-  private def getOrAddEmptyStat(key: Seq[String]): Stat = {
-    // Two checks to avoid using `synchronized` for every call...
+  private def getOrPutEmptyStat(key: Seq[String]): Stat = {
+    // Two checks to avoid acquiring a lock for every call...
     // First check: is the key already in the trie?
     // If it is: just return its value.
     val hasKeyAtFirstCheck = keyToEntryIndex.contains(key)
-    if (!hasKeyAtFirstCheck) {
-      // Otherwise, grab the lock.
-      lock.synchronized {
-        // Second check: was it added just before we acquired the lock?
-        // If not, add it; else return its value.
-        val hasKeyAtSecondCheck = keyToEntryIndex.contains(key)
-        if (!hasKeyAtSecondCheck) {
-          val newStat = Stat()
-          putInternal(key, newStat, entryConfirmedNotPresent = true)
-          return newStat
-        }
-      }
+    if (hasKeyAtFirstCheck) {
+      return getNullableStat(key, entryConfirmedExists = true)
     }
-    // If we reach here, we've confirmed the entry already exists; return the value.
-    getNullableStat(key, entryConfirmedExists = true)
+    // Otherwise, grab the lock.
+    writeLock.lock()
+    try {
+      // Second check: was it added just before we acquired the lock?
+      // If not, add it; else return its value.
+      val hasKeyAtSecondCheck = keyToEntryIndex.contains(key)
+      if (!hasKeyAtSecondCheck) {
+        val newStat = Stat()
+        putInternal(key, newStat, entryConfirmedNotPresent = true)
+        newStat
+      } else {
+        // NOTE: calling this outside the lock might race with clear().
+        getNullableStat(key, entryConfirmedExists = true)
+      }
+    } finally {
+      writeLock.unlock()
+    }
   }
 
   /**
    * Add the argument [[QueryStats]]' counters to this [[QueryStats]]' counters.
-   *
-   * *** NOT THREAD-SAFE!!! ***
-   * Concurrent modification of *argument* [[QueryStats]] gives undefined behavior!
-   * This [[QueryStats]] may be concurrently modified.
    */
   def add(s: QueryStats): Unit = {
-    var i = 0
-    while (i < s.entries.size) {
-      val (key, value) = s.entries(i)
-      getOrAddEmptyStat(key).add(value)
-      i += 1
-    }
+    s.foreach { case (key, stat) => getOrPutEmptyStat(key).add(stat) }
   }
 
   /**
    * Returns all keys in the [[QueryStats]].
    * NOTE: not intended to be highly performant.
-   *
-   * *** NOT THREAD-SAFE!!! ***
-   * Concurrent modification behavior is undefined!
    */
   def keys(): Seq[Seq[String]] = {
-    entries.map(_._1).toSeq
+    readLock.lock()
+    try {
+      entries.map { case (key, stat) => key }.toSeq
+    } finally {
+      readLock.unlock()
+    }
   }
 
   /**
@@ -548,12 +562,14 @@ case class QueryStats() {
 
   /**
    * Returns the count of elements in the [[QueryStats]].
-   *
-   * *** NOT THREAD-SAFE!!! ***
-   * Concurrent modification behavior is undefined!
    */
   def size(): Int = {
-    entries.size
+    readLock.lock()
+    try {
+      entries.size
+    } finally {
+      readLock.unlock()
+    }
   }
 
   /**
@@ -562,72 +578,75 @@ case class QueryStats() {
    * NOTE: if Nil is the only [[QueryStats]] key, all samples are counted
    *   against it. If Nil exists with other keys, samples are divided
    *   among the non-Nil keys only.
-   *
-   * *** NOT THREAD-SAFE!!! ***
-   * Concurrent modification behavior is undefined!
    */
   def addSamplesScanned(totalSampleCount: Long): Unit = {
-    // QueryStats keys are updated for all except Nil *unless* Nil
-    //   is the only entry. Nil is sometimes added to QueryStats as a default.
-    val hasSingleEmptyKey = size() == 1 && containsNilKey
-    if (hasSingleEmptyKey) {
-      getNullableStat(Nil, entryConfirmedExists = true)
-        .samplesScanned.addAndGet(totalSampleCount)
-      return
-    }
-
-    val nonNilKeyCount = size() - (if (containsNilKey) 1 else 0)
-    val samplesPerCounter = Math.ceil(
-      totalSampleCount.asInstanceOf[Double] / nonNilKeyCount
-    ).asInstanceOf[Long]
-
-    // NOTE: `while` avoids a Range allocation.
-    var i = 0
-    while (i < entries.size) {
-      val (key, stat) = entries(i)
-      if (key.nonEmpty) {
-        stat.samplesScanned.addAndGet(samplesPerCounter)
+    readLock.lock()
+    try {
+      // QueryStats keys are updated for all except Nil *unless* Nil
+      //   is the only entry. Nil is sometimes added to QueryStats as a default.
+      val hasSingleEmptyKey = size() == 1 && containsNilKey
+      if (hasSingleEmptyKey) {
+        getNullableStat(Nil, entryConfirmedExists = true)
+          .samplesScanned.addAndGet(totalSampleCount)
+        return
       }
-      i += 1
+
+      val nonNilKeyCount = size() - (if (containsNilKey) 1 else 0)
+      val samplesPerCounter = Math.ceil(
+        totalSampleCount.asInstanceOf[Double] / nonNilKeyCount
+      ).asInstanceOf[Long]
+
+      // NOTE: `while` avoids a Range allocation.
+      var i = 0
+      while (i < entries.size) {
+        val (key, stat) = entries(i)
+        if (key.nonEmpty) {
+          stat.samplesScanned.addAndGet(samplesPerCounter)
+        }
+        i += 1
+      }
+    } finally {
+      readLock.unlock()
     }
   }
 
    /**
-    * Zero-allocation foreach variant.
-    * Intended for high-performance scenarios where efficient
-    *   key processing is required.
-    *
-    * *** NOT THREAD-SAFE!!! ***
-    * Concurrent modification behavior is undefined!
+    * Applies a consumer to each entry.
+    * NOTE: not intended to be highly performant.
     */
    def foreach(consumer: ((Seq[String], Stat)) => Unit): Unit = {
-     // NOTE: `while` avoids a Range allocation.
-     var i = 0
-     while (i < entries.size) {
-       consumer.apply(entries(i))
-       i += 1
+     readLock.lock()
+     try {
+       entries.foreach(consumer)
+     } finally {
+       readLock.unlock()
      }
    }
 
   /**
    * Applies a mapper function to all entries of the [[QueryStats]].
    * NOTE: not intended to be highly performant.
-   *
-   * *** NOT THREAD-SAFE!!! ***
-   * Concurrent modification behavior is undefined!
    */
   def map[T](function: ((Seq[String], Stat)) => T): Iterable[T] = {
-    entries.map(function)
+    readLock.lock()
+    try {
+      entries.map(function)
+    } finally {
+      readLock.unlock()
+    }
   }
 
   /**
    * Clear all entries from the [[QueryStats]].
    */
   def clear(): Unit = {
-    lock.synchronized {
+    writeLock.lock()
+    try {
       entries.clear()
       keyToEntryIndex.clear()
       containsNilKey = false
+    } finally {
+      writeLock.unlock()
     }
   }
 
@@ -639,7 +658,7 @@ case class QueryStats() {
    */
   def getTimeSeriesScannedCounter(group: Seq[String] = Nil): AtomicLong = {
     val theNs = if (group.isEmpty && keyToEntryIndex.size == 1) keyToEntryIndex.head._1 else group
-    getOrAddEmptyStat(theNs).timeSeriesScanned
+    getOrPutEmptyStat(theNs).timeSeriesScanned
   }
 
   /**
@@ -650,7 +669,7 @@ case class QueryStats() {
    */
   def getDataBytesScannedCounter(group: Seq[String] = Nil): AtomicLong = {
     val theNs = if (group.isEmpty && keyToEntryIndex.size == 1) keyToEntryIndex.head._1 else group
-    getOrAddEmptyStat(theNs).dataBytesScanned
+    getOrPutEmptyStat(theNs).dataBytesScanned
   }
 
   /**
@@ -661,7 +680,7 @@ case class QueryStats() {
    */
   def getSamplesScannedCounter(group: Seq[String] = Nil): AtomicLong = {
     val theNs = if (group.isEmpty && keyToEntryIndex.size == 1) keyToEntryIndex.head._1 else group
-    getOrAddEmptyStat(theNs).samplesScanned
+    getOrPutEmptyStat(theNs).samplesScanned
   }
 
   /**
@@ -672,7 +691,7 @@ case class QueryStats() {
    */
   def getResultBytesCounter(group: Seq[String] = Nil): AtomicLong = {
     val theNs = if (group.isEmpty && keyToEntryIndex.size == 1) keyToEntryIndex.head._1 else group
-    getOrAddEmptyStat(theNs).resultBytes
+    getOrPutEmptyStat(theNs).resultBytes
   }
 
   /**
@@ -684,17 +703,20 @@ case class QueryStats() {
    */
   def getCpuNanosCounter(group: Seq[String] = Nil): AtomicLong = {
     val theNs = if (group.isEmpty && keyToEntryIndex.size == 1) keyToEntryIndex.head._1 else group
-    getOrAddEmptyStat(theNs).cpuNanos
+    getOrPutEmptyStat(theNs).cpuNanos
   }
 
   /**
    * Returns the sum of CPU nanos for all entries.
-   *
-   * *** NOT THREAD-SAFE!!! ***
-   * Concurrent modification behavior is undefined!
    */
-  def totalCpuNanos: Long = entries.map(_._2).map(_.cpuNanos.get()).sum
-
+  def totalCpuNanos: Long = {
+    readLock.lock()
+    try {
+      entries.map { case (key, stat) => stat }.map(_.cpuNanos.get()).sum
+    } finally {
+      readLock.unlock()
+    }
+  }
 }
 
 object QuerySession {

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -402,89 +402,129 @@ case class Stat() {
 
 case class QueryStats() {
 
-  private val stat = TrieMap[Seq[String], Stat]()
-
   /**
-   * Stores all stats keys.
-   * Useful if e.g. keys need frequent iteration but Iterator
-   *   allocations should be prevented.
+   * Stores all stats entries.
+   * Helpful in scenarios where e.g. entries need frequent iteration but
+   *   Iterator allocations should be prevented.
    * Also useful for efficient size() calculation (as opposed to TrieMap.size(),
    *   which allocates an Object on the heap and has some computation overhead).
    */
-  private val keyBuffer = ArrayBuffer[Seq[String]]()
+  private val entries = ArrayBuffer[(Seq[String], Stat)]()
+  private val keyToEntryIndex = new TrieMap[Seq[String], Integer]()
 
   /**
    * Set true if Nil is ever added as a key.
    * Useful in cases where this needs to be known efficiently
-   *   (e.g. while samples-scanned counters are updated.)
-   */
-  @volatile private var containsNilKeyFlag = false
+   *   (e.g. while samples-scanned counters are updated).
+   **/
+  @volatile private var containsNilKeyFlag = false;
 
   private val lock = new AnyRef
 
-  override def toString: String = stat.toString()
+  override def toString: String = entries.toString()
+
+  // scalastyle:off null
+  // NOTE: null is used to avoid Option allocations.
+  /**
+   * Returns the index of the key's entry if it exists. Else returns null.
+   * @param entryConfirmedExists as an optimization, "true" skips "contains" checks;
+   *   an error will be thrown if this is "true" but the entry does not exist.
+   */
+  private def getNullableIndex(key: Seq[String],
+                               entryConfirmedExists: Boolean = false): Integer = {
+    if (entryConfirmedExists || keyToEntryIndex.contains(key)) keyToEntryIndex(key) else null
+  }
+  // scalastyle:on null
+
+  // scalastyle:off null
+  // NOTE: null is used to avoid Option allocations.
+  /**
+   * Returns the index of the key's entry if it exists. Else returns null.
+   * More efficient than public [[get]] because [[Option]] allocations are avoided.
+   * @param entryConfirmedExists as an optimization, "true" skips "contains" checks;
+   *   an error will be thrown if this is "true" but the entry does not exist.
+   */
+  private def getNullableStat(key: Seq[String],
+                              entryConfirmedExists: Boolean = false): Stat = {
+    val index = getNullableIndex(key, entryConfirmedExists)
+    if (index == null) {
+      return null
+    }
+    entries(index)._2
+  }
+  // scalastyle:on null
 
   /**
    * Inserts a [[Stat]] into the [[QueryStats]].
-   * Overwrites existing value (if the argument key already exists).
-   * @param forceBufferAdd true to always add the key to the key buffer,
-   *   regardless of whether-or-not the trie already contains it.
-   *   "true" assumes the caller has already confirmed the key should be added.
+   * If the argument key's entry already exists, the existing [[Stat]] is overwritten.
+   *
+   * @param entryConfirmedNotPresent as an optimization, "true" skips "contains" checks;
+   *   undefined behavior if this is "true" but the entry already exists.
    */
   private def putInternal(key: Seq[String],
                           value: Stat,
-                          forceBufferAdd: Boolean = false): Unit = {
+                          entryConfirmedNotPresent: Boolean = false): Unit = {
     if (key.isEmpty) {
       containsNilKeyFlag = true
     }
     lock.synchronized {
-      if (forceBufferAdd || !stat.contains(key)) {
-        keyBuffer.addOne(key)
+      if (entryConfirmedNotPresent || !keyToEntryIndex.contains(key)) {
+        entries.addOne((key, value))
+        keyToEntryIndex.put(key, entries.size - 1)
+      } else {
+        // The key's entry must exist if we've entered this block.
+        val index = getNullableIndex(key, entryConfirmedExists = true)
+        entries(index) = (key, value)
       }
-      stat.put(key, value)
     }
   }
 
-  // scalastyle:off null
-  // NOTE: getOrElse(..., null) is used to avoid Option allocations.
   /**
    * Either returns the currently-stored [[Stat]] or returns a new,
-   *   empty one and adds it to the trie.
+   *   empty one that is stored against the argument key.
    */
   private def getOrAddEmptyStat(key: Seq[String]): Stat = {
     // Two checks to avoid using `synchronized` for every call...
     // First check: is the key already in the trie?
     // If it is: just return its value.
-    val firstStat = stat.getOrElse(key, null)
-    if (firstStat == null) {
+    val hasKeyAtFirstCheck = keyToEntryIndex.contains(key)
+    if (!hasKeyAtFirstCheck) {
       // Otherwise, grab the lock.
       lock.synchronized {
         // Second check: was it added just before we acquired the lock?
         // If not, add it; else return its value.
-        val secondStat = stat.getOrElse(key, null)
-        if (secondStat == null) {
+        val hasKeyAtSecondCheck = keyToEntryIndex.contains(key)
+        if (!hasKeyAtSecondCheck) {
           val newStat = Stat()
-          putInternal(key, newStat, forceBufferAdd = true)
-          newStat
-        } else secondStat
+          putInternal(key, newStat, entryConfirmedNotPresent = true)
+          return newStat
+        }
       }
-    } else firstStat
+    }
+    // If we reach here, we've confirmed the entry already exists; return the value.
+    getNullableStat(key, entryConfirmedExists = true)
   }
-  // scalastyle:on null
 
   /**
-   * Add the argument [[QueryStats]] counters to this [[QueryStats]]' counters.
+   * Add the argument [[QueryStats]]' counters to this [[QueryStats]]' counters.
    */
   def add(s: QueryStats): Unit = {
-    s.foreach(kv => getOrAddEmptyStat(kv._1).add(kv._2))
+    lock.synchronized {
+      // Lock is required to prevent concurrent modification while
+      //   iterating entries; foreach is not thread-safe.
+      s.foreach(kv => getOrAddEmptyStat(kv._1).add(kv._2))
+    }
   }
 
   /**
    * Returns all keys in the [[QueryStats]].
-   * NOTE: not intended to be performant.
+   * NOTE: not intended to be performant and only exists to support tests.
+   *
+   * * *** NOT THREAD-SAFE!!! ***
+   * Concurrent modification behavior is undefined!
    */
   def keys(): Seq[Seq[String]] = {
-    keyBuffer.clone().toSeq
+    entries.map(_._1).toSeq
   }
 
   /**
@@ -495,33 +535,32 @@ case class QueryStats() {
   }
 
   /**
-   * Returns the value (if it exists).
-   */
-  def get(key: Seq[String]): Option[Stat] = {
-    stat.get(key)
-  }
-
-  /**
-   * Returns the count of elements in the [[QueryStats]].
-   */
-  def size(): Int = {
-    keyBuffer.size
-  }
-
-  /**
-   * Returns true iff the [[QueryStats]] contains Nil as a key.
+   * Returns true iff Nil is a key of the [[QueryStats]].
    * Useful in cases where this needs to be known efficiently
-   *   (e.g. while samples-scanned counters are updated.)
-   */
+   *   (e.g. while samples-scanned counters are updated).
+   *
+   * *** NOT THREAD-SAFE!!! ***
+   * Concurrent modification behavior is undefined!
+   * */
   def containsNilKey(): Boolean = {
     containsNilKeyFlag
   }
 
   /**
-   * Applies a mapper function to all entries of the [[QueryStats]].
+   * Returns the entry's value (if it exists).
    */
-  def map[T](function: ((Seq[String], Stat)) => T): Iterable[T] = {
-    stat.map(function)
+  def get(key: Seq[String]): Option[Stat] = {
+    Option(getNullableStat(key))
+  }
+
+  /**
+   * Returns the count of elements in the [[QueryStats]].
+   *
+   * *** NOT THREAD-SAFE!!! ***
+   * Concurrent modification behavior is undefined!
+   */
+  def size(): Int = {
+    entries.size
   }
 
   /**
@@ -532,21 +571,23 @@ case class QueryStats() {
    * *** NOT THREAD-SAFE!!! ***
    * Concurrent modification behavior is undefined!
    */
-  def foreachKey(consumer: Seq[String] => Unit): Unit = {
+  def foreach(consumer: ((Seq[String], Stat)) => Unit): Unit = {
     // NOTE: `while` avoids a Range allocation.
     var i = 0
-    while (i < keyBuffer.size) {
-      consumer.apply(keyBuffer(i))
+    while (i < entries.size) {
+      consumer.apply(entries(i))
       i += 1
     }
   }
 
   /**
-   * Standard-fare foreach that applies a consumer to
-   *   every entry of the [[QueryStats]].
+   * Applies a mapper function to all entries of the [[QueryStats]].
+   *
+   * *** NOT THREAD-SAFE!!! ***
+   * Concurrent modification behavior is undefined!
    */
-  def foreach(consumer: ((Seq[String], Stat)) => Unit): Unit = {
-    stat.foreach(consumer)
+  def map[T](function: ((Seq[String], Stat)) => T): Iterable[T] = {
+    entries.map(function)
   }
 
   /**
@@ -554,8 +595,8 @@ case class QueryStats() {
    */
   def clear(): Unit = {
     lock.synchronized {
-      stat.clear()
-      keyBuffer.clear()
+      entries.clear()
+      keyToEntryIndex.clear()
       containsNilKeyFlag = false
     }
   }
@@ -567,7 +608,7 @@ case class QueryStats() {
    *              then head group is used if it exists.
    */
   def getTimeSeriesScannedCounter(group: Seq[String] = Nil): AtomicLong = {
-    val theNs = if (group.isEmpty && stat.size == 1) stat.head._1 else group
+    val theNs = if (group.isEmpty && keyToEntryIndex.size == 1) keyToEntryIndex.head._1 else group
     getOrAddEmptyStat(theNs).timeSeriesScanned
   }
 
@@ -578,7 +619,7 @@ case class QueryStats() {
    *              then head group is used if it exists.
    */
   def getDataBytesScannedCounter(group: Seq[String] = Nil): AtomicLong = {
-    val theNs = if (group.isEmpty && stat.size == 1) stat.head._1 else group
+    val theNs = if (group.isEmpty && keyToEntryIndex.size == 1) keyToEntryIndex.head._1 else group
     getOrAddEmptyStat(theNs).dataBytesScanned
   }
 
@@ -589,7 +630,7 @@ case class QueryStats() {
    *              then head group is used if it exists.
    */
   def getSamplesScannedCounter(group: Seq[String] = Nil): AtomicLong = {
-    val theNs = if (group.isEmpty && stat.size == 1) stat.head._1 else group
+    val theNs = if (group.isEmpty && keyToEntryIndex.size == 1) keyToEntryIndex.head._1 else group
     getOrAddEmptyStat(theNs).samplesScanned
   }
 
@@ -600,7 +641,7 @@ case class QueryStats() {
    *              then head group is used if it exists.
    */
   def getResultBytesCounter(group: Seq[String] = Nil): AtomicLong = {
-    val theNs = if (group.isEmpty && stat.size == 1) stat.head._1 else group
+    val theNs = if (group.isEmpty && keyToEntryIndex.size == 1) keyToEntryIndex.head._1 else group
     getOrAddEmptyStat(theNs).resultBytes
   }
 
@@ -612,11 +653,17 @@ case class QueryStats() {
    *              then head group is used if it exists.
    */
   def getCpuNanosCounter(group: Seq[String] = Nil): AtomicLong = {
-    val theNs = if (group.isEmpty && stat.size == 1) stat.head._1 else group
+    val theNs = if (group.isEmpty && keyToEntryIndex.size == 1) keyToEntryIndex.head._1 else group
     getOrAddEmptyStat(theNs).cpuNanos
   }
 
-  def totalCpuNanos: Long = stat.valuesIterator.map(_.cpuNanos.get()).sum
+  /**
+   * Returns the sum of CPU nanos for all entries.
+   *
+   * *** NOT THREAD-SAFE!!! ***
+   * Concurrent modification behavior is undefined!
+   */
+  def totalCpuNanos: Long = entries.map(_._2).map(_.cpuNanos.get()).sum
 
 }
 

--- a/core/src/main/scala/filodb.core/query/QueryUtils.scala
+++ b/core/src/main/scala/filodb.core/query/QueryUtils.scala
@@ -167,32 +167,6 @@ object QueryUtils {
   }
 
   /**
-   * Adds a total sample count to the argument [[QueryStats]]; the total is divided
-   *   evenly across all samples-scanned counters.
-   * NOTE: if Nil is the only [[QueryStats]] key, all samples are counted
-   *   against it. If Nil exists with other keys, samples are divided
-   *   among the non-Nil keys only.
-   */
-  private def updateSamplesScannedCounters(queryStats: QueryStats, totalSampleCount: Long): Unit = {
-    // QueryStats keys are updated for all except Nil *unless* Nil
-    //   is the only entry. Nil is sometimes added to QueryStats as a default.
-    val hasSingleEmptyKey = queryStats.size == 1 && queryStats.containsNilKey()
-    if (hasSingleEmptyKey) {
-      queryStats.getSamplesScannedCounter(Nil).addAndGet(totalSampleCount)
-      return
-    }
-    val nonNilKeyCount = queryStats.size() - (if (queryStats.containsNilKey()) 1 else 0)
-    val samplesPerCounter = Math.ceil(
-      totalSampleCount.asInstanceOf[Double] / nonNilKeyCount
-    ).asInstanceOf[Long]
-    queryStats.foreach{ entry =>
-      if (entry._1.nonEmpty) {
-        entry._2.samplesScanned.addAndGet(samplesPerCounter)
-      }
-    }
-  }
-
-  /**
    * Efficiently compute the appropriate per-row samples-scanned multiplier.
    */
   private def computeSamplesScannedRowMultiplier(schema: ResultSchema,
@@ -209,11 +183,7 @@ object QueryUtils {
 
   /**
    * Given the arguments, determines the total count of samples scanned.
-   * Adds the total to the argument [[QueryStats]]; the total is divided
-   *   evenly across all samples-scanned counters.
-   * NOTE: if Nil is the only [[QueryStats]] key, all samples are counted
-   *   against it. If Nil exists with other keys, samples are divided
-   *   among the non-Nil keys only.
+   * Adds the total to the argument [[QueryStats]].
    *
    * @param clazz The class that produced these samples.
    */
@@ -254,17 +224,12 @@ object QueryUtils {
       rowSamples + seriesSamples + partKeySamples
     ).asInstanceOf[Long]
 
-    updateSamplesScannedCounters(queryStats, totalSamples)
+    queryStats.addSamplesScanned(totalSamples)
   }
 
   /**
    * Given the arguments, determines the total count of samples scanned.
-   * Adds the total to the argument [[QueryStats]]; the total is divided
-   *   evenly across all samples-scanned counters.
-   *
-   * NOTE: if Nil is the only [[QueryStats]] key, all samples are counted
-   *   against it. If Nil exists with other keys, samples are divided
-   *   among the non-Nil keys only.
+   * Adds the total to the argument [[QueryStats]].
    *
    * @param class The class that produced these samples.
    */
@@ -282,12 +247,7 @@ object QueryUtils {
 
   /**
    * Given the arguments, determines the total count of samples scanned.
-   * Adds the total to the argument [[QueryStats]]; the total is divided
-   *   evenly across all samples-scanned counters.
-   *
-   * NOTE: if Nil is the only [[QueryStats]] key, all samples are counted
-   *   against it. If Nil exists with other keys, samples are divided
-   *   among the non-Nil keys only.
+   * Adds the total to the argument [[QueryStats]].
    *
    * @param childRv The [[RangeVector]] that was scanned by the parent.
    * @param parentClass The class that scanned the child [[RangeVector]].
@@ -327,7 +287,7 @@ object QueryUtils {
       rowSamples + seriesSamples + partKeySamples
     ).asInstanceOf[Long]
 
-    updateSamplesScannedCounters(queryStats, totalSamples)
+    queryStats.addSamplesScanned(totalSamples)
   }
 
   def maxIgnoreNaN(a: Double, b: Double): Double = {

--- a/core/src/main/scala/filodb.core/query/QueryUtils.scala
+++ b/core/src/main/scala/filodb.core/query/QueryUtils.scala
@@ -214,9 +214,13 @@ object QueryUtils {
       return
     }
 
-    val rowMultiplier = schema.columns
-      .map(getSamplesScannedRowMultiplier(_, config))
-      .sum
+    // NOTE: avoiding .sum, .map, and `for` to prevent the allocation overhead.
+    var rowMultiplier = 0.0
+    var i = 0
+    while (i < schema.columns.size) {
+      rowMultiplier += getSamplesScannedRowMultiplier(schema.columns(i), config)
+      i += 1
+    }
     val rowSamples = rowsScanned * rowMultiplier *
       config.classToSamplesPerRow.getOrElse(clazz, config.defaultSamplesPerRow)
     rowSamplesScanned.increment(rowSamples.toLong)
@@ -281,9 +285,13 @@ object QueryUtils {
       return
     }
 
-    val rowMultiplier = schema.columns
-      .map(getSamplesScannedRowMultiplier(_, config))
-      .sum
+    // NOTE: avoiding .sum, .map, and `for` to prevent the allocation overhead.
+    var rowMultiplier = 0.0
+    var i = 0
+    while (i < schema.columns.size) {
+      rowMultiplier += getSamplesScannedRowMultiplier(schema.columns(i), config)
+      i += 1
+    }
     val rowSamples = childRv.estimateNumRows() * rowMultiplier *
       config.classToSamplesPerChildRow.getOrElse(parentClass, config.defaultSamplesPerChildRow)
     childRowSamplesScanned.increment(rowSamples.toLong)

--- a/core/src/main/scala/filodb.core/query/QueryUtils.scala
+++ b/core/src/main/scala/filodb.core/query/QueryUtils.scala
@@ -195,7 +195,7 @@ object QueryUtils {
                           schema: ResultSchema,
                           config: SamplesScannedConfig): Unit = {
     // Exit early if there are no stats to update.
-    if (queryStats.size == 0) {
+    if (queryStats.unsafeSize() == 0) {
       return
     }
 
@@ -235,7 +235,7 @@ object QueryUtils {
       rowSamples + seriesSamples + partKeySamples
     ).asInstanceOf[Long]
 
-    queryStats.addSamplesScanned(totalSamples)
+    queryStats.unsafeAddSamplesScanned(totalSamples)
   }
 
   /**
@@ -269,7 +269,7 @@ object QueryUtils {
                                schema: ResultSchema,
                                config: SamplesScannedConfig): Unit = {
     // Exit early if there are no stats to update.
-    if (queryStats.size == 0) {
+    if (queryStats.unsafeSize() == 0) {
       return
     }
 
@@ -298,7 +298,7 @@ object QueryUtils {
       rowSamples + seriesSamples + partKeySamples
     ).asInstanceOf[Long]
 
-    queryStats.addSamplesScanned(totalSamples)
+    queryStats.unsafeAddSamplesScanned(totalSamples)
   }
 
   def maxIgnoreNaN(a: Double, b: Double): Double = {

--- a/core/src/main/scala/filodb.core/query/QueryUtils.scala
+++ b/core/src/main/scala/filodb.core/query/QueryUtils.scala
@@ -199,26 +199,37 @@ object QueryUtils {
       return
     }
 
-    // NOTE: avoiding getOrElse below to avoid lambda allocations.
+    // Each computation below has an if() short-circuit.
+    // This is helpful for leaf samples-scanned counters, where this method is sometimes invoked
+    //   specifically to account for rows, and sometimes invoked specifically to account for series.
+    val rowSamples = if (rowsScanned > 0) {
+      val rowMultiplier = computeSamplesScannedRowMultiplier(schema, config)
+      val rowSamples = rowsScanned * rowMultiplier * (
+          // NOTE: avoiding getOrElse to avoid lambda allocations.
+          if (config.classToSamplesPerRow.contains(clazz)) config.classToSamplesPerRow(clazz)
+          else config.defaultSamplesPerRow
+        )
+      rowSamplesScanned.increment(rowSamples.toLong)
+      rowSamples
+    } else 0
 
-    val rowMultiplier = computeSamplesScannedRowMultiplier(schema, config)
-    val rowSamples = rowsScanned * rowMultiplier * (
-        if (config.classToSamplesPerRow.contains(clazz)) config.classToSamplesPerRow(clazz)
-        else config.defaultSamplesPerRow
-      )
-    rowSamplesScanned.increment(rowSamples.toLong)
+    val seriesSamples = if (seriesScanned > 0) {
+      val sampleCount = seriesScanned * (
+          if (config.classToSamplesPerSeries.contains(clazz)) config.classToSamplesPerSeries(clazz)
+          else config.defaultSamplesPerSeries
+        )
+      seriesSamplesScanned.increment(sampleCount.toLong)
+      sampleCount
+    } else 0
 
-    val seriesSamples = seriesScanned * (
-        if (config.classToSamplesPerSeries.contains(clazz)) config.classToSamplesPerSeries(clazz)
-        else config.defaultSamplesPerSeries
-      )
-    seriesSamplesScanned.increment(seriesSamples.toLong)
-
-    val partKeySamples = partKeyBytes * (
-        if (config.classToSamplesPerPartKeyByte.contains(clazz)) config.classToSamplesPerPartKeyByte(clazz)
-        else config.defaultSamplesPerPartKeyByte
-      )
-    partKeyBytesSamplesScanned.increment(partKeySamples.toLong)
+    val partKeySamples = if (partKeyBytes > 0) {
+      val sampleCount = partKeyBytes * (
+          if (config.classToSamplesPerPartKeyByte.contains(clazz)) config.classToSamplesPerPartKeyByte(clazz)
+          else config.defaultSamplesPerPartKeyByte
+        )
+      partKeyBytesSamplesScanned.increment(sampleCount.toLong)
+      sampleCount
+    } else 0
 
     val totalSamples = Math.ceil(
       rowSamples + seriesSamples + partKeySamples

--- a/core/src/main/scala/filodb.core/query/QueryUtils.scala
+++ b/core/src/main/scala/filodb.core/query/QueryUtils.scala
@@ -167,6 +167,32 @@ object QueryUtils {
   }
 
   /**
+   * Adds a total sample count to the argument [[QueryStats]]; the total is divided
+   *   evenly across all samples-scanned counters.
+   * NOTE: if Nil is the only [[QueryStats]] key, all samples are counted
+   *   against it. If Nil exists with other keys, samples are divided
+   *   among the non-Nil keys only.
+   */
+  private def updateSamplesScannedCounters(queryStats: QueryStats, totalSampleCount: Long): Unit = {
+    // QueryStats keys are updated for all except Nil *unless* Nil
+    //   is the only entry. Nil is sometimes added to QueryStats as a default.
+    val hasSingleEmptyKey = queryStats.size == 1 && queryStats.containsNilKey()
+    if (hasSingleEmptyKey) {
+      queryStats.getSamplesScannedCounter(Nil).addAndGet(totalSampleCount)
+      return
+    }
+    val nonNilKeyCount = queryStats.size() - (if (queryStats.containsNilKey()) 1 else 0)
+    val samplesPerCounter = Math.ceil(
+      totalSampleCount.asInstanceOf[Double] / nonNilKeyCount
+    ).asInstanceOf[Long]
+    queryStats.foreachKey{ k =>
+      if (k.nonEmpty) {
+        queryStats.getSamplesScannedCounter(k).addAndGet(samplesPerCounter)
+      }
+    }
+  }
+
+  /**
    * Given the arguments, determines the total count of samples scanned.
    * Adds the total to the argument [[QueryStats]]; the total is divided
    *   evenly across all samples-scanned counters.
@@ -184,16 +210,9 @@ object QueryUtils {
                           schema: ResultSchema,
                           config: SamplesScannedConfig): Unit = {
     // Exit early if there are no stats to update.
-    if (queryStats.stat.isEmpty) {
+    if (queryStats.size == 0) {
       return
     }
-
-    // QueryStats keys are updated for all except Nil *unless* Nil
-    //   is the only entry. Nil is always added to QueryStats.
-    val hasSingleEmptyKey = queryStats.stat.size == 1 && queryStats.stat.keys.head.isEmpty
-    val statKeys = if (!hasSingleEmptyKey) {
-      queryStats.stat.keys.filter(_.nonEmpty).toSeq
-    } else Seq(Nil)
 
     val rowMultiplier = schema.columns
       .map(getSamplesScannedRowMultiplier(_, config))
@@ -214,11 +233,7 @@ object QueryUtils {
       rowSamples + seriesSamples + partKeySamples
     ).asInstanceOf[Long]
 
-    val samplesPerCounter = Math.ceil(
-      totalSamples.asInstanceOf[Double] / statKeys.size
-    ).asInstanceOf[Long]
-
-    statKeys.foreach(k => queryStats.getSamplesScannedCounter(k).addAndGet(samplesPerCounter))
+    updateSamplesScannedCounters(queryStats, totalSamples)
   }
 
   /**
@@ -262,16 +277,9 @@ object QueryUtils {
                                schema: ResultSchema,
                                config: SamplesScannedConfig): Unit = {
     // Exit early if there are no stats to update.
-    if (queryStats.stat.isEmpty) {
+    if (queryStats.size == 0) {
       return
     }
-
-    // QueryStats keys are updated for all except Nil *unless* Nil
-    //   is the only entry. Nil is always added to QueryStats.
-    val hasSingleEmptyKey = queryStats.stat.size == 1 && queryStats.stat.keys.head.isEmpty
-    val statKeys = if (!hasSingleEmptyKey) {
-      queryStats.stat.keys.filter(_.nonEmpty).toSeq
-    } else Seq(Nil)
 
     val rowMultiplier = schema.columns
       .map(getSamplesScannedRowMultiplier(_, config))
@@ -292,11 +300,7 @@ object QueryUtils {
       rowSamples + seriesSamples + partKeySamples
     ).asInstanceOf[Long]
 
-    val samplesPerCounter = Math.ceil(
-      totalSamples.asInstanceOf[Double] / statKeys.size
-    ).asInstanceOf[Long]
-
-    statKeys.foreach(k => queryStats.getSamplesScannedCounter(k).addAndGet(samplesPerCounter))
+    updateSamplesScannedCounters(queryStats, totalSamples)
   }
 
   def maxIgnoreNaN(a: Double, b: Double): Double = {

--- a/core/src/main/scala/filodb.core/query/QueryUtils.scala
+++ b/core/src/main/scala/filodb.core/query/QueryUtils.scala
@@ -221,16 +221,25 @@ object QueryUtils {
       rowMultiplier += getSamplesScannedRowMultiplier(schema.columns(i), config)
       i += 1
     }
-    val rowSamples = rowsScanned * rowMultiplier *
-      config.classToSamplesPerRow.getOrElse(clazz, config.defaultSamplesPerRow)
+
+    // NOTE: avoiding getOrElse below to avoid lambda allocations.
+
+    val rowSamples = rowsScanned * rowMultiplier * (
+        if (config.classToSamplesPerRow.contains(clazz)) config.classToSamplesPerRow(clazz)
+        else config.defaultSamplesPerRow
+      )
     rowSamplesScanned.increment(rowSamples.toLong)
 
-    val seriesSamples = seriesScanned *
-      config.classToSamplesPerSeries.getOrElse(clazz, config.defaultSamplesPerSeries)
+    val seriesSamples = seriesScanned * (
+        if (config.classToSamplesPerSeries.contains(clazz)) config.classToSamplesPerSeries(clazz)
+        else config.defaultSamplesPerSeries
+      )
     seriesSamplesScanned.increment(seriesSamples.toLong)
 
-    val partKeySamples = partKeyBytes *
-      config.classToSamplesPerPartKeyByte.getOrElse(clazz, config.defaultSamplesPerPartKeyByte)
+    val partKeySamples = partKeyBytes * (
+        if (config.classToSamplesPerPartKeyByte.contains(clazz)) config.classToSamplesPerPartKeyByte(clazz)
+        else config.defaultSamplesPerPartKeyByte
+      )
     partKeyBytesSamplesScanned.increment(partKeySamples.toLong)
 
     val totalSamples = Math.ceil(
@@ -292,16 +301,25 @@ object QueryUtils {
       rowMultiplier += getSamplesScannedRowMultiplier(schema.columns(i), config)
       i += 1
     }
-    val rowSamples = childRv.estimateNumRows() * rowMultiplier *
-      config.classToSamplesPerChildRow.getOrElse(parentClass, config.defaultSamplesPerChildRow)
+
+    // NOTE: avoiding getOrElse below to avoid lambda allocations.
+
+    val rowSamples = childRv.estimateNumRows() * rowMultiplier * (
+        if (config.classToSamplesPerChildRow.contains(parentClass)) config.classToSamplesPerChildRow(parentClass)
+        else config.defaultSamplesPerChildRow
+      )
     childRowSamplesScanned.increment(rowSamples.toLong)
 
-    val seriesSamples = config.classToSamplesPerChildSeries.getOrElse(
-      parentClass, config.defaultSamplesPerChildSeries)
+    val seriesSamples =
+      if (config.classToSamplesPerChildSeries.contains(parentClass)) config.classToSamplesPerChildSeries(parentClass)
+      else config.defaultSamplesPerChildSeries
     childSeriesSamplesScanned.increment(seriesSamples.toLong)
 
-    val partKeySamples = childRv.key.keySize *
-      config.classToSamplesPerChildPartKeyByte.getOrElse(parentClass, config.defaultSamplesPerChildPartKeyByte)
+    val partKeySamples = childRv.key.keySize * (
+        if (config.classToSamplesPerChildPartKeyByte.contains(parentClass))
+          config.classToSamplesPerChildPartKeyByte(parentClass)
+        else config.defaultSamplesPerChildPartKeyByte
+      )
     childPartKeyBytesSamplesScanned.increment(partKeySamples.toLong)
 
     val totalSamples = Math.ceil(

--- a/core/src/main/scala/filodb.core/query/QueryUtils.scala
+++ b/core/src/main/scala/filodb.core/query/QueryUtils.scala
@@ -185,11 +185,26 @@ object QueryUtils {
     val samplesPerCounter = Math.ceil(
       totalSampleCount.asInstanceOf[Double] / nonNilKeyCount
     ).asInstanceOf[Long]
-    queryStats.foreachKey{ k =>
-      if (k.nonEmpty) {
-        queryStats.getSamplesScannedCounter(k).addAndGet(samplesPerCounter)
+    queryStats.foreach{ entry =>
+      if (entry._1.nonEmpty) {
+        entry._2.samplesScanned.addAndGet(samplesPerCounter)
       }
     }
+  }
+
+  /**
+   * Efficiently compute the appropriate per-row samples-scanned multiplier.
+   */
+  private def computeSamplesScannedRowMultiplier(schema: ResultSchema,
+                                                 config: SamplesScannedConfig): Double = {
+    // NOTE: avoiding .sum, .map, and `for` to prevent the allocation overhead.
+    var rowMultiplier = 0.0
+    var i = 0
+    while (i < schema.columns.size) {
+      rowMultiplier += getSamplesScannedRowMultiplier(schema.columns(i), config)
+      i += 1
+    }
+    rowMultiplier
   }
 
   /**
@@ -214,16 +229,9 @@ object QueryUtils {
       return
     }
 
-    // NOTE: avoiding .sum, .map, and `for` to prevent the allocation overhead.
-    var rowMultiplier = 0.0
-    var i = 0
-    while (i < schema.columns.size) {
-      rowMultiplier += getSamplesScannedRowMultiplier(schema.columns(i), config)
-      i += 1
-    }
-
     // NOTE: avoiding getOrElse below to avoid lambda allocations.
 
+    val rowMultiplier = computeSamplesScannedRowMultiplier(schema, config)
     val rowSamples = rowsScanned * rowMultiplier * (
         if (config.classToSamplesPerRow.contains(clazz)) config.classToSamplesPerRow(clazz)
         else config.defaultSamplesPerRow
@@ -294,16 +302,9 @@ object QueryUtils {
       return
     }
 
-    // NOTE: avoiding .sum, .map, and `for` to prevent the allocation overhead.
-    var rowMultiplier = 0.0
-    var i = 0
-    while (i < schema.columns.size) {
-      rowMultiplier += getSamplesScannedRowMultiplier(schema.columns(i), config)
-      i += 1
-    }
-
     // NOTE: avoiding getOrElse below to avoid lambda allocations.
 
+    val rowMultiplier = computeSamplesScannedRowMultiplier(schema, config)
     val rowSamples = childRv.estimateNumRows() * rowMultiplier * (
         if (config.classToSamplesPerChildRow.contains(parentClass)) config.classToSamplesPerChildRow(parentClass)
         else config.defaultSamplesPerChildRow

--- a/core/src/main/scala/filodb.core/query/QueryUtils.scala
+++ b/core/src/main/scala/filodb.core/query/QueryUtils.scala
@@ -204,13 +204,13 @@ object QueryUtils {
     //   specifically to account for rows, and sometimes invoked specifically to account for series.
     val rowSamples = if (rowsScanned > 0) {
       val rowMultiplier = computeSamplesScannedRowMultiplier(schema, config)
-      val rowSamples = rowsScanned * rowMultiplier * (
+      val sampleCount = rowsScanned * rowMultiplier * (
           // NOTE: avoiding getOrElse to avoid lambda allocations.
           if (config.classToSamplesPerRow.contains(clazz)) config.classToSamplesPerRow(clazz)
           else config.defaultSamplesPerRow
         )
-      rowSamplesScanned.increment(rowSamples.toLong)
-      rowSamples
+      rowSamplesScanned.increment(sampleCount.toLong)
+      sampleCount
     } else 0
 
     val seriesSamples = if (seriesScanned > 0) {

--- a/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
@@ -348,13 +348,18 @@ class CountingChunkInfoIterator(base: ChunkInfoIterator,
     val reader = base.nextInfoReader
     var bytesRead = 0
     var bucketsFactor = 1
-    columnIDs.foreach { c =>
-      bytesRead += BinaryVector.totalBytes(reader.vectorAccessor(c), reader.vectorAddress(c))
-      if (BinaryVector.majorVectorType(reader.vectorAccessor(c), reader.vectorAddress(c))
+
+    // Avoiding `foreach` and `for` to prevent Range allocations.
+    var iCol = 0
+    while (iCol < columnIDs.size) {
+      val colId = columnIDs(iCol)
+      bytesRead += BinaryVector.totalBytes(reader.vectorAccessor(colId), reader.vectorAddress(colId))
+      if (BinaryVector.majorVectorType(reader.vectorAccessor(colId), reader.vectorAddress(colId))
                     == WireFormat.VECTORTYPE_HISTOGRAM) {
         // since histogram has several buckets, include a factor when counting samples
         bucketsFactor = 20 // TODO fixed to avoid performance issues in opening hist vector here. Make it better later.
       }
+      iCol += 1
     }
 
     // Why two counters ?

--- a/core/src/main/scala/filodb.core/store/ChunkSource.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSource.scala
@@ -192,6 +192,22 @@ trait ChunkSource extends RawChunkSource with StrictLogging {
       }
     }
 
+    val samplesScannedConfig = querySession.queryConfig.samplesScannedConfig
+    val resultSchema = {
+      val numRowKeyCols = 1
+      ResultSchema(schema.infosFromIDs(columnIDs), numRowKeyCols, colIDs = columnIDs)
+    }
+
+    // Create a row-count consumer to account for row-based samples-scanned as chunks are iterated.
+    // Series/part-key-based samples are accounted for below while looping through partitions.
+    def samplesScannedRowCountConsumer(rowsScanned: Long): Unit = {
+      if (samplesScannedConfig.leafSamplesEnabled) {
+        QueryUtils.trackSamplesScanned(
+          seriesScanned = 0, rowsScanned, partKeyBytes = 0, this.getClass,
+          querySession.queryStats, resultSchema, querySession.queryConfig.samplesScannedConfig)
+      }
+    }
+
     filteredParts.map { partition =>
       stats.incrReadPartitions(1)
       val subgroup = TimeSeriesShard.partKeyGroup(schema.partKeySchema, partition.partKeyBase,
@@ -200,29 +216,12 @@ trait ChunkSource extends RawChunkSource with StrictLogging {
                                         schema.partKeySchema, partCols, partition.shard,
                                         subgroup, partition.partID, schema.name)
 
-      val resultSchema = {
-        val numRowKeyCols = 1
-        ResultSchema(schema.infosFromIDs(columnIDs), numRowKeyCols, colIDs = columnIDs)
-      }
-
-      // Add leaf-level samples-scanned into the QueryStats.
-      val samplesScannedConfig = querySession.queryConfig.samplesScannedConfig
-      val isSeriesCounted = AtomicBoolean(false)
-      def samplesScannedRowCountConsumer(rowsScanned: Long): Unit = {
-        if (!samplesScannedConfig.leafSamplesEnabled) {
-          return
-        }
-        // Only count the series/pk-bytes once; all other calls will exclusively count rows.
-        if (!isSeriesCounted.get()) {
-          QueryUtils.trackSamplesScanned(
-            seriesScanned = 1, rowsScanned, partKeyBytes = key.keySize, this.getClass,
-            querySession.queryStats, resultSchema, querySession.queryConfig.samplesScannedConfig)
-          isSeriesCounted.set(true)
-        } else {
-          QueryUtils.trackSamplesScanned(
-            seriesScanned = 0, rowsScanned, partKeyBytes = 0, this.getClass,
-            querySession.queryStats, resultSchema, querySession.queryConfig.samplesScannedConfig)
-        }
+      // Account for series- & part-key-based samples-scanned up-front;
+      //   row-based samples-scanned are accounted for by the consumer created above.
+      if (samplesScannedConfig.leafSamplesEnabled) {
+        QueryUtils.trackSamplesScanned(
+          seriesScanned = 1, 0, partKeyBytes = key.keySize, this.getClass,
+          querySession.queryStats, resultSchema, querySession.queryConfig.samplesScannedConfig)
       }
 
       RawDataRangeVector(

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -644,7 +644,7 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     val value = memStore.scanPartitions(dataset1.ref, Seq(0, 1), FilteredPartitionScan(split, filters),
       querySession = session)
       .toListL.runToFuture.futureValue
-    session.queryStats.size shouldEqual 1
+    session.queryStats.unsafeSize shouldEqual 1
     session.queryStats.keys().head.size shouldEqual 5
     session.queryStats.keys().head(2) shouldEqual "test_ws"
     session.queryStats.keys().head(3) shouldEqual "App-0|App-1"

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -644,11 +644,11 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
     val value = memStore.scanPartitions(dataset1.ref, Seq(0, 1), FilteredPartitionScan(split, filters),
       querySession = session)
       .toListL.runToFuture.futureValue
-    session.queryStats.stat.size shouldEqual 1
-    session.queryStats.stat.head._1.size shouldEqual 5
-    session.queryStats.stat.head._1(2) shouldEqual "test_ws"
-    session.queryStats.stat.head._1(3) shouldEqual "App-0|App-1"
-    session.queryStats.stat.head._1(4) shouldEqual "http_latency"
+    session.queryStats.size shouldEqual 1
+    session.queryStats.keys().head.size shouldEqual 5
+    session.queryStats.keys().head(2) shouldEqual "test_ws"
+    session.queryStats.keys().head(3) shouldEqual "App-0|App-1"
+    session.queryStats.keys().head(4) shouldEqual "http_latency"
   }
 
   it("should assign same previously assigned partId using bloom filter when evicted series starts re-ingesting") {

--- a/core/src/test/scala/filodb.core/query/QueryContextSpec.scala
+++ b/core/src/test/scala/filodb.core/query/QueryContextSpec.scala
@@ -3,6 +3,9 @@ package filodb.core.query
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
+
+import scala.collection.mutable.ArrayBuffer
+
 class QueryContextSpec extends AnyFunSpec with Matchers {
 
   it("should produce correct log line") {
@@ -41,5 +44,88 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
       s"My log message promQL = -=# myQuery #=- queryOrigin = Some(rr) queryPrincipal = None " +
         s"queryOriginId = Some(rr_id) queryId = ${queryContext.queryId}"
     )
+  }
+
+  it("should maintain QueryStats state correctly") {
+    val stats = QueryStats()
+
+    stats.size() shouldEqual 0
+    stats.keys() shouldEqual Nil
+    stats.get(Seq("foo", "bar")) shouldEqual None
+    stats.containsNilKey() shouldEqual false
+
+    // Test "getOrCreate" functionality.
+    stats.getSamplesScannedCounter(Seq("foo", "bar"))
+    stats.size() shouldEqual 1
+    stats.keys().size shouldEqual 1
+    stats.keys().toSet shouldEqual Set(Seq("foo", "bar"))
+    stats.get(Seq("foo", "bar")).isDefined shouldEqual true
+    stats.containsNilKey() shouldEqual false
+
+    // Test put.
+    stats.put(Seq("abc", "123"), Stat())
+    stats.size() shouldEqual 2
+    stats.keys().size shouldEqual 2
+    stats.keys().toSet shouldEqual Set(Seq("foo", "bar"), Seq("abc", "123"))
+    stats.get(Seq("foo", "bar")).isDefined shouldEqual true
+    stats.get(Seq("abc", "123")).isDefined shouldEqual true
+    stats.containsNilKey() shouldEqual false
+
+    // Test Nil handling.
+    stats.getSamplesScannedCounter(Nil)
+    stats.size() shouldEqual 3
+    stats.keys().size shouldEqual 3
+    stats.keys().toSet shouldEqual Set(Seq("foo", "bar"), Seq("abc", "123"), Nil)
+    stats.get(Nil).isDefined shouldEqual true
+    stats.containsNilKey() shouldEqual true
+
+    // Test add.
+    val emptyStats = QueryStats()
+    emptyStats.add(stats)
+    emptyStats.size() shouldEqual 3
+    stats.keys().size shouldEqual 3
+    emptyStats.keys().toSet shouldEqual Set(Seq("foo", "bar"), Seq("abc", "123"), Nil)
+    emptyStats.get(Nil).isDefined shouldEqual true
+    emptyStats.containsNilKey() shouldEqual true
+
+    // Test clear.
+    stats.clear()
+    stats.size() shouldEqual 0
+    stats.keys() shouldEqual Nil
+    stats.get(Nil).isDefined shouldEqual false
+    stats.containsNilKey() shouldEqual false
+  }
+
+  it("should correctly support per-element QueryStats operations") {
+    val stats = QueryStats()
+
+    // Populated/cleared as part of each test below.
+    val keyBuffer = ArrayBuffer[Seq[String]]()
+
+    // Test empty stats. #################################
+
+    stats.map(entry => entry._1) shouldEqual Nil
+
+    stats.foreach(entry => keyBuffer.addOne(entry._1))
+    keyBuffer.toSeq shouldEqual Nil
+
+    stats.foreachKey(key => keyBuffer.addOne(key))
+    keyBuffer.toSeq shouldEqual Nil
+
+    // Test nonempty stats. #################################
+
+    stats.getSamplesScannedCounter(Nil)
+    stats.getSamplesScannedCounter(Seq("foo"))
+    stats.getSamplesScannedCounter(Seq("abc", "123"))
+
+    stats.map(entry => entry._1).toSet shouldEqual Set(Nil, Seq("foo"), Seq("abc", "123"))
+
+    stats.foreach(entry => keyBuffer.addOne(entry._1))
+    keyBuffer.toSet shouldEqual Set(Nil, Seq("foo"), Seq("abc", "123"))
+    keyBuffer.clear()
+
+    stats.foreachKey(key => keyBuffer.addOne(key))
+    keyBuffer.toSet shouldEqual Set(Nil, Seq("foo"), Seq("abc", "123"))
+    keyBuffer.clear()
   }
 }

--- a/core/src/test/scala/filodb.core/query/QueryContextSpec.scala
+++ b/core/src/test/scala/filodb.core/query/QueryContextSpec.scala
@@ -52,7 +52,6 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
     stats.size() shouldEqual 0
     stats.keys() shouldEqual Nil
     stats.get(Seq("foo", "bar")) shouldEqual None
-    stats.containsNilKey() shouldEqual false
 
     // Test "getOrCreate" functionality.
     stats.getSamplesScannedCounter(Seq("foo", "bar"))
@@ -60,7 +59,6 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
     stats.keys().size shouldEqual 1
     stats.keys().toSet shouldEqual Set(Seq("foo", "bar"))
     stats.get(Seq("foo", "bar")).isDefined shouldEqual true
-    stats.containsNilKey() shouldEqual false
 
     // Test put.
     stats.put(Seq("abc", "123"), Stat())
@@ -69,7 +67,6 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
     stats.keys().toSet shouldEqual Set(Seq("foo", "bar"), Seq("abc", "123"))
     stats.get(Seq("foo", "bar")).isDefined shouldEqual true
     stats.get(Seq("abc", "123")).isDefined shouldEqual true
-    stats.containsNilKey() shouldEqual false
 
     // Test Nil handling.
     stats.getSamplesScannedCounter(Nil)
@@ -77,7 +74,6 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
     stats.keys().size shouldEqual 3
     stats.keys().toSet shouldEqual Set(Seq("foo", "bar"), Seq("abc", "123"), Nil)
     stats.get(Nil).isDefined shouldEqual true
-    stats.containsNilKey() shouldEqual true
 
     // Test add.
     val emptyStats = QueryStats()
@@ -86,14 +82,12 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
     stats.keys().size shouldEqual 3
     emptyStats.keys().toSet shouldEqual Set(Seq("foo", "bar"), Seq("abc", "123"), Nil)
     emptyStats.get(Nil).isDefined shouldEqual true
-    emptyStats.containsNilKey() shouldEqual true
 
     // Test clear.
     stats.clear()
     stats.size() shouldEqual 0
     stats.keys() shouldEqual Nil
     stats.get(Nil).isDefined shouldEqual false
-    stats.containsNilKey() shouldEqual false
   }
 
   it("should correctly support per-element QueryStats operations") {
@@ -120,5 +114,85 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
     stats.foreach(entry => keyBuffer.addOne(entry._1))
     keyBuffer.toSet shouldEqual Set(Nil, Seq("foo"), Seq("abc", "123"))
     keyBuffer.clear()
+  }
+
+  it("should correctly add samples-scanned to QueryStats") {
+    {
+      // Empty -- effectively a no-op; should not throw.
+      val stats = QueryStats()
+      stats.addSamplesScanned(100)
+      stats.size() shouldEqual 0
+    }
+
+    {
+      // One key; should account for all samples.
+      val stats = QueryStats()
+      stats.getSamplesScannedCounter(Seq("hello"))
+      stats.addSamplesScanned(100)
+      stats.foreach { case (key, stat) => stat.samplesScanned.get() shouldEqual 100 }
+    }
+
+    {
+      // Two keys; each should account for half of all samples.
+      val stats = QueryStats()
+      stats.getSamplesScannedCounter(Seq("hello"))
+      stats.getSamplesScannedCounter(Seq("goodbye"))
+      stats.addSamplesScanned(100)
+      stats.foreach { case (key, stat) => stat.samplesScanned.get() shouldEqual 50 }
+    }
+
+    {
+      // Nil key; should account for all samples.
+      val stats = QueryStats()
+      stats.getSamplesScannedCounter(Nil)
+      stats.addSamplesScanned(100)
+      stats.foreach { case (key, stat) => stat.samplesScanned.get() shouldEqual 100 }
+    }
+
+    {
+      // Nil key with one other; non-nil should account for all samples.
+      val stats = QueryStats()
+      stats.getSamplesScannedCounter(Nil)
+      stats.getSamplesScannedCounter(Seq("hello"))
+      stats.addSamplesScanned(100)
+      stats.foreach { case (key, stat) =>
+        if (key.isEmpty) {
+          stat.samplesScanned.get() shouldEqual 0
+        } else {
+          stat.samplesScanned.get() shouldEqual 100
+        }
+      }
+    }
+
+    {
+      // Nil key with two others; non-nils should each account for half of all samples.
+      val stats = QueryStats()
+      stats.getSamplesScannedCounter(Nil)
+      stats.getSamplesScannedCounter(Seq("hello"))
+      stats.getSamplesScannedCounter(Seq("goodbye"))
+      stats.addSamplesScanned(100)
+      stats.foreach { case (key, stat) =>
+        if (key.isEmpty) {
+          stat.samplesScanned.get() shouldEqual 0
+        } else {
+          stat.samplesScanned.get() shouldEqual 50
+        }
+      }
+    }
+
+    {
+      // Only samples-scanned counters should be updated.
+      val stats = QueryStats()
+      stats.getSamplesScannedCounter(Nil)
+      stats.getSamplesScannedCounter(Seq("hello"))
+      stats.getSamplesScannedCounter(Seq("goodbye"))
+      stats.addSamplesScanned(100)
+      stats.foreach { case (key, stat) =>
+        stat.timeSeriesScanned.get() shouldEqual 0
+        stat.cpuNanos.get() shouldEqual 0
+        stat.dataBytesScanned.get() shouldEqual 0
+        stat.resultBytes.get() shouldEqual 0
+      }
+    }
   }
 }

--- a/core/src/test/scala/filodb.core/query/QueryContextSpec.scala
+++ b/core/src/test/scala/filodb.core/query/QueryContextSpec.scala
@@ -49,20 +49,20 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
   it("should maintain QueryStats state correctly") {
     val stats = QueryStats()
 
-    stats.size() shouldEqual 0
+    stats.unsafeSize() shouldEqual 0
     stats.keys() shouldEqual Nil
     stats.get(Seq("foo", "bar")) shouldEqual None
 
     // Test "getOrCreate" functionality.
     stats.getSamplesScannedCounter(Seq("foo", "bar"))
-    stats.size() shouldEqual 1
+    stats.unsafeSize() shouldEqual 1
     stats.keys().size shouldEqual 1
     stats.keys().toSet shouldEqual Set(Seq("foo", "bar"))
     stats.get(Seq("foo", "bar")).isDefined shouldEqual true
 
     // Test put.
     stats.put(Seq("abc", "123"), Stat())
-    stats.size() shouldEqual 2
+    stats.unsafeSize() shouldEqual 2
     stats.keys().size shouldEqual 2
     stats.keys().toSet shouldEqual Set(Seq("foo", "bar"), Seq("abc", "123"))
     stats.get(Seq("foo", "bar")).isDefined shouldEqual true
@@ -70,7 +70,7 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
 
     // Test Nil handling.
     stats.getSamplesScannedCounter(Nil)
-    stats.size() shouldEqual 3
+    stats.unsafeSize() shouldEqual 3
     stats.keys().size shouldEqual 3
     stats.keys().toSet shouldEqual Set(Seq("foo", "bar"), Seq("abc", "123"), Nil)
     stats.get(Nil).isDefined shouldEqual true
@@ -78,14 +78,14 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
     // Test add.
     val emptyStats = QueryStats()
     emptyStats.add(stats)
-    emptyStats.size() shouldEqual 3
+    emptyStats.unsafeSize() shouldEqual 3
     stats.keys().size shouldEqual 3
     emptyStats.keys().toSet shouldEqual Set(Seq("foo", "bar"), Seq("abc", "123"), Nil)
     emptyStats.get(Nil).isDefined shouldEqual true
 
     // Test clear.
     stats.clear()
-    stats.size() shouldEqual 0
+    stats.unsafeSize() shouldEqual 0
     stats.keys() shouldEqual Nil
     stats.get(Nil).isDefined shouldEqual false
   }
@@ -120,15 +120,15 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
     {
       // Empty -- effectively a no-op; should not throw.
       val stats = QueryStats()
-      stats.addSamplesScanned(100)
-      stats.size() shouldEqual 0
+      stats.unsafeAddSamplesScanned(100)
+      stats.unsafeSize() shouldEqual 0
     }
 
     {
       // One key; should account for all samples.
       val stats = QueryStats()
       stats.getSamplesScannedCounter(Seq("hello"))
-      stats.addSamplesScanned(100)
+      stats.unsafeAddSamplesScanned(100)
       stats.foreach { case (key, stat) => stat.samplesScanned.get() shouldEqual 100 }
     }
 
@@ -137,7 +137,7 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
       val stats = QueryStats()
       stats.getSamplesScannedCounter(Seq("hello"))
       stats.getSamplesScannedCounter(Seq("goodbye"))
-      stats.addSamplesScanned(100)
+      stats.unsafeAddSamplesScanned(100)
       stats.foreach { case (key, stat) => stat.samplesScanned.get() shouldEqual 50 }
     }
 
@@ -145,7 +145,7 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
       // Nil key; should account for all samples.
       val stats = QueryStats()
       stats.getSamplesScannedCounter(Nil)
-      stats.addSamplesScanned(100)
+      stats.unsafeAddSamplesScanned(100)
       stats.foreach { case (key, stat) => stat.samplesScanned.get() shouldEqual 100 }
     }
 
@@ -154,7 +154,7 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
       val stats = QueryStats()
       stats.getSamplesScannedCounter(Nil)
       stats.getSamplesScannedCounter(Seq("hello"))
-      stats.addSamplesScanned(100)
+      stats.unsafeAddSamplesScanned(100)
       stats.foreach { case (key, stat) =>
         if (key.isEmpty) {
           stat.samplesScanned.get() shouldEqual 0
@@ -170,7 +170,7 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
       stats.getSamplesScannedCounter(Nil)
       stats.getSamplesScannedCounter(Seq("hello"))
       stats.getSamplesScannedCounter(Seq("goodbye"))
-      stats.addSamplesScanned(100)
+      stats.unsafeAddSamplesScanned(100)
       stats.foreach { case (key, stat) =>
         if (key.isEmpty) {
           stat.samplesScanned.get() shouldEqual 0
@@ -186,7 +186,7 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
       stats.getSamplesScannedCounter(Nil)
       stats.getSamplesScannedCounter(Seq("hello"))
       stats.getSamplesScannedCounter(Seq("goodbye"))
-      stats.addSamplesScanned(100)
+      stats.unsafeAddSamplesScanned(100)
       stats.foreach { case (key, stat) =>
         stat.timeSeriesScanned.get() shouldEqual 0
         stat.cpuNanos.get() shouldEqual 0

--- a/core/src/test/scala/filodb.core/query/QueryContextSpec.scala
+++ b/core/src/test/scala/filodb.core/query/QueryContextSpec.scala
@@ -109,9 +109,6 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
     stats.foreach(entry => keyBuffer.addOne(entry._1))
     keyBuffer.toSeq shouldEqual Nil
 
-    stats.foreachKey(key => keyBuffer.addOne(key))
-    keyBuffer.toSeq shouldEqual Nil
-
     // Test nonempty stats. #################################
 
     stats.getSamplesScannedCounter(Nil)
@@ -121,10 +118,6 @@ class QueryContextSpec extends AnyFunSpec with Matchers {
     stats.map(entry => entry._1).toSet shouldEqual Set(Nil, Seq("foo"), Seq("abc", "123"))
 
     stats.foreach(entry => keyBuffer.addOne(entry._1))
-    keyBuffer.toSet shouldEqual Set(Nil, Seq("foo"), Seq("abc", "123"))
-    keyBuffer.clear()
-
-    stats.foreachKey(key => keyBuffer.addOne(key))
     keyBuffer.toSet shouldEqual Set(Nil, Seq("foo"), Seq("abc", "123"))
     keyBuffer.clear()
   }

--- a/core/src/test/scala/filodb.core/query/QueryUtilsSpec.scala
+++ b/core/src/test/scala/filodb.core/query/QueryUtilsSpec.scala
@@ -40,20 +40,20 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
     def assertSamplesScanned(queryStats: QueryStats, expectedCounts: Map[Seq[String], Long]): Unit = {
       for ((key, value) <- expectedCounts) {
-        assert(value == queryStats.stat(key).samplesScanned.get())
+        assert(value == queryStats.get(key).get.samplesScanned.get())
       }
 
       // Have to awkwardly account for the Nil key; Nil is always added for some plans.
       val nilInExpected = expectedCounts.exists(_._1.isEmpty)
-      val nilInActual = queryStats.stat.contains(Nil)
+      val nilInActual = queryStats.get(Nil).isDefined
       if (!nilInExpected && nilInActual) {
         // Make sure we've already asserted the values of all other keys.
-        assert(queryStats.stat.size == 1 + expectedCounts.size)
+        assert(queryStats.size == 1 + expectedCounts.size)
         // Make sure no samples-scanned have been counted against Nil.
-        assert(queryStats.stat(Nil).samplesScanned.get() == 0)
+        assert(queryStats.get(Nil).get.samplesScanned.get() == 0)
       } else {
         // Make sure we've already asserted the values of all keys.
-        assert(queryStats.stat.size == expectedCounts.size)
+        assert(queryStats.size == expectedCounts.size)
       }
     }
 
@@ -62,12 +62,12 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
         val stats = QueryStats()
         QueryUtils.trackSamplesScanned(seriesScanned = 5, rowsScanned = 10, partKeyBytes = 100,
           classOf[String], stats, doubleSchema, SamplesScannedConfig())
-        assert(stats.stat.isEmpty)
+        assert(stats.size == 0)
       }
 
       it("should count only row samples with default config") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         QueryUtils.trackSamplesScanned(seriesScanned = 5, rowsScanned = 10, partKeyBytes = 100,
           classOf[String], stats, doubleSchema, SamplesScannedConfig())
@@ -79,9 +79,9 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should split samples evenly across QueryStats entries") {
         val stats = QueryStats()
-        stats.stat.put(Seq("hello"), Stat())
-        stats.stat.put(Seq("goodbye"), Stat())
-        stats.stat.put(Seq("applesauce"), Stat())
+        stats.put(Seq("hello"), Stat())
+        stats.put(Seq("goodbye"), Stat())
+        stats.put(Seq("applesauce"), Stat())
 
         QueryUtils.trackSamplesScanned(seriesScanned = 0, rowsScanned = 6, partKeyBytes = 0,
           classOf[String], stats, doubleSchema, SamplesScannedConfig())
@@ -95,7 +95,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should apply correct row multiplier for non-exponential HistogramColumn") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         val expHistSchema = ResultSchema(
           Seq(ColumnInfo("timestamp", ColumnType.TimestampColumn),
@@ -110,7 +110,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should apply correct row multiplier for exponential HistogramColumn") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         QueryUtils.trackSamplesScanned(seriesScanned = 0, rowsScanned = 5, partKeyBytes = 0,
           classOf[String], stats, histSchema, SamplesScannedConfig())
@@ -121,7 +121,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should apply default samplesPerRow") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         val config = SamplesScannedConfig(defaultSamplesPerRow = 3.0)
         QueryUtils.trackSamplesScanned(seriesScanned = 0, rowsScanned = 4, partKeyBytes = 0,
@@ -132,7 +132,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should apply default samplesPerSeries") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         val config = SamplesScannedConfig(defaultSamplesPerSeries =  2.0)
         QueryUtils.trackSamplesScanned(seriesScanned = 5, rowsScanned = 0, partKeyBytes = 0,
@@ -143,7 +143,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should apply default samplesPerPartKeyByte") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         val config = SamplesScannedConfig(defaultSamplesPerPartKeyByte = 0.5)
         QueryUtils.trackSamplesScanned(seriesScanned = 0, rowsScanned = 0, partKeyBytes = 20,
@@ -154,7 +154,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should apply class-specific samplesPerRow") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         val config = SamplesScannedConfig(classToSamplesPerRow = Map(classOf[String] -> 3.0))
         QueryUtils.trackSamplesScanned(seriesScanned = 0, rowsScanned = 4, partKeyBytes = 0,
@@ -165,7 +165,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should apply class-specific samplesPerSeries") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         val config = SamplesScannedConfig(classToSamplesPerSeries = Map(classOf[String] -> 2.0))
         QueryUtils.trackSamplesScanned(seriesScanned = 5, rowsScanned = 0, partKeyBytes = 0,
@@ -176,7 +176,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should apply class-specific samplesPerPartKeyByte") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         val config = SamplesScannedConfig(classToSamplesPerPartKeyByte = Map(classOf[String] -> 0.5))
         QueryUtils.trackSamplesScanned(seriesScanned = 0, rowsScanned = 0, partKeyBytes = 20,
@@ -187,7 +187,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should increment Nil counter when only Nil key exists") {
         val stats = QueryStats()
-        stats.stat.put(Nil, Stat())
+        stats.put(Nil, Stat())
 
         QueryUtils.trackSamplesScanned(seriesScanned = 0, rowsScanned = 6, partKeyBytes = 0,
           classOf[String], stats, doubleSchema, SamplesScannedConfig())
@@ -197,8 +197,8 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should not increment Nil counter when non-Nil keys exist") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
-        stats.stat.put(Nil, Stat())
+        stats.put(Seq("key"), Stat())
+        stats.put(Nil, Stat())
 
         QueryUtils.trackSamplesScanned(seriesScanned = 0, rowsScanned = 6, partKeyBytes = 0,
           classOf[String], stats, doubleSchema, SamplesScannedConfig())
@@ -208,7 +208,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should count samples for 1 series, all rows, and correct part-key bytes during RV overload") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         val rv = makeRV(Some(3), None, 5)
         QueryUtils.trackSamplesScanned(
@@ -227,12 +227,12 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
         val rv = makeRV(Some(10), None, 50)
         QueryUtils.trackChildSamplesScanned(
           rv, classOf[String], stats, doubleSchema, SamplesScannedConfig())
-        assert(stats.stat.isEmpty)
+        assert(stats.size == 0)
       }
 
       it("should count zero child samples with default config") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         val rv = makeRV(Some(10), None, 50)
         QueryUtils.trackChildSamplesScanned(
@@ -243,7 +243,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should apply default samplesPerChildRow") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         val rv = makeRV(Some(10), None, 0)
         val config = SamplesScannedConfig(defaultSamplesPerChildRow = 2)
@@ -255,7 +255,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should apply default samplesPerChildSeries") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         val rv = makeRV(Some(0), None, 0)
         val config = SamplesScannedConfig(defaultSamplesPerChildSeries = 7.0)
@@ -267,7 +267,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should apply default samplesPerChildPartKeyByte") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         val rv = makeRV(None, None, 10)
         val config = SamplesScannedConfig(defaultSamplesPerChildPartKeyByte = 3.0)
@@ -279,7 +279,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should apply class-specific samplesPerChildRow") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         val rv = makeRV(Some(10), None, 0)
         val config = SamplesScannedConfig(classToSamplesPerChildRow = Map(classOf[String] -> 2.0))
@@ -291,7 +291,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should apply class-specific samplesPerChildSeries") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         val rv = makeRV(Some(0), None, 0)
         val config = SamplesScannedConfig(classToSamplesPerChildSeries = Map(classOf[String] -> 7.0))
@@ -303,7 +303,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should apply class-specific samplesPerChildPartKeyByte") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         val rv = makeRV(None, None, 10)
         val config = SamplesScannedConfig(classToSamplesPerChildPartKeyByte = Map(classOf[String] -> 3.0))
@@ -315,7 +315,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should apply child row multiplier for HistogramColumn") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
+        stats.put(Seq("key"), Stat())
 
         val rv = makeRV(Some(5), None, 0)
         val config = SamplesScannedConfig(classToSamplesPerChildRow = Map(classOf[String] -> 1.0))
@@ -328,7 +328,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should increment Nil counter when only Nil key exists") {
         val stats = QueryStats()
-        stats.stat.put(Nil, Stat())
+        stats.put(Nil, Stat())
 
         val rv = makeRV(Some(10), None, 0)
         val config = SamplesScannedConfig(classToSamplesPerChildRow = Map(classOf[String] -> 1.0))
@@ -340,8 +340,8 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
 
       it("should not increment Nil counter when non-Nil keys exist") {
         val stats = QueryStats()
-        stats.stat.put(Seq("key"), Stat())
-        stats.stat.put(Nil, Stat())
+        stats.put(Seq("key"), Stat())
+        stats.put(Nil, Stat())
 
         val rv = makeRV(Some(10), None, 0)
         val config = SamplesScannedConfig(classToSamplesPerChildRow = Map(classOf[String] -> 1.0))

--- a/core/src/test/scala/filodb.core/query/QueryUtilsSpec.scala
+++ b/core/src/test/scala/filodb.core/query/QueryUtilsSpec.scala
@@ -48,12 +48,12 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
       val nilInActual = queryStats.get(Nil).isDefined
       if (!nilInExpected && nilInActual) {
         // Make sure we've already asserted the values of all other keys.
-        assert(queryStats.size == 1 + expectedCounts.size)
+        assert(queryStats.unsafeSize == 1 + expectedCounts.size)
         // Make sure no samples-scanned have been counted against Nil.
         assert(queryStats.get(Nil).get.samplesScanned.get() == 0)
       } else {
         // Make sure we've already asserted the values of all keys.
-        assert(queryStats.size == expectedCounts.size)
+        assert(queryStats.unsafeSize == expectedCounts.size)
       }
     }
 
@@ -62,7 +62,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
         val stats = QueryStats()
         QueryUtils.trackSamplesScanned(seriesScanned = 5, rowsScanned = 10, partKeyBytes = 100,
           classOf[String], stats, doubleSchema, SamplesScannedConfig())
-        assert(stats.size == 0)
+        assert(stats.unsafeSize == 0)
       }
 
       it("should count only row samples with default config") {
@@ -227,7 +227,7 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
         val rv = makeRV(Some(10), None, 50)
         QueryUtils.trackChildSamplesScanned(
           rv, classOf[String], stats, doubleSchema, SamplesScannedConfig())
-        assert(stats.size == 0)
+        assert(stats.unsafeSize == 0)
       }
 
       it("should count zero child samples with default config") {

--- a/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
+++ b/prometheus/src/main/scala/filodb/prometheus/query/PrometheusModel.scala
@@ -237,7 +237,7 @@ object PrometheusModel {
     ErrorResponse(qe.t.getClass.getSimpleName, qe.t.getMessage, "error", Some(toQueryStatistics(qe.queryStats)))
   }
 
-  def toQueryStatistics(qs: QueryStats): Seq[QueryStatistics] = qs.stat.map(stat =>
+  def toQueryStatistics(qs: QueryStats): Seq[QueryStatistics] = qs.map(stat =>
     QueryStatistics(stat._1, stat._2.timeSeriesScanned.get(),
       stat._2.dataBytesScanned.get(), stat._2.samplesScanned.get(), stat._2.resultBytes.get(), stat._2.cpuNanos.get())
   ).toSeq

--- a/query/src/main/scala/filodb/query/ProtoConverters.scala
+++ b/query/src/main/scala/filodb/query/ProtoConverters.scala
@@ -445,7 +445,7 @@ object ProtoConverters {
   implicit class QueryStatsToProtoConverter(stats: QueryStats) {
     def toProto: GrpcMultiPartitionQueryService.QueryResultStats = {
       val builder = GrpcMultiPartitionQueryService.QueryResultStats.newBuilder()
-      stats.stat.foreach {
+      stats.foreach {
         case (key, stat)  =>
           builder.putStats( key.mkString("##@##"), stat.toProto)
       }
@@ -457,7 +457,7 @@ object ProtoConverters {
     def fromProto: QueryStats = {
       val qs = QueryStats()
       statGrpc.getStatsMap.forEach {
-        case (key, stat)  =>  qs.stat.put(key.split("##@##").toList, stat.fromProto)
+        case (key, stat)  =>  qs.put(key.split("##@##").toList, stat.fromProto)
       }
       qs
     }

--- a/query/src/test/scala/filodb/query/ProtoConvertersSpec.scala
+++ b/query/src/test/scala/filodb/query/ProtoConvertersSpec.scala
@@ -154,9 +154,9 @@ class ProtoConvertersSpec extends AnyFunSpec with Matchers {
     stat2.timeSeriesScanned.addAndGet(156)
 
     val qStats = QueryStats()
-    qStats.stat.put(List(), stat2)
-    qStats.stat.put(List("L1", "L2", "L3"), stat1)
-    qStats.stat.put(List("L1", "L2", "L4"), stat)
+    qStats.put(List(), stat2)
+    qStats.put(List("L1", "L2", "L3"), stat1)
+    qStats.put(List("L1", "L2", "L4"), stat)
 
     qStats.toProto.fromProto shouldEqual qStats
   }
@@ -224,7 +224,7 @@ class ProtoConvertersSpec extends AnyFunSpec with Matchers {
     stat.timeSeriesScanned.addAndGet(5)
 
     val qStats = QueryStats()
-    qStats.stat.put(List(), stat)
+    qStats.put(List(), stat)
 
     val warnings = QueryWarnings()
     warnings.updateTimeSeriesScanned(1)
@@ -275,7 +275,7 @@ class ProtoConvertersSpec extends AnyFunSpec with Matchers {
     stat.timeSeriesScanned.addAndGet(5)
 
     val qStats = QueryStats()
-    qStats.stat.put(List(), stat)
+    qStats.put(List(), stat)
 
     val warnings = QueryWarnings()
     warnings.updateJoinQueryCardinality(1)
@@ -353,7 +353,7 @@ class ProtoConvertersSpec extends AnyFunSpec with Matchers {
     stat.timeSeriesScanned.addAndGet(5)
 
     val qStats = QueryStats()
-    qStats.stat.put(List(), stat)
+    qStats.put(List(), stat)
 
     val err = StreamQueryError("id", "planId", qStats, new IllegalArgumentException("Args"))
     val deser = err.toProto.fromProto.asInstanceOf[StreamQueryError]
@@ -422,7 +422,7 @@ class ProtoConvertersSpec extends AnyFunSpec with Matchers {
     stat.timeSeriesScanned.addAndGet(5)
 
     val qStats = QueryStats()
-    qStats.stat.put(List(), stat)
+    qStats.put(List(), stat)
 
     val warnings = QueryWarnings()
     warnings.updateTimeSeriesScanned(1)

--- a/query/src/test/scala/filodb/query/exec/ExecPlanSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/ExecPlanSpec.scala
@@ -320,20 +320,20 @@ class ExecPlanSpec extends AnyFunSpec with Matchers with ScalaFutures {
 
     def assertSamplesScanned(queryStats: QueryStats, expectedCounts: Map[Seq[String], Long]): Unit = {
       for ((key, value) <- expectedCounts) {
-        assert(value == queryStats.stat(key).samplesScanned.get())
+        assert(value == queryStats.getSamplesScannedCounter(key).get())
       }
 
       // Have to awkwardly account for the Nil key; Nil is always added for some plans.
       val nilInExpected = expectedCounts.exists(_._1.isEmpty)
-      val nilInActual = queryStats.stat.contains(Nil)
+      val nilInActual = queryStats.get(Nil).isDefined
       if (!nilInExpected && nilInActual) {
         // Make sure we've already asserted the values of all other keys.
-        assert(queryStats.stat.size == 1 + expectedCounts.size)
+        assert(queryStats.size() == 1 + expectedCounts.size)
         // Make sure no samples-scanned have been counted against Nil.
-        assert(queryStats.stat(Nil).samplesScanned.get() == 0)
+        assert(queryStats.getSamplesScannedCounter(Nil).get() == 0)
       } else {
         // Make sure we've already asserted the values of all keys.
-        assert(queryStats.stat.size == expectedCounts.size)
+        assert(queryStats.size() == expectedCounts.size)
       }
     }
 

--- a/query/src/test/scala/filodb/query/exec/ExecPlanSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/ExecPlanSpec.scala
@@ -328,12 +328,12 @@ class ExecPlanSpec extends AnyFunSpec with Matchers with ScalaFutures {
       val nilInActual = queryStats.get(Nil).isDefined
       if (!nilInExpected && nilInActual) {
         // Make sure we've already asserted the values of all other keys.
-        assert(queryStats.size() == 1 + expectedCounts.size)
+        assert(queryStats.unsafeSize() == 1 + expectedCounts.size)
         // Make sure no samples-scanned have been counted against Nil.
         assert(queryStats.getSamplesScannedCounter(Nil).get() == 0)
       } else {
         // Make sure we've already asserted the values of all keys.
-        assert(queryStats.size() == expectedCounts.size)
+        assert(queryStats.unsafeSize() == expectedCounts.size)
       }
     }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

It was found during perf testing that functions in the new samples-scanned accounting infrastructure allocate more heap objects than expected. This happens because some `TrieMap` methods (e.g. `isEmpty`) create a read-only snapshot every time they are invoked. The snapshots are small, but the memory pressure will add up on a hot path.

**New behavior :**

This PR refactors existing code to prevent unnecessary allocations. Primarily, the implementation of `QueryStats` is now changed to support frequent entry iteration without any `Iterator` allocations. The most-important fields are now:
```
  /**
   * Stores all stats entries.
   * Helpful in scenarios where e.g. entries need frequent iteration but
   *   Iterator allocations should be prevented.
   * Also useful for efficient size() calculation (as opposed to TrieMap.size(),
   *   which allocates an Object on the heap and has some computation overhead).
   */
  private val entries = ArrayBuffer[(Seq[String], Stat)]()
  private val keyToEntryIndex = new TrieMap[Seq[String], Integer]()
```

Since `QueryStats`' previous backing `TrieMap` was exposed outside the class, clients invoked its methods directly. Some of the ostensibly-overkill methods included with this PR have been added to `QueryStats` to bridge that gap; the trie no longer contains the same data, so all instances of direct trie usage have been replaced with new `QueryStats` methods.

These changes allow the new samples-scanned accounting infrastructure to operate without incurring massive memory overhead.

One additional `QueryStats`-unrelated lambda allocation in `ChunkSetInfo.scala` was found while running performance tests; this accounted for ~10% of all allocations under heavy load. The allocation is also removed as part of this PR.