### PR TITLE
Fix lcf hll sketch jdk21 serialization

### DIFF
--- a/project/FiloBuild.scala
+++ b/project/FiloBuild.scala
@@ -128,6 +128,7 @@ object Submodules {
     .dependsOn(cassandra, core % "compile->compile; test->test")
     .settings(
       commonSettings,
+      FiloSettings.testSettings,
       name := "spark-jobs",
       fork in Test := true,
       Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,

--- a/project/FiloSettings.scala
+++ b/project/FiloSettings.scala
@@ -105,6 +105,7 @@ object FiloSettings {
     "--add-opens=java.base/java.nio=ALL-UNNAMED",
     "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
     "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
+    "--add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED",
     "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
     "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
     "--add-opens=java.base/sun.security.action=ALL-UNNAMED",

--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/HllSketchAgg.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/HllSketchAgg.scala
@@ -7,34 +7,36 @@ import org.apache.spark.sql.{Encoder, Encoders}
 import org.apache.spark.sql.expressions.Aggregator
 
 case class HllSketchAgg(lgK: Int = 12, tgt: TgtHllType = TgtHllType.HLL_4)
-  extends Aggregator[String, HllSketch, Array[Byte]] with Serializable {
+  extends Aggregator[String, Array[Byte], Array[Byte]] with Serializable {
 
   // buffer zero: a fresh updatable sketch
-  override def zero: HllSketch = new HllSketch(lgK, tgt)
+  override def zero: Array[Byte] = new HllSketch(lgK, tgt).toCompactByteArray
 
   // add single input to the sketch
-  override def reduce(buffer: HllSketch, input: String): HllSketch = {
+  override def reduce(buffer: Array[Byte], input: String): Array[Byte] = {
     if (input != null) {
-      buffer.update(input.getBytes(StandardCharsets.UTF_8))
-    }
-    buffer
+      val sketch = HllSketch.heapify(buffer)
+      sketch.update(input.getBytes(StandardCharsets.UTF_8))
+      sketch.toCompactByteArray
+    } else buffer
   }
 
   // merge two sketches using Union (safe/easy path)
-  override def merge(b1: HllSketch, b2: HllSketch): HllSketch = {
-    val union = new Union(Math.max(lgK, Math.max(b1.getLgConfigK, b2.getLgConfigK)))
-    union.update(b1)
-    union.update(b2)
-    union.getResult(tgt)
+  override def merge(b1: Array[Byte], b2: Array[Byte]): Array[Byte] = {
+    val s1 = HllSketch.heapify(b1)
+    val s2 = HllSketch.heapify(b2)
+    val union = new Union(Math.max(lgK, Math.max(s1.getLgConfigK, s2.getLgConfigK)))
+    union.update(s1)
+    union.update(s2)
+    union.getResult(tgt).toCompactByteArray
   }
 
-  override def finish(reduction: HllSketch): Array[Byte] = {
+  override def finish(reduction: Array[Byte]): Array[Byte] = {
     // Use compact representation (smaller) for storage/transfers
-    reduction.toCompactByteArray
+    reduction
   }
 
   // encoders
-  override def bufferEncoder: Encoder[HllSketch] = Encoders.kryo[HllSketch]
+  override def bufferEncoder: Encoder[Array[Byte]] = Encoders.BINARY
   override def outputEncoder: Encoder[Array[Byte]] = Encoders.BINARY
 }
-

--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/HllSketchMergeAgg.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/HllSketchMergeAgg.scala
@@ -10,28 +10,32 @@ import org.apache.spark.sql.expressions.Aggregator
  * sketches built per salt bucket into the final per-(ws, label) sketch.
  */
 case class HllSketchMergeAgg(lgK: Int = 12, tgt: TgtHllType = TgtHllType.HLL_4)
-  extends Aggregator[Array[Byte], HllSketch, Array[Byte]] with Serializable {
+  extends Aggregator[Array[Byte], Array[Byte], Array[Byte]] with Serializable {
 
-  override def zero: HllSketch = new HllSketch(lgK, tgt)
+  override def zero: Array[Byte] = new HllSketch(lgK, tgt).toCompactByteArray
 
-  override def reduce(buffer: HllSketch, input: Array[Byte]): HllSketch = {
+  override def reduce(buffer: Array[Byte], input: Array[Byte]): Array[Byte] = {
     if (input != null) {
-      val union = new Union(Math.max(lgK, buffer.getLgConfigK))
-      union.update(buffer)
-      union.update(HllSketch.heapify(input))
-      union.getResult(tgt)
+      val s1 = HllSketch.heapify(buffer)
+      val s2 = HllSketch.heapify(input)
+      val union = new Union(Math.max(lgK, Math.max(s1.getLgConfigK, s2.getLgConfigK)))
+      union.update(s1)
+      union.update(s2)
+      union.getResult(tgt).toCompactByteArray
     } else buffer
   }
 
-  override def merge(b1: HllSketch, b2: HllSketch): HllSketch = {
-    val union = new Union(Math.max(lgK, Math.max(b1.getLgConfigK, b2.getLgConfigK)))
-    union.update(b1)
-    union.update(b2)
-    union.getResult(tgt)
+  override def merge(b1: Array[Byte], b2: Array[Byte]): Array[Byte] = {
+    val s1 = HllSketch.heapify(b1)
+    val s2 = HllSketch.heapify(b2)
+    val union = new Union(Math.max(lgK, Math.max(s1.getLgConfigK, s2.getLgConfigK)))
+    union.update(s1)
+    union.update(s2)
+    union.getResult(tgt).toCompactByteArray
   }
 
-  override def finish(reduction: HllSketch): Array[Byte] = reduction.toCompactByteArray
+  override def finish(reduction: Array[Byte]): Array[Byte] = reduction
 
-  override def bufferEncoder: Encoder[HllSketch]   = Encoders.kryo[HllSketch]
+  override def bufferEncoder: Encoder[Array[Byte]] = Encoders.BINARY
   override def outputEncoder: Encoder[Array[Byte]] = Encoders.BINARY
 }


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** fails on HllSketch serialization, due to Kryo encoder dependency. JDK 21 enforces stricter lambda serialization rules that break KryoSerializationCodec$


**New behavior :** fixed by using Array[Byte] instead
