### PR TITLE
fix: add dependency download backoff and reduce parallelism

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -40,7 +40,15 @@ jobs:
     - name: Install cargo-zigbuild
       run: pip install cargo-zigbuild
     - name: Run tests
-      run: .github/workflows/runtests.sh
+      uses: nick-fields/retry@v3
+      env:
+        # Default is 6; reduced to limit concurrent Maven Central connections to help prevent 429s.
+        SBT_OPTS: "-Dsbt.coursier.parallel-download-count=3"
+      with:
+        timeout_minutes: 120
+        max_attempts: 3
+        retry_wait_seconds: 60
+        command: .github/workflows/runtests.sh
     - name: Coverage Reports
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Currently, PRB dependencies fail to download due to Maven `429` (rate-limiting) errors.

**New behavior :**

- Add a backoff/retry config.
- Reduce dependency download parallelism.

**BREAKING CHANGES**

None.