### PR TITLE
fix(query): add missing samples-scanned config parse

### DIFF
--- a/coordinator/src/main/scala/filodb/coordinator/ProtoConverters.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/ProtoConverters.scala
@@ -117,6 +117,9 @@ object ProtoConverters extends StrictLogging {
       builder.setRvtSamplesEnabled(config.rvtSamplesEnabled)
       builder.setRvtChildSamplesEnabled(config.rvtChildSamplesEnabled)
       builder.setSrvSamplesEnabled(config.srvSamplesEnabled)
+      if (config.fixedRowMultiplier.isDefined) {
+        builder.setFixedRowMultiplier(config.fixedRowMultiplier.get)
+      }
       builder.setDefaultRowMultiplier(config.defaultRowMultiplier)
       builder.setHistogramRowMultiplier(config.histogramRowMultiplier)
       builder.setExponentialHistogramRowMultiplier(config.exponentialHistogramRowMultiplier)
@@ -158,6 +161,7 @@ object ProtoConverters extends StrictLogging {
         config.getRvtSamplesEnabled,
         config.getRvtChildSamplesEnabled,
         config.getSrvSamplesEnabled,
+        if (config.hasFixedRowMultiplier) Some(config.getFixedRowMultiplier) else None,
         config.getDefaultRowMultiplier,
         config.getHistogramRowMultiplier,
         config.getExponentialHistogramRowMultiplier,

--- a/core/src/main/scala/filodb.core/query/QueryConfig.scala
+++ b/core/src/main/scala/filodb.core/query/QueryConfig.scala
@@ -47,7 +47,11 @@ object QueryConfig {
         stitchDisabledTenantColumn
     )
 
-    val samplesScannedConfig = SamplesScannedConfig(queryConfig.getConfig("samples-scanned"))
+    val samplesScannedConfig = if (queryConfig.hasPath("samples-scanned")) {
+      SamplesScannedConfig(queryConfig.getConfig("samples-scanned"))
+    } else {
+      SamplesScannedConfig()
+    }
 
     val scCachingEnabled = queryConfig.as[Boolean]("single.cluster.cache.enabled")
     val scCacheSize = queryConfig.as[Int]("single.cluster.cache.cache-size")

--- a/core/src/main/scala/filodb.core/query/QueryConfig.scala
+++ b/core/src/main/scala/filodb.core/query/QueryConfig.scala
@@ -47,6 +47,8 @@ object QueryConfig {
         stitchDisabledTenantColumn
     )
 
+    val samplesScannedConfig = SamplesScannedConfig(queryConfig.getConfig("samples-scanned"))
+
     val scCachingEnabled = queryConfig.as[Boolean]("single.cluster.cache.enabled")
     val scCacheSize = queryConfig.as[Int]("single.cluster.cache.cache-size")
     val cachingConfig = CachingConfig(scCachingEnabled, scCacheSize)
@@ -62,7 +64,7 @@ object QueryConfig {
       grpcDenyList.split(",").map(_.trim.toLowerCase).toSet,
       flightDenyList.split(",").map(_.trim.toLowerCase).toSet,
       None,
-      containerOverrides, rc, cachingConfig, enableLocalDispatch)
+      containerOverrides, rc, cachingConfig, enableLocalDispatch, samplesScannedConfig)
   }
   // scalastyle:on method.length
 
@@ -87,6 +89,68 @@ object QueryConfig {
                                              Map("filodb-query-exec-aggregate-large-container" -> 65536,
                                                   "filodb-query-exec-metadataexec"             -> 8192))
 }
