### PR TITLE
Cherry pick improve-cassandra-read-performance-churn-finder-job  to main

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/DownsamplerContext.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/DownsamplerContext.scala
@@ -6,6 +6,7 @@ import com.typesafe.scalalogging.{Logger, StrictLogging}
 import monix.execution.Scheduler
 
 import filodb.cassandra.FiloSessionProvider
+import filodb.cassandra.columnstore.CassandraColumnStore
 import filodb.core.concurrentCache
 
 object DownsamplerContext extends StrictLogging {
@@ -14,6 +15,17 @@ object DownsamplerContext extends StrictLogging {
 
   lazy protected[downsampler] val readSched = Scheduler.io("cass-read-sched")
   lazy protected[downsampler] val writeSched = Scheduler.io("cass-write-sched")
+
+  lazy protected[downsampler] val colStoreMap = concurrentCache[Config, CassandraColumnStore](2)
+
+  def getOrCreateCassandraColumnStore(filodbConfig: Config, cassandraConfig: Config)
+                                     (implicit sched: Scheduler): CassandraColumnStore = {
+    colStoreMap.getOrElseUpdate(filodbConfig, { conf =>
+      dsLogger.info(s"Creating new CassandraColumnStore")
+      val session = getOrCreateCassandraSession(cassandraConfig)
+      new CassandraColumnStore(conf, sched, session, false)(sched)
+    })
+  }
 
   def getOrCreateCassandraSession(config: Config): Session = {
     import filodb.core._

--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelChurnFinder.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelChurnFinder.scala
@@ -1,9 +1,12 @@
 package filodb.labelchurnfinder
 
+import java.util.concurrent.TimeUnit
+
 import scala.concurrent.duration.DurationInt
 
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
+import kamon.Kamon
 import monix.execution.Scheduler
 import net.ceedubs.ficus.Ficus._
 import org.apache.datasketches.hll.HllSketch
@@ -11,14 +14,30 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.{functions, DataFrame, Dataset, SparkSession}
 import org.apache.spark.sql.functions._
 
-import filodb.cassandra.columnstore.{CassandraColumnStore, CassandraTokenRangeSplit}
+import filodb.cassandra.columnstore.CassandraTokenRangeSplit
+import filodb.coordinator.KamonShutdownHook
 import filodb.core.DatasetRef
 import filodb.core.metadata.Schemas
+import filodb.core.metrics.FilodbMetrics
 import filodb.downsampler.DownsamplerContext
 import filodb.downsampler.chunk.DownsamplerSettings
 import filodb.memory.format.UnsafeUtils
 
 object LabelChurnFinderMain extends App {
+  Kamon.init()
+  KamonShutdownHook.registerShutdownHook()
+
+  private val jobStartMs = System.currentTimeMillis()
+
+  @transient private lazy val jobDuration         =
+    FilodbMetrics.timeHistogram("lcf_job_duration", TimeUnit.MILLISECONDS)
+  @transient private lazy val workspacesPublished =
+    FilodbMetrics.counter("lcf_workspaces_published_total")
+  @transient private lazy val labelsPublished     =
+    FilodbMetrics.counter("lcf_labels_published_total")
+  @transient private lazy val kafkaFailures       =
+    FilodbMetrics.counter("lcf_kafka_publish_failures_total")
+
   private val dsSettings = new DownsamplerSettings()
   private val labelChurnFinder = new LabelChurnFinder(dsSettings)
   private val sparkConf = new SparkConf(loadDefaults = true)
@@ -27,10 +46,26 @@ object LabelChurnFinderMain extends App {
     .appName("LabelChurnFinder")
     .config(sparkConf)
     .getOrCreate()
-  private val labelStats = labelChurnFinder.computeLabelStats(spark)
+
+  // Spark accumulators collect executor-side counts back to the driver
+  private val failuresAcc   = spark.sparkContext.longAccumulator("lcf_kafka_failures")
+  private val labelsAcc     = spark.sparkContext.longAccumulator("lcf_labels_published")
+  private val workspacesAcc = spark.sparkContext.longAccumulator("lcf_workspaces_published")
+
+  private val labelStats     = labelChurnFinder.computeLabelStats(spark)
   private val publishToKafka = dsSettings.filodbConfig.as[Boolean]("labelchurnfinder.publish-to-kafka")
-  private val producer = if (publishToKafka) Some(new LabelStatsKafkaProducer(dsSettings.filodbConfig)) else None
+  private val producer = if (publishToKafka)
+    Some(new LabelStatsKafkaProducer(dsSettings.filodbConfig, failuresAcc, labelsAcc, workspacesAcc))
+  else None
+
   labelChurnFinder.actionOnLabelStats(labelStats, producer)
+
+  // After the Spark job completes, read accumulator totals and record to OTel on the driver
+  workspacesPublished.increment(workspacesAcc.value)
+  labelsPublished.increment(labelsAcc.value)
+  kafkaFailures.increment(failuresAcc.value)
+  jobDuration.record(System.currentTimeMillis() - jobStartMs)
+  Thread.sleep(62000) // allow Kamon MosaicReporter periodic tick to fire and complete gRPC publish before shutdown
   spark.stop()
 }
 
@@ -74,10 +109,10 @@ class LabelChurnFinder(dsSettings: DownsamplerSettings) extends Serializable wit
 
   import LabelChurnFinder._
 
-  // lazy since they get initialized and used in executors as well
-  @transient lazy private val session = DownsamplerContext.getOrCreateCassandraSession(dsSettings.cassandraConfig)
-  @transient lazy private[labelchurnfinder] val colStore =
-    new CassandraColumnStore(dsSettings.filodbConfig, sched, session, false)(sched)
+
+  private[labelchurnfinder] def colStore =
+    DownsamplerContext.getOrCreateCassandraColumnStore(dsSettings.filodbConfig, dsSettings.cassandraConfig)(sched)
+
   @transient lazy val datasetName = dsSettings.filodbConfig.as[String]("labelchurnfinder.raw-dataset-name")
   @transient lazy val datasetRef = DatasetRef(datasetName)
   @transient lazy private[labelchurnfinder] val filters = dsSettings.filodbConfig
@@ -93,7 +128,6 @@ class LabelChurnFinder(dsSettings: DownsamplerSettings) extends Serializable wit
    */
   private def fetchLabelValues(split: (String, String),
                        shard: Int): Iterator[LabelValRow] = {
-    logger.info(s"fetchLabelValues: shard=$shard, filters=$filters")
     colStore.scanPartKeysByStartEndTimeRangeNoAsync(datasetRef, shard, split, 0,
         Long.MaxValue, 0, Long.MaxValue)
       .flatMap { pk  =>

--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelStatsKafkaProducer.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelStatsKafkaProducer.scala
@@ -10,6 +10,7 @@ import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, Produce
 import org.apache.kafka.common.serialization.StringSerializer
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions._
+import org.apache.spark.util.LongAccumulator
 
 /**
  * Distributed Kafka producer for publishing label statistics from Spark executors.
@@ -20,7 +21,12 @@ import org.apache.spark.sql.functions._
  * 3. Publish messages in parallel from all executors
  *
  */
-class LabelStatsKafkaProducer(config: Config) extends StrictLogging {
+class LabelStatsKafkaProducer(config: Config,
+                               failuresAcc: LongAccumulator,
+                               labelsAcc: LongAccumulator,
+                               workspacesAcc: LongAccumulator,
+                               producerFactory: Map[String, String] => KafkaProducer[String, String]
+                               = LabelStatsKafkaProducer.createKafkaProducer) extends StrictLogging {
 
   import LabelChurnFinder._
 
@@ -30,7 +36,7 @@ class LabelStatsKafkaProducer(config: Config) extends StrictLogging {
 
   // Collect all kafka config properties to broadcast to executors
   private[labelchurnfinder] val kafkaProps: Map[String, String] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     kafkaConfig.entrySet().asScala
       .map(e => e.getKey -> e.getValue.unwrapped().toString)
       .toMap
@@ -97,13 +103,20 @@ class LabelStatsKafkaProducer(config: Config) extends StrictLogging {
     broadcastPartition: org.apache.spark.broadcast.Broadcast[String],
     jobTimestamp: Instant
   ): Unit = {
+    val failuresAccLocal   = failuresAcc
+    val labelsAccLocal     = labelsAcc
+    val workspacesAccLocal = workspacesAcc
+    val localFactory       = producerFactory
+
     groupedData.foreachPartition { (partition: Iterator[Row]) =>
-      val localProducer = LabelStatsKafkaProducer.createKafkaProducer(broadcastKafkaProps.value)
+      val localProducer = localFactory(broadcastKafkaProps.value)
 
       try {
         partition.foreach { row =>
           LabelStatsKafkaProducer.publishRow(row, localProducer,
-            broadcastTopic.value, broadcastPartition.value, jobTimestamp)
+            broadcastTopic.value, broadcastPartition.value, jobTimestamp,
+            failuresAccLocal, labelsAccLocal)
+          workspacesAccLocal.add(1)
         }
         localProducer.flush()
       } finally {
@@ -167,18 +180,22 @@ object LabelStatsKafkaProducer {
    * Publishes a single row (workspace) to Kafka.
    * Extracts labels, builds message, and sends asynchronously.
    */
-  private def publishRow(
+  private[labelchurnfinder] def publishRow(
     row: Row,
     producer: KafkaProducer[String, String],
     topic: String,
     partition: String,
-    jobTimestamp: Instant
+    jobTimestamp: Instant,
+    failuresAcc: LongAccumulator,
+    labelsAcc: LongAccumulator
   ): Unit = {
     val workspaceId = row.getAs[String](WsCol)
     val nsGroup = row.getAs[String](NsGroupCol)
-    val labelsArray = row.getAs[Seq[Row]]("labels")
+    val labelsArray = row.getAs[scala.collection.Seq[Row]]("labels")
 
     val labels = buildLabelsFromRows(labelsArray)
+    labelsAcc.add(labels.size)
+
     val message = LabelStatisticsMessage(
       workspaceId = workspaceId,
       mosaicPartition = partition,
@@ -187,13 +204,14 @@ object LabelStatsKafkaProducer {
       labels = labels
     )
 
-    sendToKafka(producer, topic, workspaceId, message, partition)
+    sendToKafka(producer, topic, workspaceId, message, partition, failuresAcc)
   }
 
   /**
    * Builds label statistics from Spark Row data.
    */
-  private[labelchurnfinder] def buildLabelsFromRows(labelsArray: Seq[Row]): Seq[LabelStatDto] = {
+  private[labelchurnfinder] def buildLabelsFromRows(labelsArray: scala.collection.Seq[Row]):
+  scala.collection.Seq[LabelStatDto] = {
     labelsArray.map { labelRow =>
       LabelStatDto(
         labelName = labelRow.getAs[String](0),
@@ -215,13 +233,15 @@ object LabelStatsKafkaProducer {
     topic: String,
     key: String,
     message: LabelStatisticsMessage,
-    partition: String
+    partition: String,
+    failuresAcc: LongAccumulator
   ): Unit = {
     val record = new ProducerRecord[String, String](topic, key, message.asJson.noSpaces)
 
-    producer.send(record, (metadata: RecordMetadata, exception: Exception) => {
+    producer.send(record, (_: RecordMetadata, exception: Exception) => {
       if (exception != null) {
         logger.error(s"Failed to publish for workspace=$key, partition=$partition: ${exception.getMessage}")
+        failuresAcc.add(1)
       }
     })
   }

--- a/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelStatsKafkaProducerSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelStatsKafkaProducerSpec.scala
@@ -3,9 +3,13 @@ package filodb.labelchurnfinder
 import com.typesafe.config.ConfigFactory
 import io.circe.parser._
 import io.circe.syntax._
+import org.apache.kafka.clients.producer.{Callback, KafkaProducer, ProducerRecord, RecordMetadata}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.types._
+import org.mockito.ArgumentMatchers.any
+import org.mockito.{Mockito, MockitoSugar}
+import org.mockito.invocation.InvocationOnMock
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -15,7 +19,7 @@ import java.time.Instant
 /**
  * Unit tests for LabelStatsKafkaProducer.
  */
-class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll {
+class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll with MockitoSugar {
 
   import LabelStatisticsMessage._
 
@@ -150,7 +154,10 @@ class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAn
           |}
           |""".stripMargin)
 
-      val producer = new LabelStatsKafkaProducer(config)
+      val producer = new LabelStatsKafkaProducer(config,
+        spark.sparkContext.longAccumulator("failures"),
+        spark.sparkContext.longAccumulator("labels"),
+        spark.sparkContext.longAccumulator("workspaces"))
 
       val grouped = producer.groupLabelsByWorkspace(df)
 
@@ -161,17 +168,17 @@ class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAn
 
       // Workspace1 should have 3 labels
       val ws1 = result.find(_.getAs[String]("ws") == "workspace1").get
-      val ws1Labels = ws1.getAs[Seq[Row]]("labels")
+      val ws1Labels = ws1.getAs[scala.collection.Seq[Row]]("labels")
       ws1Labels should have length 3
 
       // Workspace2 should have 1 label
       val ws2 = result.find(_.getAs[String]("ws") == "workspace2").get
-      val ws2Labels = ws2.getAs[Seq[Row]]("labels")
+      val ws2Labels = ws2.getAs[scala.collection.Seq[Row]]("labels")
       ws2Labels should have length 1
 
       // Workspace3 should have 1 label
       val ws3 = result.find(_.getAs[String]("ws") == "workspace3").get
-      val ws3Labels = ws3.getAs[Seq[Row]]("labels")
+      val ws3Labels = ws3.getAs[scala.collection.Seq[Row]]("labels")
       ws3Labels should have length 1
     }
   }
@@ -205,7 +212,6 @@ class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAn
   }
 
   describe("Producer configuration") {
-
     it("should use correct Kafka configuration values") {
       val config = ConfigFactory.parseString(
         """
@@ -216,11 +222,99 @@ class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAn
           |}
           |""".stripMargin)
 
-      val producer = new LabelStatsKafkaProducer(config)
+      val producer = new LabelStatsKafkaProducer(config,
+        spark.sparkContext.longAccumulator("failures"),
+        spark.sparkContext.longAccumulator("labels"),
+        spark.sparkContext.longAccumulator("workspaces"))
 
       producer.topic shouldBe "test-topic"
       producer.kafkaProps("pie.queue.kaffe.connect") shouldBe "test-server:9092"
       producer.mosaicPartition shouldBe "us-east-1-p1"
+    }
+  }
+
+  describe("Accumulator tracking") {
+
+    val accConfig = ConfigFactory.parseString(
+      """
+        |partition = "us-east-1-p1"
+        |labelchurnfinder.kafka {
+        |  topic = "test-topic"
+        |  pie.queue.kaffe.connect = "localhost:9092"
+        |}
+        |""".stripMargin)
+
+    it("should increment labelsAcc by the number of labels in the published row") {
+      val failuresAcc   = spark.sparkContext.longAccumulator("failures")
+      val labelsAcc     = spark.sparkContext.longAccumulator("labels")
+      val workspacesAcc = spark.sparkContext.longAccumulator("workspaces")
+
+      val df = createTestDataFrame(Seq(
+        ("ws-1", "All", "pod",      100L, 200L, 300L, Array[Byte](1), Array[Byte](2), Array[Byte](3)),
+        ("ws-1", "All", "instance",  50L, 100L, 150L, Array[Byte](4), Array[Byte](5), Array[Byte](6)),
+        ("ws-1", "All", "container", 30L,  60L,  90L, Array[Byte](7), Array[Byte](8), Array[Byte](9))
+      ))
+
+      val producer = new LabelStatsKafkaProducer(accConfig, failuresAcc, labelsAcc, workspacesAcc)
+      val row = producer.groupLabelsByWorkspace(df).collect().head
+
+      val mockProducer = mock[KafkaProducer[String, String]]
+      LabelStatsKafkaProducer.publishRow(row, mockProducer, "test-topic", "us-east-1-p1",
+        Instant.now(), failuresAcc, labelsAcc)
+
+      labelsAcc.value shouldBe 3
+      failuresAcc.value shouldBe 0
+    }
+
+    it("should increment failuresAcc when Kafka send callback fires with an exception") {
+      val failuresAcc   = spark.sparkContext.longAccumulator("failures")
+      val labelsAcc     = spark.sparkContext.longAccumulator("labels")
+      val workspacesAcc = spark.sparkContext.longAccumulator("workspaces")
+
+      val df = createTestDataFrame(Seq(
+        ("ws-2", "All", "pod", 100L, 200L, 300L, Array[Byte](1), Array[Byte](2), Array[Byte](3))
+      ))
+
+      val producer = new LabelStatsKafkaProducer(accConfig, failuresAcc, labelsAcc, workspacesAcc)
+      val row = producer.groupLabelsByWorkspace(df).collect().head
+
+      val mockProducer = mock[KafkaProducer[String, String]]
+      doAnswer((invocation: InvocationOnMock) => {
+        val callback = invocation.getArgument[Callback](1)
+        callback.onCompletion(null, new RuntimeException("broker unavailable"))
+        null.asInstanceOf[java.util.concurrent.Future[RecordMetadata]]
+      }).when(mockProducer).send(any[ProducerRecord[String, String]], any[Callback])
+
+      LabelStatsKafkaProducer.publishRow(row, mockProducer, "test-topic", "us-east-1-p1",
+        Instant.now(), failuresAcc, labelsAcc)
+
+      failuresAcc.value shouldBe 1
+      labelsAcc.value shouldBe 1
+    }
+
+    it("should update accumulators for all labels and workspaces via publishLabelStats") {
+      val failuresAcc   = spark.sparkContext.longAccumulator("failures")
+      val labelsAcc     = spark.sparkContext.longAccumulator("labels")
+      val workspacesAcc = spark.sparkContext.longAccumulator("workspaces")
+
+      val factory = new (Map[String, String] => KafkaProducer[String, String]) with Serializable {
+        override def apply(props: Map[String, String]): KafkaProducer[String, String] =
+          Mockito.mock(classOf[KafkaProducer[String, String]])
+      }
+
+      val producer = new LabelStatsKafkaProducer(accConfig, failuresAcc, labelsAcc, workspacesAcc, factory)
+
+      val df = createTestDataFrame(Seq(
+        ("ws-1", "All", "pod",      100L, 200L, 300L, Array[Byte](1), Array[Byte](2), Array[Byte](3)),
+        ("ws-1", "All", "instance",  50L, 100L, 150L, Array[Byte](4), Array[Byte](5), Array[Byte](6)),
+        ("ws-2", "All", "pod",       75L, 125L, 175L, Array[Byte](7), Array[Byte](8), Array[Byte](9))
+      ))
+
+      producer.publishLabelStats(df)
+
+      workspacesAcc.value shouldBe 2
+      labelsAcc.value shouldBe 3
+      failuresAcc.value shouldBe 0
     }
   }
 }


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Current behavior :
transient lazy val colStore was re-initialized on every task deserialization, causing CassandraColumnStore to be created ~100 times per job and re-preparing ~374k CQL statements unnecessarily.

New behavior :
colStore is now initialized once per executor JVM via DownsamplerContext singleton cache and reused across all tasks on that executor.
