### PR TITLE
fix: resolve Kamon memory leak with singleton initialization

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/FilodbCluster.scala
@@ -13,7 +13,6 @@ import akka.cluster.ClusterEvent._
 import akka.util.Timeout
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
-import kamon.Kamon
 import monix.execution.{Scheduler, UncaughtExceptionReporter}
 
 import filodb.core.GlobalScheduler
@@ -244,7 +243,7 @@ final class FilodbCluster(val system: ExtendedActorSystem, overrideConfig: Confi
 }
 
 private[filodb] trait KamonInit {
-  Kamon.init()
+  filodb.coordinator.KamonSingleton.initOnce()
 }
 
 /** Mixin for easy usage of the FiloDBCluster Extension.

--- a/coordinator/src/main/scala/filodb/coordinator/KamonSingleton.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/KamonSingleton.scala
@@ -1,0 +1,42 @@
+package filodb.coordinator
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import com.typesafe.scalalogging.StrictLogging
+import kamon.Kamon
+
+/**
+ * Singleton object to ensure Kamon is initialized only once per JVM.
+ * This prevents memory leaks from multiple Kamon.init() calls in Spark workers.
+ */
+object KamonSingleton extends StrictLogging {
+
+  private val initialized = new AtomicBoolean(false)
+
+  /**
+   * Initializes Kamon if it hasn't been initialized already.
+   * This method is thread-safe and idempotent.
+   */
+  def initOnce(): Unit = {
+    if (initialized.compareAndSet(false, true)) {
+      logger.info("Initializing Kamon for the first time in this JVM")
+      Kamon.init()
+      logger.info("Kamon initialization completed")
+    } else {
+      logger.debug("Kamon already initialized in this JVM, skipping")
+    }
+  }
+
+  /**
+   * Checks if Kamon has been initialized in this JVM.
+   */
+  def isInitialized: Boolean = initialized.get()
+
+  /**
+   * For testing purposes only - resets the initialization state.
+   * Should not be used in production code.
+   */
+  private[coordinator] def resetForTesting(): Unit = {
+    initialized.set(false)
+  }
+}

--- a/coordinator/src/test/scala/filodb/coordinator/KamonSingletonSpec.scala
+++ b/coordinator/src/test/scala/filodb/coordinator/KamonSingletonSpec.scala
@@ -1,0 +1,77 @@
+package filodb.coordinator
+
+import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
+
+class KamonSingletonSpec extends FunSpec with Matchers with BeforeAndAfterEach {
+
+  override def beforeEach(): Unit = {
+    // Reset the initialization state before each test
+    KamonSingleton.resetForTesting()
+  }
+
+  describe("KamonSingleton") {
+    it("should initialize Kamon only once") {
+      // Initially not initialized
+      KamonSingleton.isInitialized shouldBe false
+
+      // First call should initialize
+      KamonSingleton.initOnce()
+      KamonSingleton.isInitialized shouldBe true
+
+      // Second call should be idempotent (no-op)
+      KamonSingleton.initOnce()
+      KamonSingleton.isInitialized shouldBe true
+    }
+
+    it("should be thread-safe") {
+      import scala.concurrent.{ExecutionContext, Future}
+      import scala.concurrent.duration._
+      import scala.util.{Failure, Success}
+      
+      implicit val ec: ExecutionContext = ExecutionContext.global
+      
+      // Create multiple threads that try to initialize Kamon concurrently
+      val futures = (1 to 10).map { _ =>
+        Future {
+          KamonSingleton.initOnce()
+          KamonSingleton.isInitialized
+        }
+      }
+
+      // Wait for all futures to complete
+      val results = Future.sequence(futures)
+      
+      // All should return true (initialized)
+      results.onComplete {
+        case Success(values) =>
+          values.foreach(_ shouldBe true)
+          KamonSingleton.isInitialized shouldBe true
+        case Failure(exception) =>
+          fail(s"Thread safety test failed: ${exception.getMessage}")
+      }
+      
+      // Block until completion (for test purposes)
+      Thread.sleep(1000)
+    }
+
+    it("should handle multiple calls from different simulated Spark workers") {
+      // Simulate multiple Spark worker JVMs calling initOnce
+      val workerSimulations = (1 to 5).map { workerId =>
+        () => {
+          // Each "worker" calls initOnce multiple times (simulating map/mapPartitions)
+          (1 to 3).foreach { _ =>
+            KamonSingleton.initOnce()
+          }
+          KamonSingleton.isInitialized
+        }
+      }
+
+      // Execute all worker simulations
+      val results = workerSimulations.map(_.apply())
+      
+      // All should return true and Kamon should be initialized only once
+      results.foreach(_ shouldBe true)
+      KamonSingleton.isInitialized shouldBe true
+    }
+  }
+}

