### PR TITLE
feat(coord): Zstd compression for arrow flight rpc path instead of gzip

### DIFF
--- a/coordinator/src/main/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducer.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducer.scala
@@ -6,9 +6,11 @@ import java.util.{Collections, Optional}
 import java.util.concurrent.Executors
 
 import akka.actor.ActorRef
+import com.github.luben.zstd.{ZstdInputStream, ZstdOutputStream}
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
-import io.grpc.{BindableService, CallOptions, Channel, ClientCall, ClientInterceptor, Metadata, MethodDescriptor,
+import io.grpc.{BindableService, CallOptions, Channel, ClientCall, ClientInterceptor, Compressor,
+  CompressorRegistry, Decompressor, DecompressorRegistry, Metadata, MethodDescriptor,
   Server, ServerBuilder, ServerCall, ServerCallHandler, ServerInterceptor}
 import io.grpc.netty.NettyServerBuilder
 import monix.eval.Task
@@ -123,7 +125,10 @@ object FiloDBSinglePartitionFlightProducer extends StrictLogging {
       executor)
 
     val server1 = NettyServerBuilder.forPort(port)
-    val server2 = if (compressionEnabled) server1.intercept(GzipServerInterceptor) else server1
+    val server2 = if (compressionEnabled) {
+      val decompReg = DecompressorRegistry.getDefaultInstance().`with`(ZstdDecompressor, true)
+      server1.intercept(ZstdServerInterceptor).decompressorRegistry(decompReg)
+    } else server1
     val server3 = server2.addService(svc).build()
     logger.info(s"Starting FiloDB Flight server on $host:$port with compression = $compressionEnabled")
     server3.start()
@@ -131,20 +136,31 @@ object FiloDBSinglePartitionFlightProducer extends StrictLogging {
   }
 }
 
