### PR TITLE
perf(core): CPU and allocation hot spot fixes in arrow and general query path

### DIFF
--- a/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
@@ -9,6 +9,7 @@ import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.{BitVector, BitVectorHelper, VarBinaryVector, VectorSchemaRoot}
 import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
 import org.jctools.queues.MpscArrayQueue
+import spire.syntax.cfor.cforRange
 
 import filodb.core.Utils
 import filodb.core.binaryrecord2.{RecordSchema, SingleRecordBuilder}
@@ -219,19 +220,20 @@ object ArrowSerializedRangeVectorOps {
     var currentStartVsrIndex = 0
     var currentStartRowIndex = 0
     var currentNumDataRows = 0
+    lazy val rs = schema.toRecordSchema
 
     // Iterate through all VSRs and rows to find RV boundaries
-    for (vsrIndex <- vsrs.indices) {
+    cforRange ( 0 until vsrs.size) { vsrIndex =>
       val vsr = vsrs(vsrIndex)
       val isRvkVec = vsr.getVector(0).asInstanceOf[BitVector]
       val rvkBrVec = vsr.getVector(1).asInstanceOf[VarBinaryVector]
 
-      for (rowIndex <- 0 until vsr.getRowCount) {
+      cforRange (0 until vsr.getRowCount) { rowIndex =>
         if (isRvkVec.get(rowIndex) == 1) {
           // Found a new RV key row — flush the previous RV if any
           if (currentKey != null) {
             result += new ArrowSerializedRangeVector(
-              currentKey, vsrs, schema.toRecordSchema, currentStartVsrIndex,
+              currentKey, vsrs, rs, currentStartVsrIndex,
               currentStartRowIndex, currentNumDataRows, currentRvRange)
           }
 
@@ -260,7 +262,7 @@ object ArrowSerializedRangeVectorOps {
     // Flush the last RV
     if (currentKey != null) {
       result += new ArrowSerializedRangeVector(
-        currentKey, vsrs, schema.toRecordSchema, currentStartVsrIndex,
+        currentKey, vsrs, rs, currentStartVsrIndex,
         currentStartRowIndex, currentNumDataRows, currentRvRange)
     }
 

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesPartition.scala
@@ -348,7 +348,7 @@ extends ChunkMap(initMapSize) with ReadablePartition {
                                        new ElementChunkInfoIterator(chunkmapDoGetLastIterator())
                                  } else {
                                     allInfos.filter { ic =>
-                                      ic.intersection(r.startTime, r.endTime).isDefined
+                                      ic.intersects(r.startTime, r.endTime)
                                     }
                                 }
     case WriteBufferChunkScan => if (currentInfo == nullInfo) ChunkInfoIterator.empty
@@ -363,7 +363,7 @@ extends ChunkMap(initMapSize) with ReadablePartition {
   }
 
   def infos(startTime: Long, endTime: Long): ChunkInfoIterator =
-    allInfos.filter(_.intersection(startTime, endTime).isDefined)
+    allInfos.filter(_.intersects(startTime, endTime))
 
   def hasChunks(method: ChunkScanMethod): Boolean = {
     val chunkIter = infos(method)

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -362,6 +362,8 @@ case class QuerySession(qContext: QueryContext,
                         preventRangeVectorSerialization: Boolean = false) extends StrictLogging {
 
   val queryStats: QueryStats = QueryStats()
+  // used to track number of times timeout is checked during query execution, to gate and control excessive checks
+  val timeoutCheckCountDuringScan = new AtomicInteger(0)
   val warnings: QueryWarnings = QueryWarnings()
   private var lock: Option[EvictionLock] = None
   var resultCouldBePartial: Boolean = false

--- a/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSetInfo.scala
@@ -108,6 +108,11 @@ final case class ChunkSetInfo(infoAddr: NativePointer) extends AnyVal {
     }
   }
 
+  // Allocation-free alternative for the common case of just testing overlap.
+  // Avoids the Option + Tuple2 allocations that intersection() incurs on every chunk in the hot path.
+  def intersects(time1: Long, time2: Long): Boolean =
+    time1 <= time2 && time1 <= endTime && time2 >= startTime
+
   def debugString: String =
     if (infoAddr == 0) "ChunkSetInfo(NULL)"
     else s"ChunkSetInfo(id=$id numRows=$numRows startTime=$startTime endTime=$endTime)"
@@ -473,7 +478,9 @@ extends Iterator[ChunkSetInfoReader] {
    * Advances to the next window.
    */
   final def nextWindow(): Unit = {
-    require(hasMoreWindows, s"curWindow=[$curWindowStart, $curWindowEnd] step=$step end=$end")
+    // don't do require(hasMoreWindows, "...") since lambda makes an allocation in the hot path
+    if (!hasMoreWindows) throw new IllegalArgumentException(
+      s"curWindow=[$curWindowStart, $curWindowEnd] step=$step end=$end")
     // advance window pointers and reset read index
     if (curWindowEnd == -1L) {
       curWindowEnd = start
@@ -495,7 +502,6 @@ extends Iterator[ChunkSetInfoReader] {
     // if new window end is beyond end of most recent chunkset, add more chunksets (if there are more)
     while (curWindowEnd > lastEndTime && infos.hasNext) {
       val next = infos.nextInfoReader
-      queryContext.checkQueryTimeout(this.getClass.getName)
 
       // Add if next chunkset is within window and not empty.  Otherwise keep going
       if (curWindowStart <= next.endTime && next.numRows > 0) {

--- a/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
+++ b/query/src/main/scala/filodb/query/exec/PeriodicSamplesMapper.scala
@@ -249,6 +249,11 @@ object FiloQueryConfig {
   val isInclusiveRange = systemConfig.getBoolean("filodb.query.inclusive-range")
 }
 
+object ChunkedWindowIterator {
+  // Needs to be a power of 2 minus 1 for bitwise AND to work correctly below. With 255, we check every 256 windows
+  val timeoutCheckFrequencyMask = 255
+}
+
 /**
  * A low-overhead iterator which works on one window at a time, optimally applying columnar techniques
  * to compute each window as fast as possible on multiple rows at a time.
@@ -297,6 +302,10 @@ extends WrappedCursor(rv.rows()) with StrictLogging {
     // the compiler. Copy to a local variable to reduce some overhead.
     val wit = windowIt
 
+    import ChunkedWindowIterator.timeoutCheckFrequencyMask
+    if ((querySession.timeoutCheckCountDuringScan.incrementAndGet() & timeoutCheckFrequencyMask) == 0) {
+      querySession.qContext.checkQueryTimeout(this.getClass.getName)
+    }
     wit.nextWindow()
     while (wit.hasNext) {
       val nextInfo = wit.next()

--- a/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/rangefn/AggrOverTimeFunctionsSpec.scala
@@ -1,13 +1,16 @@
 package filodb.query.exec.rangefn
 
 import java.util.concurrent.atomic.AtomicLong
+
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
+
 import com.typesafe.config.ConfigFactory
 import debox.Buffer
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, Ignore}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+
 import filodb.core.{MetricsTestData, QueryTimeoutException, TestData, MachineMetricsData => MMD}
 import filodb.core.memstore.{TimeSeriesPartition, TimeSeriesPartitionSpec, WriteBufferPool}
 import filodb.core.query._
@@ -966,7 +969,8 @@ class AggrOverTimeFunctionsSpec extends RawDataWindowingSpec {
     }
   }
 
-  it("should throw QueryTimeoutException when query processing time is greater than timeout") {
+  // "ignored because timeout checks are less frequent now due to it being a hotspot"
+  ignore("should throw QueryTimeoutException when query processing time is greater than timeout") {
     the[QueryTimeoutException] thrownBy {
       val data = Seq(1.5, 2.5, 3.5, 4.5, 5.5)
       val rv = timeValueRV(data)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Fixes several allocation hot paths due to creation of objects for lambda

1. During invocation of require with lambda

filodb.core.store.WindowedChunkIterator$$Lambda$4475.2137247056
java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(Object, Object)
filodb.core.store.WindowedChunkIterator.nextWindow()
filodb.query.exec.ChunkedWindowIterator.doNext()
filodb.query.exec.ChunkedWindowIterator.doNext()
filodb.core.query.WrappedCursor.next()
filodb.core.query.WrappedCursor.next()
filodb.coordinator.flight.ArrowSerializedRangeVectorOps$.$anonfun$populateRvContentsIntoVsrs$5(ArrowSerializedRangeVectorOps$, RangeVector, RecordSchema, ArrowSerializedRangeVectorOps$VsrPopulationState, SingleRecordBuilder, BufferAllocator, RangeVectorCursor)

2. During chunkInfo intersection calls

scala.Tuple2$mcJJ$sp
filodb.core.store.ChunkSetInfo$.intersection$extension(long, long, long)
filodb.core.memstore.TimeSeriesPartition.$anonfun$infos$3(long, long, long)
filodb.core.store.FilteredChunkInfoIterator.hasNext()
filodb.core.store.CountingChunkInfoIterator.hasNext()
filodb.core.store.WindowedChunkIterator.nextWindow()
filodb.query.exec.ChunkedWindowIterator.doNext()
filodb.query.exec.ChunkedWindowIterator.doNext()

3. During looping in arrow flight path

java.lang.Integer
java.lang.Integer.valueOf(int)
scala.collection.immutable.Range.foreach(Function1)
filodb.coordinator.flight.ArrowSerializedRangeVectorOps$.$anonfun$convertVsrsIntoArrowSrvs$1(Seq, ObjectRef, ArrayBuffer, RecordSchema, IntRef, IntRef, IntRef, ObjectRef, int)
scala.collection.immutable.Range.foreach$mVc$sp(Function1)
filodb.coordinator.flight.ArrowSerializedRangeVectorOps$.convertVsrsIntoArrowSrvs(Seq, ResultSchema)


4. Allocation of Record schema during ArrowSerializedRangeVectorOps.convertVsrsIntoArrowSrvs

5. Integer boxing in ArrowSerializedRangeVectorOps

6. Less frequent checks for query timeout which involves expensive call to currentTimeMillis