### PR TITLE
fix(spark-jobs): Fix churn finder job data skew cherry-pick to integration

### DIFF
--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/HllSketchMergeAgg.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/HllSketchMergeAgg.scala
@@ -1,0 +1,37 @@
+package filodb.labelchurnfinder
+
+import org.apache.datasketches.hll._
+import org.apache.spark.sql.{Encoder, Encoders}
+import org.apache.spark.sql.expressions.Aggregator
+
+/**
+ * Merges serialized HLL sketch byte arrays produced by HllSketchAgg.
+ * Used in the second phase of two-phase aggregation to combine partial
+ * sketches built per salt bucket into the final per-(ws, label) sketch.
+ */
+case class HllSketchMergeAgg(lgK: Int = 12, tgt: TgtHllType = TgtHllType.HLL_4)
+  extends Aggregator[Array[Byte], HllSketch, Array[Byte]] with Serializable {
+
+  override def zero: HllSketch = new HllSketch(lgK, tgt)
+
+  override def reduce(buffer: HllSketch, input: Array[Byte]): HllSketch = {
+    if (input != null) {
+      val union = new Union(Math.max(lgK, buffer.getLgConfigK))
+      union.update(buffer)
+      union.update(HllSketch.heapify(input))
+      union.getResult(tgt)
+    } else buffer
+  }
+
+  override def merge(b1: HllSketch, b2: HllSketch): HllSketch = {
+    val union = new Union(Math.max(lgK, Math.max(b1.getLgConfigK, b2.getLgConfigK)))
+    union.update(b1)
+    union.update(b2)
+    union.getResult(tgt)
+  }
+
+  override def finish(reduction: HllSketch): Array[Byte] = reduction.toCompactByteArray
+
+  override def bufferEncoder: Encoder[HllSketch]   = Encoders.kryo[HllSketch]
+  override def outputEncoder: Encoder[Array[Byte]] = Encoders.BINARY
+}

--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelChurnFinder.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelChurnFinder.scala
@@ -85,6 +85,7 @@ object LabelChurnFinder {
   private[labelchurnfinder] val LabelCard1h = "labelCard1h"
   private[labelchurnfinder] val LabelCard3d = "labelCard3d"
   private[labelchurnfinder] val LabelCard7d = "labelCard7d"
+  private[labelchurnfinder] val SaltCol     = "salt"
 }
 
 case class LabelValRow(ws: String, ns: String, label: String, labelVal: String, endTime: Long)
@@ -122,6 +123,9 @@ class LabelChurnFinder(dsSettings: DownsamplerSettings) extends Serializable wit
     .find(_.getString("dataset") == datasetName)
     .getOrElse(ConfigFactory.empty())
     .as[Option[Int]]("num-shards").get
+
+  @transient private[labelchurnfinder] val numSalts =
+    dsSettings.filodbConfig.as[Option[Int]]("labelchurnfinder.num-salts").getOrElse(50)
 
   /**
    * Returns iterator of LcfRow objects containing label/value for given token range split and shard.
@@ -193,8 +197,12 @@ class LabelChurnFinder(dsSettings: DownsamplerSettings) extends Serializable wit
                            tMinus7d: Long): DataFrame = {
 
     val hllSketch = udaf(HllSketchAgg())
-    labelAndValuesDf
-      .groupBy(WsCol, LabelCol)
+    val hllMerge  = udaf(HllSketchMergeAgg())
+
+    // Phase 1: salt by row position to break up skewed (ws, label) keys across numSalts partitions.
+    val partial = labelAndValuesDf
+      .withColumn(SaltCol, pmod(monotonically_increasing_id(), lit(numSalts)))
+      .groupBy(WsCol, LabelCol, SaltCol)
       .agg(
         count(when(col(EndTimeCol) === Long.MaxValue, col(LabelValCol))).alias(Ats1hWithLabelCol),
         count(when(col(EndTimeCol) > tMinus3d, col(LabelValCol))).alias(Ats3dWithLabelCol),
@@ -202,6 +210,18 @@ class LabelChurnFinder(dsSettings: DownsamplerSettings) extends Serializable wit
         hllSketch(when(col(EndTimeCol) === Long.MaxValue, col(LabelValCol))).alias(LabelSketch1hCol),
         hllSketch(when(col(EndTimeCol) >= tMinus3d, col(LabelValCol))).alias(LabelSketch3dCol),
         hllSketch(when(col(EndTimeCol) >= tMinus7d, col(LabelValCol))).alias(LabelSketch7dCol)
+      )
+
+    // Phase 2: merge partial results per (ws, label).
+    partial
+      .groupBy(WsCol, LabelCol)
+      .agg(
+        sum(col(Ats1hWithLabelCol)).alias(Ats1hWithLabelCol),
+        sum(col(Ats3dWithLabelCol)).alias(Ats3dWithLabelCol),
+        sum(col(Ats7dWithLabelCol)).alias(Ats7dWithLabelCol),
+        hllMerge(col(LabelSketch1hCol)).alias(LabelSketch1hCol),
+        hllMerge(col(LabelSketch3dCol)).alias(LabelSketch3dCol),
+        hllMerge(col(LabelSketch7dCol)).alias(LabelSketch7dCol)
       )
       .withColumn(NsGroupCol, lit("All")) // placeholder for future ns grouping
   }

--- a/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelChurnFinderSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelChurnFinderSpec.scala
@@ -77,7 +77,7 @@ class LabelChurnFinderSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
     case class PkToWrite(pkr: PartKeyRecord, updateHour: Long)
     val pks = for { i <- 0 to numContainers } yield {
       val schema = schemas(i % schemas.size)
-      val partKey = partBuilder.partKeyFromObjects(schema, s"bulkmetric", bulkSeriesTags ++ Map(
+      val partKey = partBuilder.partKeyFromObjects(schema, s"bulkmetric", Map(
         "_ws_".utf8 -> "bulk_ws".utf8,
         "_ns_".utf8 -> s"bulk_ns${i % numNs}".utf8,
         "pod".utf8 -> s"pod${i % numPods}".utf8,


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** computeChurnAndUsage used a single groupBy(ws, label). System labels (metric, ws, ns) appear in every time series, producing ~20M rows per label all routed to one Spark partition. This caused a permanent straggler.

**New behavior :**
Two-phase salted aggregation splits skewed (ws, label) keys across numSalts partitions (configurable, default 50). Phase 1 builds partial HLL sketches per salt bucket, phase 2 merges them into the final per-label cardinality.