-object GzipServerInterceptor extends ServerInterceptor {
+object ZstdCompressor extends Compressor {
+  override def getMessageEncoding: String = "zstd"
+  override def compress(os: java.io.OutputStream): java.io.OutputStream = new ZstdOutputStream(os)
+}
+
+object ZstdDecompressor extends Decompressor {
+  override def getMessageEncoding: String = "zstd"
+  override def decompress(is: java.io.InputStream): java.io.InputStream = new ZstdInputStream(is)
+}
+
+object ZstdServerInterceptor extends ServerInterceptor {
+  CompressorRegistry.getDefaultInstance().register(ZstdCompressor)
   override def interceptCall[ReqT, RespT](call: ServerCall[ReqT, RespT],
                                           headers: Metadata,
                                           next: ServerCallHandler[ReqT, RespT]): ServerCall.Listener[ReqT] = {
-    call.setCompression("gzip")
+    call.setCompression("zstd")
     next.startCall(call, headers)
   }
 }
 
-object GzipClientInterceptor extends ClientInterceptor {
-
+object ZstdClientInterceptor extends ClientInterceptor {
+  CompressorRegistry.getDefaultInstance().register(ZstdCompressor)
   override def interceptCall[ReqT, RespT](method: MethodDescriptor[ReqT, RespT],
                                           callOptions: CallOptions,
                                           next: Channel): ClientCall[ReqT, RespT] = {
-    next.newCall(method, callOptions.withCompression("gzip"))
+    next.newCall(method, callOptions.withCompression("zstd"))
   }
 }

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducer.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducer.scala
@@ -10,7 +10,7 @@ import com.github.luben.zstd.{ZstdInputStream, ZstdOutputStream}
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 import io.grpc.{BindableService, CallOptions, Channel, ClientCall, ClientInterceptor, Compressor,
-  CompressorRegistry, Decompressor, DecompressorRegistry, Metadata, MethodDescriptor,
+  CompressorRegistry, Decompressor, DecompressorRegistry, ForwardingClientCall, Metadata, MethodDescriptor,
   Server, ServerBuilder, ServerCall, ServerCallHandler, ServerInterceptor}
 import io.grpc.netty.NettyServerBuilder
 import monix.eval.Task
@@ -148,19 +148,36 @@ object ZstdDecompressor extends Decompressor {
 
 object ZstdServerInterceptor extends ServerInterceptor {
   CompressorRegistry.getDefaultInstance().register(ZstdCompressor)
+
+  private val AcceptEncodingKey =
+    Metadata.Key.of("grpc-accept-encoding", Metadata.ASCII_STRING_MARSHALLER)
+
   override def interceptCall[ReqT, RespT](call: ServerCall[ReqT, RespT],
                                           headers: Metadata,
                                           next: ServerCallHandler[ReqT, RespT]): ServerCall.Listener[ReqT] = {
-    call.setCompression("zstd")
+    val acceptEncoding = headers.get(AcceptEncodingKey)
+    if (acceptEncoding != null && acceptEncoding.split(",").map(_.trim).contains("zstd")) {
+      call.setCompression("zstd")
+    }
     next.startCall(call, headers)
   }
 }
 
 object ZstdClientInterceptor extends ClientInterceptor {
   CompressorRegistry.getDefaultInstance().register(ZstdCompressor)
+
+  private val AcceptEncodingKey =
+    Metadata.Key.of("grpc-accept-encoding", Metadata.ASCII_STRING_MARSHALLER)
+
   override def interceptCall[ReqT, RespT](method: MethodDescriptor[ReqT, RespT],
                                           callOptions: CallOptions,
                                           next: Channel): ClientCall[ReqT, RespT] = {
-    next.newCall(method, callOptions.withCompression("zstd"))
+    val delegate = next.newCall(method, callOptions.withCompression("zstd"))
+    new ForwardingClientCall.SimpleForwardingClientCall[ReqT, RespT](delegate) {
+      override def start(responseListener: ClientCall.Listener[RespT], headers: Metadata): Unit = {
+        headers.put(AcceptEncodingKey, "zstd")
+        super.start(responseListener, headers)
+      }
+    }
   }
 }

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducer.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducer.scala
@@ -126,58 +126,13 @@ object FiloDBSinglePartitionFlightProducer extends StrictLogging {
 
     val server1 = NettyServerBuilder.forPort(port)
     val server2 = if (compressionEnabled) {
-      val decompReg = DecompressorRegistry.getDefaultInstance().`with`(ZstdDecompressor, true)
-      server1.intercept(ZstdServerInterceptor).decompressorRegistry(decompReg)
+      server1.intercept(ZstdServerInterceptor)
+        .compressorRegistry(ZstdCodecs.compressorRegistry)
+        .decompressorRegistry(ZstdCodecs.decompressorRegistry)
     } else server1
     val server3 = server2.addService(svc).build()
     logger.info(s"Starting FiloDB Flight server on $host:$port with compression = $compressionEnabled")
     server3.start()
     server3
-  }
-}
-
-object ZstdCompressor extends Compressor {
-  override def getMessageEncoding: String = "zstd"
-  override def compress(os: java.io.OutputStream): java.io.OutputStream = new ZstdOutputStream(os)
-}
-
-object ZstdDecompressor extends Decompressor {
-  override def getMessageEncoding: String = "zstd"
-  override def decompress(is: java.io.InputStream): java.io.InputStream = new ZstdInputStream(is)
-}
-
-object ZstdServerInterceptor extends ServerInterceptor {
-  CompressorRegistry.getDefaultInstance().register(ZstdCompressor)
-
-  private val AcceptEncodingKey =
-    Metadata.Key.of("grpc-accept-encoding", Metadata.ASCII_STRING_MARSHALLER)
-
-  override def interceptCall[ReqT, RespT](call: ServerCall[ReqT, RespT],
-                                          headers: Metadata,
-                                          next: ServerCallHandler[ReqT, RespT]): ServerCall.Listener[ReqT] = {
-    val acceptEncoding = headers.get(AcceptEncodingKey)
-    if (acceptEncoding != null && acceptEncoding.split(",").map(_.trim).contains("zstd")) {
-      call.setCompression("zstd")
-    }
-    next.startCall(call, headers)
-  }
-}
-
-object ZstdClientInterceptor extends ClientInterceptor {
-  CompressorRegistry.getDefaultInstance().register(ZstdCompressor)
-
-  private val AcceptEncodingKey =
-    Metadata.Key.of("grpc-accept-encoding", Metadata.ASCII_STRING_MARSHALLER)
-
-  override def interceptCall[ReqT, RespT](method: MethodDescriptor[ReqT, RespT],
-                                          callOptions: CallOptions,
-                                          next: Channel): ClientCall[ReqT, RespT] = {
-    val delegate = next.newCall(method, callOptions.withCompression("zstd"))
-    new ForwardingClientCall.SimpleForwardingClientCall[ReqT, RespT](delegate) {
-      override def start(responseListener: ClientCall.Listener[RespT], headers: Metadata): Unit = {
-        headers.put(AcceptEncodingKey, "zstd")
-        super.start(responseListener, headers)
-      }
-    }
   }
 }

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FlightClientManager.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FlightClientManager.scala
@@ -6,8 +6,8 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import scala.concurrent.duration.FiniteDuration
 
 import com.typesafe.scalalogging.StrictLogging
+import io.grpc.DecompressorRegistry
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
-import io.grpc.{DecompressorRegistry, ManagedChannelBuilder}
 import monix.execution.{CancelableFuture, UncaughtExceptionReporter}
 import monix.reactive.Observable
 import org.apache.arrow.flight.{CallOptions, FlightClient, FlightGrpcUtils, Location}

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FlightClientManager.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FlightClientManager.scala
@@ -6,7 +6,8 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import scala.concurrent.duration.FiniteDuration
 
 import com.typesafe.scalalogging.StrictLogging
-import io.grpc.ManagedChannelBuilder
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
+import io.grpc.{DecompressorRegistry, ManagedChannelBuilder}
 import monix.execution.{CancelableFuture, UncaughtExceptionReporter}
 import monix.reactive.Observable
 import org.apache.arrow.flight.{CallOptions, FlightClient, FlightGrpcUtils, Location}
@@ -155,10 +156,13 @@ class FlightClientManager(allocator: BufferAllocator) extends StrictLogging {
   private def createNewClientEntry(location: Location): FlightClientEntry = {
     try {
 
-      val channel1 = ManagedChannelBuilder.forAddress(location.getUri.getHost, location.getUri.getPort)
-        .usePlaintext().asInstanceOf[ManagedChannelBuilder[_]]
-      val channel2 = if (compressionEnabled) channel1.intercept(GzipClientInterceptor) else channel1
-      val channel3 = channel2.asInstanceOf[ManagedChannelBuilder[_]].build()
+      val channel1 = NettyChannelBuilder.forAddress(location.getUri.getHost, location.getUri.getPort)
+        .usePlaintext()
+      val channel2 = if (compressionEnabled) {
+        val decompReg = DecompressorRegistry.getDefaultInstance.`with`(ZstdDecompressor, true)
+        channel1.intercept(ZstdClientInterceptor).decompressorRegistry(decompReg)
+      } else channel1
+      val channel3 = channel2.build()
       val client = FlightGrpcUtils.createFlightClient(allocator, channel3)
 
       val entry = FlightClientEntry(

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FlightClientManager.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FlightClientManager.scala
@@ -6,7 +6,6 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import scala.concurrent.duration.FiniteDuration
 
 import com.typesafe.scalalogging.StrictLogging
-import io.grpc.DecompressorRegistry
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
 import monix.execution.{CancelableFuture, UncaughtExceptionReporter}
 import monix.reactive.Observable
@@ -159,8 +158,9 @@ class FlightClientManager(allocator: BufferAllocator) extends StrictLogging {
       val channel1 = NettyChannelBuilder.forAddress(location.getUri.getHost, location.getUri.getPort)
         .usePlaintext()
       val channel2 = if (compressionEnabled) {
-        val decompReg = DecompressorRegistry.getDefaultInstance.`with`(ZstdDecompressor, true)
-        channel1.intercept(ZstdClientInterceptor).decompressorRegistry(decompReg)
+        channel1.intercept(ZstdClientInterceptor)
+          .compressorRegistry(ZstdCodecs.compressorRegistry)
+          .decompressorRegistry(ZstdCodecs.decompressorRegistry)
       } else channel1
       val channel3 = channel2.build()
       val client = FlightGrpcUtils.createFlightClient(allocator, channel3)

--- a/coordinator/src/main/scala/filodb/coordinator/flight/ZstdGrpc.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/ZstdGrpc.scala
@@ -1,0 +1,57 @@
+package filodb.coordinator.flight
+
+import com.github.luben.zstd.{ZstdInputStream, ZstdOutputStream}
+import io.grpc._
+
+object ZstdCompressor extends Compressor {
+  override def getMessageEncoding: String = "zstd"
+  override def compress(os: java.io.OutputStream): java.io.OutputStream = new ZstdOutputStream(os)
+}
+
+object ZstdDecompressor extends Decompressor {
+  override def getMessageEncoding: String = "zstd"
+  override def decompress(is: java.io.InputStream): java.io.InputStream = new ZstdInputStream(is)
+}
+
+object ZstdCodecs {
+  val compressorRegistry: CompressorRegistry = {
+    val r = CompressorRegistry.newEmptyInstance()
+    r.register(ZstdCompressor)
+    r
+  }
+  val decompressorRegistry: DecompressorRegistry =
+    DecompressorRegistry.getDefaultInstance.`with`(ZstdDecompressor, true)
+}
+
+object ZstdServerInterceptor extends ServerInterceptor {
+
+  private val AcceptEncodingKey =
+    Metadata.Key.of("grpc-accept-encoding", Metadata.ASCII_STRING_MARSHALLER)
+
+  override def interceptCall[ReqT, RespT](call: ServerCall[ReqT, RespT],
+                                          headers: Metadata,
+                                          next: ServerCallHandler[ReqT, RespT]): ServerCall.Listener[ReqT] = {
+    val acceptEncoding = headers.get(AcceptEncodingKey)
+    if (acceptEncoding != null && acceptEncoding.split(",").map(_.trim).contains("zstd")) {
+      call.setCompression("zstd")
+    }
+    next.startCall(call, headers)
+  }
+}
+
+object ZstdClientInterceptor extends ClientInterceptor {
+  private val AcceptEncodingKey =
+    Metadata.Key.of("grpc-accept-encoding", Metadata.ASCII_STRING_MARSHALLER)
+
+  override def interceptCall[ReqT, RespT](method: MethodDescriptor[ReqT, RespT],
+                                          callOptions: CallOptions,
+                                          next: Channel): ClientCall[ReqT, RespT] = {
+    val delegate = next.newCall(method, callOptions.withCompression("zstd"))
+    new ForwardingClientCall.SimpleForwardingClientCall[ReqT, RespT](delegate) {
+      override def start(responseListener: ClientCall.Listener[RespT], headers: Metadata): Unit = {
+        headers.put(AcceptEncodingKey, "zstd")
+        super.start(responseListener, headers)
+      }
+    }
+  }
+}

--- a/coordinator/src/test/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducerSpec.scala
+++ b/coordinator/src/test/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducerSpec.scala
@@ -1,7 +1,11 @@
 package filodb.coordinator.flight
 
 import com.typesafe.config.ConfigFactory
-import org.apache.arrow.flight.Location
+import io.grpc.{CallOptions, Channel, ClientCall, ClientInterceptor, DecompressorRegistry, Metadata, MethodDescriptor}
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall
+import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener
+import io.grpc.netty.NettyChannelBuilder
+import org.apache.arrow.flight.{FlightGrpcUtils, Location, Ticket}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
@@ -294,6 +298,46 @@ class FiloDBSinglePartitionFlightProducerSpec extends AnyFunSpec with Matchers w
       qRes4.result.head.asInstanceOf[ArrowSerializedRangeVector].vsrs.foreach(_.close())
       // println(allocator.toVerboseString)
       allocator.getAllocatedMemory shouldEqual allocatedMemBeforeQuery
+    }
+
+    it("should use zstd encoding on the wire when compression-enabled is true") {
+      val encodingKey = Metadata.Key.of("grpc-encoding", Metadata.ASCII_STRING_MARSHALLER)
+      @volatile var capturedEncoding: Option[String] = None
+
+      val headerCapture = new ClientInterceptor {
+        override def interceptCall[ReqT, RespT](method: MethodDescriptor[ReqT, RespT],
+                                                callOptions: CallOptions,
+                                                next: Channel): ClientCall[ReqT, RespT] =
+          new SimpleForwardingClientCall[ReqT, RespT](next.newCall(method, callOptions)) {
+            override def start(responseListener: ClientCall.Listener[RespT], headers: Metadata): Unit =
+              super.start(new SimpleForwardingClientCallListener[RespT](responseListener) {
+                override def onHeaders(responseHeaders: Metadata): Unit = {
+                  capturedEncoding = Option(responseHeaders.get(encodingKey))
+                  super.onHeaders(responseHeaders)
+                }
+              }, headers)
+          }
+      }
+
+      val testAllocator = FlightAllocator.newChildAllocatorForTesting("CompressionTest", 0, 1000000)
+      val decompReg = DecompressorRegistry.getDefaultInstance().`with`(ZstdDecompressor, true)
+      val channel = NettyChannelBuilder
+        .forAddress("localhost", 38815)
+        .usePlaintext()
+        .intercept(ZstdClientInterceptor)
+        .intercept(headerCapture)
+        .decompressorRegistry(decompReg)
+        .build()
+      val testClient = FlightGrpcUtils.createFlightClient(testAllocator, channel)
+      try {
+        val stream = testClient.getStream(new Ticket(FlightKryoSerDeser.serializeToBytes(mspe1)))
+        try { while (stream.next()) {} } finally { stream.close() }
+      } finally {
+        testClient.close()
+        testAllocator.close()
+      }
+
+      capturedEncoding shouldEqual Some("zstd")
     }
   }
 }

--- a/coordinator/src/test/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducerSpec.scala
+++ b/coordinator/src/test/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducerSpec.scala
@@ -1,7 +1,7 @@
 package filodb.coordinator.flight
 
 import com.typesafe.config.ConfigFactory
-import io.grpc.{CallOptions, Channel, ClientCall, ClientInterceptor, DecompressorRegistry, Metadata, MethodDescriptor}
+import io.grpc.{CallOptions, Channel, ClientCall, ClientInterceptor, Metadata, MethodDescriptor}
 import io.grpc.ForwardingClientCall.SimpleForwardingClientCall
 import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener
 import io.grpc.netty.NettyChannelBuilder
@@ -320,13 +320,13 @@ class FiloDBSinglePartitionFlightProducerSpec extends AnyFunSpec with Matchers w
       }
 
       val testAllocator = FlightAllocator.newChildAllocatorForTesting("CompressionTest", 0, 1000000)
-      val decompReg = DecompressorRegistry.getDefaultInstance().`with`(ZstdDecompressor, true)
       val channel = NettyChannelBuilder
         .forAddress("localhost", 38815)
         .usePlaintext()
         .intercept(ZstdClientInterceptor)
         .intercept(headerCapture)
-        .decompressorRegistry(decompReg)
+        .compressorRegistry(ZstdCodecs.compressorRegistry)
+        .decompressorRegistry(ZstdCodecs.decompressorRegistry)
         .build()
       val testClient = FlightGrpcUtils.createFlightClient(testAllocator, channel)
       try {

--- a/coordinator/src/test/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducerSpec.scala
+++ b/coordinator/src/test/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducerSpec.scala
@@ -339,5 +339,43 @@ class FiloDBSinglePartitionFlightProducerSpec extends AnyFunSpec with Matchers w
 
       capturedEncoding shouldEqual Some("zstd")
     }
+
+    it("should not use zstd encoding when client does not advertise zstd in grpc-accept-encoding") {
+      val encodingKey = Metadata.Key.of("grpc-encoding", Metadata.ASCII_STRING_MARSHALLER)
+      @volatile var capturedEncoding: Option[String] = None
+
+      val headerCapture = new ClientInterceptor {
+        override def interceptCall[ReqT, RespT](method: MethodDescriptor[ReqT, RespT],
+                                                callOptions: CallOptions,
+                                                next: Channel): ClientCall[ReqT, RespT] =
+          new SimpleForwardingClientCall[ReqT, RespT](next.newCall(method, callOptions)) {
+            override def start(responseListener: ClientCall.Listener[RespT], headers: Metadata): Unit =
+              super.start(new SimpleForwardingClientCallListener[RespT](responseListener) {
+                override def onHeaders(responseHeaders: Metadata): Unit = {
+                  capturedEncoding = Option(responseHeaders.get(encodingKey))
+                  super.onHeaders(responseHeaders)
+                }
+              }, headers)
+          }
+      }
+
+      val testAllocator = FlightAllocator.newChildAllocatorForTesting("NoZstdAcceptTest", 0, 1000000)
+      // No ZstdClientInterceptor — grpc-accept-encoding: zstd is never sent
+      val channel = NettyChannelBuilder
+        .forAddress("localhost", 38815)
+        .usePlaintext()
+        .intercept(headerCapture)
+        .build()
+      val testClient = FlightGrpcUtils.createFlightClient(testAllocator, channel)
+      try {
+        val stream = testClient.getStream(new Ticket(FlightKryoSerDeser.serializeToBytes(mspe1)))
+        try { while (stream.next()) {} } finally { stream.close() }
+      } finally {
+        testClient.close()
+        testAllocator.close()
+      }
+
+      capturedEncoding should not equal Some("zstd")
+    }
   }
 }

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -521,7 +521,8 @@ filodb {
     # Maximum memory for Flight server root allocator (in bytes)
     root-allocator-max-memory = 2 GB
 
-    # gzip compression for Flight
+    # zstd compression for Flight (better than gzip)
+    # disabled by default since I still see allocations without much decrease in latency
     compression-enabled = false
 
     server {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Replacing gzip compression with zstd for arrow flight.
FWIW, it is still disabled by default for prod since the gains are not significant yet.