+
+object SamplesScannedConfig {
+  // scalastyle:off method.length
+  def apply(config: Config): SamplesScannedConfig = {
+    val defaults = SamplesScannedConfig()
+    SamplesScannedConfig(
+      config.as[Option[Boolean]]("leaf-samples-enabled")
+        .getOrElse(defaults.leafSamplesEnabled),
+      config.as[Option[Boolean]]("exec-result-samples-enabled")
+        .getOrElse(defaults.execResultSamplesEnabled),
+      config.as[Option[Boolean]]("exec-child-samples-enabled")
+        .getOrElse(defaults.execChildSamplesEnabled),
+      config.as[Option[Boolean]]("rvt-samples-enabled")
+        .getOrElse(defaults.rvtSamplesEnabled),
+      config.as[Option[Boolean]]("rvt-child-samples-enabled")
+        .getOrElse(defaults.rvtChildSamplesEnabled),
+      config.as[Option[Boolean]]("srv-samples-enabled")
+        .getOrElse(defaults.srvSamplesEnabled),
+
+      config.as[Option[Double]]("default-row-multiplier")
+        .getOrElse(defaults.defaultRowMultiplier),
+      config.as[Option[Double]]("histogram-row-multiplier")
+        .getOrElse(defaults.histogramRowMultiplier),
+      config.as[Option[Double]]("exponential-histogram-row-multiplier")
+        .getOrElse(defaults.exponentialHistogramRowMultiplier),
+
+      config.as[Option[Double]]("default-samples-per-row")
+        .getOrElse(defaults.defaultSamplesPerRow),
+      config.as[Option[Double]]("default-samples-per-series")
+        .getOrElse(defaults.defaultSamplesPerSeries),
+      config.as[Option[Double]]("default-samples-per-part-key-byte")
+        .getOrElse(defaults.defaultSamplesPerPartKeyByte),
+      config.as[Option[Map[String, Double]]]("class-to-samples-per-row")
+        .map { classNameToVal => classNameToVal.map { case (name, value) => Class.forName(name) -> value }}
+        .getOrElse(defaults.classToSamplesPerRow),
+      config.as[Option[Map[String, Double]]]("class-to-samples-per-series")
+        .map { classNameToVal => classNameToVal.map { case (name, value) => Class.forName(name) -> value } }
+        .getOrElse(defaults.classToSamplesPerSeries),
+      config.as[Option[Map[String, Double]]]("class-to-samples-per-part-key-byte")
+        .map { classNameToVal => classNameToVal.map { case (name, value) => Class.forName(name) -> value } }
+        .getOrElse(defaults.classToSamplesPerPartKeyByte),
+
+      config.as[Option[Double]]("default-samples-per-child-row")
+        .getOrElse(defaults.defaultSamplesPerChildRow),
+      config.as[Option[Double]]("default-samples-per-child-series")
+        .getOrElse(defaults.defaultSamplesPerChildSeries),
+      config.as[Option[Double]]("default-samples-per-child-part-key-byte")
+        .getOrElse(defaults.defaultSamplesPerPartKeyByte),
+      config.as[Option[Map[String, Double]]]("class-to-samples-per-child-row")
+        .map { classNameToVal => classNameToVal.map { case (name, value) => Class.forName(name) -> value } }
+        .getOrElse(defaults.classToSamplesPerChildRow),
+      config.as[Option[Map[String, Double]]]("class-to-samples-per-child-series")
+        .map { classNameToVal => classNameToVal.map { case (name, value) => Class.forName(name) -> value } }
+        .getOrElse(defaults.classToSamplesPerChildSeries),
+      config.as[Option[Map[String, Double]]]("class-to-samples-per-child-part-key-byte")
+        .map { classNameToVal => classNameToVal.map { case (name, value) => Class.forName(name) -> value } }
+        .getOrElse(defaults.classToSamplesPerChildPartKeyByte)
+    )
+  }
+  //scalastyle:on method.length
+}
+
 case class RoutingConfig(
                           supportRemoteRawExport: Boolean                = false,
                           maxRemoteRawExportTimeRange: FiniteDuration    = 3 days,

--- a/core/src/main/scala/filodb.core/query/QueryConfig.scala
+++ b/core/src/main/scala/filodb.core/query/QueryConfig.scala
@@ -108,6 +108,8 @@ object SamplesScannedConfig {
       config.as[Option[Boolean]]("srv-samples-enabled")
         .getOrElse(defaults.srvSamplesEnabled),
 
+      config.as[Option[Double]]("fixed-row-multiplier")
+        .orElse(defaults.fixedRowMultiplier),
       config.as[Option[Double]]("default-row-multiplier")
         .getOrElse(defaults.defaultRowMultiplier),
       config.as[Option[Double]]("histogram-row-multiplier")
@@ -188,6 +190,8 @@ case class CachingConfig(
  * @param rvtSamplesEnabled toggle whether-or-not RangeVectorTransformer samples are counted.
  * @param rvtChildSamplesEnabled toggle whether-or-not RangeVectorTransformer child samples are counted.
  * @param srvSamplesEnabled toggle whether-or-not SerializedRangeVector samples are counted.
+ * @param fixedRowMultiplier if present, overrides other row-multiplier configs. This single multiplier is applied
+ *                           regardless of how many schema columns are present; the usual sum is skipped.
  * @param defaultRowMultiplier multiplier applied to row count for all non-histogram columns value types.
  * @param histogramRowMultiplier multiplier applied to row count for all non-
  *                               exponential histogram columns value types.
@@ -223,6 +227,7 @@ case class SamplesScannedConfig(
                                  rvtChildSamplesEnabled: Boolean = false,
                                  srvSamplesEnabled: Boolean = false,
 
+                                 fixedRowMultiplier: Option[Double] = None,
                                  defaultRowMultiplier: Double = 1.0,
                                  histogramRowMultiplier: Double = 25.0,
                                  exponentialHistogramRowMultiplier: Double = 50.0,

--- a/core/src/main/scala/filodb.core/query/QueryUtils.scala
+++ b/core/src/main/scala/filodb.core/query/QueryUtils.scala
@@ -171,6 +171,10 @@ object QueryUtils {
    */
   private def computeSamplesScannedRowMultiplier(schema: ResultSchema,
                                                  config: SamplesScannedConfig): Double = {
+    if (config.fixedRowMultiplier.isDefined) {
+      return config.fixedRowMultiplier.get
+    }
+
     // NOTE: avoiding .sum, .map, and `for` to prevent the allocation overhead.
     var rowMultiplier = 0.0
     var i = 0

--- a/core/src/test/scala/filodb.core/query/QueryUtilsSpec.scala
+++ b/core/src/test/scala/filodb.core/query/QueryUtilsSpec.scala
@@ -77,6 +77,18 @@ class QueryUtilsSpec extends AnyFunSpec with Matchers{
         assertSamplesScanned(stats, Map(Seq("key") -> 20))
       }
 
+      it("should correctly use fixedRowMultiplier when configured") {
+        val stats = QueryStats()
+        stats.put(Seq("key"), Stat())
+
+        QueryUtils.trackSamplesScanned(seriesScanned = 5, rowsScanned = 10, partKeyBytes = 100,
+          classOf[String], stats, doubleSchema, SamplesScannedConfig(fixedRowMultiplier = Some(1.0)))
+        // rowMultiplier = 1.0 (fixed)
+        // rowSamples = 10 * 1.0 * 1.0 (defaultSamplesPerRow) = 10
+        // seriesSamples = 5 * 0.0 = 0; partKeySamples = 100 * 0.0 = 0
+        assertSamplesScanned(stats, Map(Seq("key") -> 10))
+      }
+
       it("should split samples evenly across QueryStats entries") {
         val stats = QueryStats()
         stats.put(Seq("hello"), Stat())

--- a/grpc/src/main/protobuf/query_service.proto
+++ b/grpc/src/main/protobuf/query_service.proto
@@ -418,21 +418,22 @@ message SamplesScannedConfig {
   bool rvtSamplesEnabled                                = 4;
   bool rvtChildSamplesEnabled                           = 5;
   bool srvSamplesEnabled                                = 6;
-  double defaultRowMultiplier                           = 7;
-  double histogramRowMultiplier                         = 8;
-  double exponentialHistogramRowMultiplier              = 9;
-  double defaultSamplesPerRow                           = 10;
-  double defaultSamplesPerSeries                        = 11;
-  double defaultSamplesPerPartKeyByte                   = 12;
-  map<string, double> classToSamplesPerRow              = 13;
-  map<string, double> classToSamplesPerSeries           = 14;
-  map<string, double> classToSamplesPerPartKeyByte      = 15;
-  double defaultSamplesPerChildRow                      = 16;
-  double defaultSamplesPerChildSeries                   = 17;
-  double defaultSamplesPerChildPartKeyByte              = 18;
-  map<string, double> classToSamplesPerChildRow         = 19;
-  map<string, double> classToSamplesPerChildSeries      = 20;
-  map<string, double> classToSamplesPerChildPartKeyByte = 21;
+  optional double fixedRowMultiplier                    = 7;
+  double defaultRowMultiplier                           = 8;
+  double histogramRowMultiplier                         = 9;
+  double exponentialHistogramRowMultiplier              = 10;
+  double defaultSamplesPerRow                           = 11;
+  double defaultSamplesPerSeries                        = 12;
+  double defaultSamplesPerPartKeyByte                   = 13;
+  map<string, double> classToSamplesPerRow              = 14;
+  map<string, double> classToSamplesPerSeries           = 15;
+  map<string, double> classToSamplesPerPartKeyByte      = 16;
+  double defaultSamplesPerChildRow                      = 17;
+  double defaultSamplesPerChildSeries                   = 18;
+  double defaultSamplesPerChildPartKeyByte              = 19;
+  map<string, double> classToSamplesPerChildRow         = 20;
+  map<string, double> classToSamplesPerChildSeries      = 21;
+  map<string, double> classToSamplesPerChildPartKeyByte = 22;
 }
 
 message QueryConfig {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)

Currently, the new samples-scanned config is not parsed correctly by existing `QueryConfig` infrastructure; the parse needs to be defined explicitly (similar to other `QueryConfig` values).

**New behavior :**

This PR adds the missing parse step.

Additionally, this PR adds a `fixedRowMultiplier` config so legacy accounting behavior can be enabled. The newer sum-of-multipliers-per-schema implementation is incompatible with legacy accounting behavior; historically, each row accounted for exactly one sample.