### PR TITLE
Add dispatch latency metric to FiloDB

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/queryplanner/QueryPlanner.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/queryplanner/QueryPlanner.scala
@@ -1,5 +1,7 @@
 package filodb.coordinator.queryplanner
 
+import java.util.concurrent.TimeUnit
+
 import scala.concurrent.duration.FiniteDuration
 
 import kamon.Kamon
@@ -7,6 +9,7 @@ import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
 
+import filodb.core.metrics.FilodbMetrics
 import filodb.core.query.{QueryContext, QuerySession}
 import filodb.query.{LogicalPlan, QueryResponse, StreamQueryResponse}
 import filodb.query.exec.{ClientParams, ExecPlan, ExecPlanWithClientParams, UnsupportedChunkSource}
@@ -27,11 +30,31 @@ trait QueryPlanner {
 
   /**
     * Trigger orchestration of the ExecPlan. It sends the ExecPlan to the destination where it will be executed.
+    *
+    * This overload preserves the original signature so existing callers (the HTTP query API and the CLI) are
+    * unaffected; their dispatch is attributed to the HTTP entry path for the `query-dispatch-latency` metric.
     */
   def dispatchExecPlan(execPlan: ExecPlan,
                        querySession: QuerySession,
                        parentSpan: kamon.trace.Span)
+                      (implicit sched: Scheduler, timeout: FiniteDuration): Task[QueryResponse] =
+    dispatchExecPlan(execPlan, querySession, parentSpan, QueryPlanner.SourceHttp)
+
+  /**
+    * Trigger orchestration of the ExecPlan.
+    *
+    * @param querySource the entry transport that originated this dispatch ("http" | "grpc"). It is emitted as the
+    *                    `source` tag on the shared `query-dispatch-latency` metric so the HTTP and gRPC entry paths
+    *                    can be compared apples-to-apples. NOTE: it is passed as a method argument and is NOT
+    *                    serialized into the QueryContext, so it introduces no cross-node (Kryo/proto) compatibility
+    *                    concerns with the data nodes.
+    */
+  def dispatchExecPlan(execPlan: ExecPlan,
+                       querySession: QuerySession,
+                       parentSpan: kamon.trace.Span,
+                       querySource: String)
                       (implicit sched: Scheduler, timeout: FiniteDuration): Task[QueryResponse] = {
+    val startNanos = System.nanoTime()
     // Please note that the following needs to be wrapped inside `runWithSpan` so that the context will be propagated
     // across threads. Note that task/observable will not run on the thread where span is present since
     // kamon uses thread-locals.
@@ -41,13 +64,27 @@ trait QueryPlanner {
       execPlan.dispatcher.dispatch(ExecPlanWithClientParams(execPlan,
         ClientParams(execPlan.queryContext.plannerParams.queryTimeoutMillis),
         querySession), UnsupportedChunkSource())
-    }
+    }.guarantee(Task.eval {
+      QueryPlanner.dispatchPlanLatency.record(System.nanoTime() - startNanos,
+        Map("source" -> querySource, "dataset" -> execPlan.dataset.dataset))
+    })
   }
 
+  /**
+    * Streaming variant. See [[dispatchExecPlan]]; this overload keeps the original signature for existing callers.
+    */
   def dispatchStreamingExecPlan(execPlan: ExecPlan,
                        querySession: QuerySession,
                        parentSpan: kamon.trace.Span)
+                      (implicit sched: Scheduler, timeout: FiniteDuration): Observable[StreamQueryResponse] =
+    dispatchStreamingExecPlan(execPlan, querySession, parentSpan, QueryPlanner.SourceHttp)
+
+  def dispatchStreamingExecPlan(execPlan: ExecPlan,
+                       querySession: QuerySession,
+                       parentSpan: kamon.trace.Span,
+                       querySource: String)
                       (implicit sched: Scheduler, timeout: FiniteDuration): Observable[StreamQueryResponse] = {
+    val startNanos = System.nanoTime()
     // Please note that the following needs to be wrapped inside `runWithSpan` so that the context will be propagated
     // across threads. Note that task/observable will not run on the thread where span is present since
     // kamon uses thread-locals.
@@ -57,7 +94,24 @@ trait QueryPlanner {
       execPlan.dispatcher.dispatchStreaming(ExecPlanWithClientParams(execPlan,
         ClientParams(execPlan.queryContext.plannerParams.queryTimeoutMillis),
         querySession), UnsupportedChunkSource())
-    }
+    }.guarantee(Task.eval {
+      QueryPlanner.dispatchPlanLatency.record(System.nanoTime() - startNanos,
+        Map("source" -> querySource, "dataset" -> execPlan.dataset.dataset))
+    })
   }
 
+}
+
+object QueryPlanner {
+  /** Entry-transport tag values for the shared `query-dispatch-latency` metric. */
+  val SourceHttp = "http"
+  val SourceGrpc = "grpc"
+
+  /**
+    * Execute-dispatch latency emitted from BOTH the HTTP and gRPC entry paths at their shared convergence
+    * (`dispatchExecPlan` / `dispatchStreamingExecPlan`). Tagged with `source` (http|grpc) and `dataset` so the two
+    * transports can be compared directly. Exported to Prometheus as `query_dispatch_latency_seconds`.
+    */
+  lazy val dispatchPlanLatency =
+    FilodbMetrics.timeHistogram("query-dispatch-latency", TimeUnit.NANOSECONDS)
 }

--- a/http/src/main/scala/filodb/http/PromQLGrpcServer.scala
+++ b/http/src/main/scala/filodb/http/PromQLGrpcServer.scala
@@ -219,7 +219,9 @@ class PromQLGrpcServer(queryPlannerSelector: String => QueryPlanner,
               TimeStepParams(queryParams.getStart, queryParams.getStep, queryParams.getEnd))
 
             val exec = queryPlanner.materialize(logicalPlan, qContext)
-            queryPlanner.dispatchExecPlan(exec, querySession, rp.span)
+            // Tag this dispatch as originating from the gRPC entry path so the shared
+            // `query-dispatch-latency` metric carries source="grpc" (vs "http" for the query API).
+            queryPlanner.dispatchExecPlan(exec, querySession, rp.span, QueryPlanner.SourceGrpc)
               .map((qr: QueryResponse) => rp.processQueryResponse(qr))
           } { querySession =>
             Task.eval(querySession.close())


### PR DESCRIPTION
 Problem

query_materialize_time_ns does not exist for grpc. It is only emitted on the http side of the query server api.

We need a similar metric on the grpc time to understand the time it takes to materialize data.

  Change

  Emit one metric at the shared convergence point both paths hit — QueryPlanner.dispatchExecPlan / dispatchStreamingExecPlan — tagged by entry transport:

  query_dispatch_latency_seconds{ source="http"|"grpc", dataset=... }

  - gRPC server passes source="grpc"; HTTP/CLI default to source="http".
  - querySource is a method argument, not a serialized QueryContext field → no Kryo/proto version-skew with data nodes.

  Why this is the right place

  Both the HTTP executor and the gRPC server call dispatchExecPlan after their own parse/materialize, so a metric here measures the same window for both — true apples-to-apples. It can't reuse the existing
  query_execute_plan_time_ns name because that's a query-service (MetricsPublisher, _ns) metric, and FiloDB code can only use FilodbMetrics (Kamon → _seconds); FiloDB also can't depend on query-service.

  Benefit

  One PromQL query compares the transports directly:
  histogram_quantile(0.99, sum by (le, source) (rate(query_dispatch_latency_seconds{...}[$interval])))