--- a/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
+++ b/gateway/src/main/scala/filodb/gateway/GatewayServer.scala
@@ -62,7 +62,7 @@ import filodb.timeseries.TestTimeseriesProducer
  * Oh, and you have to observe on shards 1 and 3.
  */
 object GatewayServer extends StrictLogging {
-  Kamon.init
+  filodb.coordinator.KamonSingleton.initOnce()
 
   // Get global configuration using universal FiloDB/Akka-based config
   val settings = new FilodbSettings()

--- a/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
+++ b/jmh/src/main/scala/filodb.jmh/QueryInMemoryBenchmark.scala
@@ -43,6 +43,7 @@ object Params {
  */
 @State(Scope.Thread)
 class QueryInMemoryBenchmark extends StrictLogging {
+  filodb.coordinator.KamonSingleton.initOnce()   // Needed for metrics logging
   org.slf4j.LoggerFactory.getLogger("filodb").asInstanceOf[Logger].setLevel(Level.INFO)
 
   import filodb.coordinator._

--- a/spark-jobs/src/main/scala/filodb/cardbuster/CadinalityBusterMain.scala
+++ b/spark-jobs/src/main/scala/filodb/cardbuster/CadinalityBusterMain.scala
@@ -1,11 +1,11 @@
 package filodb.cardbuster
 
 import com.typesafe.scalalogging.{Logger, StrictLogging}
-import kamon.Kamon
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 
 import filodb.cassandra.columnstore.CassandraTokenRangeSplit
+import filodb.coordinator.KamonSingleton
 import filodb.downsampler.chunk.DownsamplerSettings
 import filodb.downsampler.index.DSIndexJobSettings
 
@@ -64,10 +64,10 @@ class CardinalityBuster(dsSettings: DownsamplerSettings, dsIndexJobSettings: DSI
       val numPksDeleted = spark.sparkContext
         .makeRDD(busterForShard.colStore.getScanSplits(busterForShard.dataset))
         .mapPartitions { split =>
-          Kamon.init() // kamon init should be first thing in worker jvm
+          KamonSingleton.initOnce() // kamon init should be first thing in worker jvm
           split.flatMap(_.asInstanceOf[CassandraTokenRangeSplit].tokens)
         }.map { sp =>
-          Kamon.init() // kamon init should be first thing in worker jvm
+          KamonSingleton.initOnce() // kamon init should be first thing in worker jvm
           busterForShard.bustIndexRecords( -1 /* not used for v2 */, sp, isSimulation)
         }.sum()
       BusterContext.log.info(s"CardinalityBuster completed successfully with " +
@@ -78,14 +78,14 @@ class CardinalityBuster(dsSettings: DownsamplerSettings, dsIndexJobSettings: DSI
       val numPksDeleted = spark.sparkContext
         .makeRDD(0 until numShards)
         .mapPartitions { shards =>
-          Kamon.init() // kamon init should be first thing in worker jvm
+          KamonSingleton.initOnce() // kamon init should be first thing in worker jvm
           val splits = busterForShard.colStore.getScanSplits(busterForShard.dataset)
           for {sh <- shards
                sp <- splits.flatMap(_.asInstanceOf[CassandraTokenRangeSplit].tokens).iterator} yield {
             (sh, sp)
           }
         }.map { case (shard, sp) =>
-          Kamon.init() // kamon init should be first thing in worker jvm
+          KamonSingleton.initOnce() // kamon init should be first thing in worker jvm
           busterForShard.bustIndexRecords(shard, sp, isSimulation)
         }.sum()
       BusterContext.log.info(s"CardinalityBuster completed successfully with " +

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerMain.scala
@@ -8,13 +8,12 @@ import scala.collection.mutable.ListBuffer
 import scala.collection.parallel.CollectionConverters._
 import scala.collection.parallel.ForkJoinTaskSupport
 
-import kamon.Kamon
 import org.apache.spark.SparkConf
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.types._
 
-import filodb.coordinator.KamonShutdownHook
+import filodb.coordinator.{KamonShutdownHook, KamonSingleton}
 import filodb.core.binaryrecord2.RecordSchema
 import filodb.core.memstore.PagedReadablePartition
 import filodb.core.metrics.FilodbMetrics
@@ -70,7 +69,7 @@ class DefaultDSPartitionReader extends DSPartitionReader {
     spark.sparkContext
       .makeRDD(splits)
       .mapPartitions { splitIter: Iterator[ScanSplit] =>
-        Kamon.init()
+        KamonSingleton.initOnce()
         KamonShutdownHook.registerShutdownHook()
         val rawDataSource = batchDownsampler.rawCassandraColStore
         rawDataSource.initialize(
@@ -120,7 +119,7 @@ class DefaultDSPartitionReader extends DSPartitionReader {
   */
 object DownsamplerMain extends App {
 
-  Kamon.init()  // kamon init should be first thing in driver jvm
+  KamonSingleton.initOnce()  // kamon init should be first thing in driver jvm
   val settings = new DownsamplerSettings()
   val d = new Downsampler(settings)
   val sparkConf = new SparkConf(loadDefaults = true)
@@ -241,7 +240,7 @@ class Downsampler(settings: DownsamplerSettings) extends Serializable {
 
     val pagedReadablePartitionsRdd: RDD[Seq[PagedReadablePartition]] =
       sourceRdd.map { rawPartsBatch: Seq[RawPartData] =>
-        Kamon.init()
+        KamonSingleton.initOnce()
         KamonShutdownHook.registerShutdownHook()
         // convert each RawPartData to a ReadablePartition
         rawPartsBatch.map { rawPart =>

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJobMain.scala
@@ -3,11 +3,10 @@ package filodb.downsampler.index
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 
-import kamon.Kamon
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 
-import filodb.coordinator.KamonShutdownHook
+import filodb.coordinator.{KamonShutdownHook, KamonSingleton}
 import filodb.core.metrics.FilodbMetrics
 import filodb.downsampler.DownsamplerContext
 import filodb.downsampler.chunk.DownsamplerSettings
@@ -32,7 +31,7 @@ import filodb.downsampler.chunk.DownsamplerSettings
   */
 object DSIndexJobMain extends App {
 
-  Kamon.init()  // kamon init should be first thing in driver jvm
+  KamonSingleton.initOnce()  // kamon init should be first thing in driver jvm
   val dsSettings = new DownsamplerSettings()
   val dsIndexJobSettings = new DSIndexJobSettings(dsSettings)
 
@@ -107,7 +106,7 @@ class IndexJobDriver(dsSettings: DownsamplerSettings, dsIndexJobSettings: DSInde
     spark.sparkContext
       .makeRDD(0 until numShards)
       .foreach { shard =>
-        Kamon.init()
+        KamonSingleton.initOnce()
         KamonShutdownHook.registerShutdownHook()
         job.updateDSPartKeyIndex(shard, startHour, endHourExcl, doFullMigration)
       }

--- a/standalone/src/main/scala/filodb.standalone/NewFiloServerMain.scala
+++ b/standalone/src/main/scala/filodb.standalone/NewFiloServerMain.scala
@@ -27,8 +27,7 @@ object NewFiloServerMain extends StrictLogging {
 
       val allConfig = GlobalConfig.configToDisableAkkaCluster.withFallback(GlobalConfig.systemConfig)
       val settings = FilodbSettings.initialize(allConfig)
-
-      Kamon.init()
+      filodb.coordinator.KamonSingleton.initOnce()
 
       val system = ActorSystemHolder.createActorSystem("filo-standalone", allConfig)
 


### PR DESCRIPTION
Replace multiple Kamon.init() calls with thread-safe singleton pattern. Fixes creation of 2M+ ModuleRegistry instances in Spark executors.

- Add KamonSingleton with AtomicBoolean for idempotent init
- Replace Kamon.init() in all Spark jobs and server components
- Remove unused Kamon imports
- Add comprehensive test suite for thread safety

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
Before the spark job would create  `kamon.module.ModuleRegistry$$anon$4` infinitely.
<img width="2218" height="746" alt="image" src="https://github.com/user-attachments/assets/44257f92-739e-49f7-a940-b902e72c94db" />

**New behavior :**

Only create `kamon.module.ModuleRegistry$$anon$4` once.
<img width="3104" height="860" alt="image" src="https://github.com/user-attachments/assets/a5a668af-5a57-47ae-b725-b2294abbb7fe" />


**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: