### PR TITLE
Improve Cassandra read performance for churn-finder-job

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/DownsamplerContext.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/DownsamplerContext.scala
@@ -6,6 +6,7 @@ import com.typesafe.scalalogging.{Logger, StrictLogging}
 import monix.execution.Scheduler
 
 import filodb.cassandra.FiloSessionProvider
+import filodb.cassandra.columnstore.CassandraColumnStore
 import filodb.core.concurrentCache
 
 object DownsamplerContext extends StrictLogging {
@@ -14,6 +15,17 @@ object DownsamplerContext extends StrictLogging {
 
   lazy protected[downsampler] val readSched = Scheduler.io("cass-read-sched")
   lazy protected[downsampler] val writeSched = Scheduler.io("cass-write-sched")
+
+  lazy protected[downsampler] val colStoreMap = concurrentCache[Config, CassandraColumnStore](2)
+
+  def getOrCreateCassandraColumnStore(filodbConfig: Config, cassandraConfig: Config)
+                                     (implicit sched: Scheduler): CassandraColumnStore = {
+    colStoreMap.getOrElseUpdate(filodbConfig, { conf =>
+      dsLogger.info(s"Creating new CassandraColumnStore")
+      val session = getOrCreateCassandraSession(cassandraConfig)
+      new CassandraColumnStore(conf, sched, session, false)(sched)
+    })
+  }
 
   def getOrCreateCassandraSession(config: Config): Session = {
     import filodb.core._

--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelChurnFinder.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelChurnFinder.scala
@@ -14,7 +14,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.{functions, DataFrame, Dataset, SparkSession}
 import org.apache.spark.sql.functions._
 
-import filodb.cassandra.columnstore.{CassandraColumnStore, CassandraTokenRangeSplit}
+import filodb.cassandra.columnstore.CassandraTokenRangeSplit
 import filodb.coordinator.KamonShutdownHook
 import filodb.core.DatasetRef
 import filodb.core.metadata.Schemas
@@ -109,10 +109,10 @@ class LabelChurnFinder(dsSettings: DownsamplerSettings) extends Serializable wit
 
   import LabelChurnFinder._
 
-  // lazy since they get initialized and used in executors as well
-  @transient lazy private val session = DownsamplerContext.getOrCreateCassandraSession(dsSettings.cassandraConfig)
-  @transient lazy private[labelchurnfinder] val colStore =
-    new CassandraColumnStore(dsSettings.filodbConfig, sched, session, false)(sched)
+
+  private[labelchurnfinder] def colStore =
+    DownsamplerContext.getOrCreateCassandraColumnStore(dsSettings.filodbConfig, dsSettings.cassandraConfig)(sched)
+
   @transient lazy val datasetName = dsSettings.filodbConfig.as[String]("labelchurnfinder.raw-dataset-name")
   @transient lazy val datasetRef = DatasetRef(datasetName)
   @transient lazy private[labelchurnfinder] val filters = dsSettings.filodbConfig


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
**transient lazy val colStore** was re-initialized on every task deserialization, causing CassandraColumnStore to be created ~100 times per job  and re-preparing ~374k CQL statements unnecessarily.

**New behavior :**
**colStore** is now initialized once per executor JVM via DownsamplerContext singleton cache and reused across all tasks on that executor.
