### PR TITLE
fix(sparkJobs): Fix issue where spark tests don't run when connected …

### DIFF
--- a/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelChurnFinderSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelChurnFinderSpec.scala
@@ -100,9 +100,19 @@ class LabelChurnFinderSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
     }
   }
 
-  it ("should run LCF job for one namespace and workspace") {
+  private def localSparkConf(): SparkConf = {
     val sparkConf = new SparkConf(loadDefaults = true)
     sparkConf.setMaster("local[2]")
+    // Pin driver/executor to loopback so tests pass regardless of WiFi/VPN state.
+    // Without this, InetAddress.getLocalHost resolves to the WiFi IP on macOS,
+    // causing Spark internal RPC to bind on a non-loopback address that may not be reachable.
+    sparkConf.set("spark.driver.host", "127.0.0.1")
+    sparkConf.set("spark.driver.bindAddress", "127.0.0.1")
+    sparkConf
+  }
+
+  it ("should run LCF job for one namespace and workspace") {
+    val sparkConf = localSparkConf()
     val filterConfig = ConfigFactory.parseString(
       s"""
          |filodb.labelchurnfinder.pk-filters.0._ns_ = bulk_ns0
@@ -133,8 +143,7 @@ class LabelChurnFinderSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
   }
 
   it ("should run LCF job for multiple namespaces and workspaces") {
-    val sparkConf = new SparkConf(loadDefaults = true)
-    sparkConf.setMaster("local[2]")
+    val sparkConf = localSparkConf()
     val filterConfig = ConfigFactory.parseString(
       s"""
          |filodb.labelchurnfinder.pk-filters.0._ns_ = "bulk_ns.*"
@@ -164,8 +173,7 @@ class LabelChurnFinderSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
   }
 
   it ("should run LCF job for different time range") {
-    val sparkConf = new SparkConf(loadDefaults = true)
-    sparkConf.setMaster("local[2]")
+    val sparkConf = localSparkConf()
     val filterConfig = ConfigFactory.parseString(
       s"""
          |filodb.labelchurnfinder.pk-filters.0._ns_ = "bulk_ns.*"
@@ -196,8 +204,7 @@ class LabelChurnFinderSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
   }
 
   it ("should call publishLabelStats when actionOnLabelStats is invoked") {
-    val sparkConf = new SparkConf(loadDefaults = true)
-    sparkConf.setMaster("local[2]")
+    val sparkConf = localSparkConf()
     sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
     sparkSession = SparkSession.builder()
       .appName("LabelChurnFinder")

--- a/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelStatsKafkaProducerSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelStatsKafkaProducerSpec.scala
@@ -25,12 +25,24 @@ class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAn
 
   var spark: SparkSession = _
 
-  override def beforeAll(): Unit = {
+  private def localSparkConf(): SparkConf = {
     val sparkConf = new SparkConf(loadDefaults = false)
+    sparkConf.setMaster("local[2]")
       .setMaster("local[2]")
       .setAppName("LabelStatsKafkaProducerSpec")
       .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
       .set("spark.ui.enabled", "false")
+    // Pin driver/executor to loopback so tests pass regardless of WiFi/VPN state.
+    // Without this, InetAddress.getLocalHost resolves to the WiFi IP on macOS,
+    // causing Spark internal RPC to bind on a non-loopback address that may not be reachable.
+    sparkConf.set("spark.driver.host", "127.0.0.1")
+    sparkConf.set("spark.driver.bindAddress", "127.0.0.1")
+    sparkConf
+  }
+
+
+  override def beforeAll(): Unit = {
+    val sparkConf = localSparkConf()
 
     spark = SparkSession.builder()
       .config(sparkConf)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Pin spark driver/executor in unit tests to loopback so tests pass regardless of WiFi/VPN state. Without this, InetAddress.getLocalHost resolves to the WiFi IP on macOS, causing Spark internal RPC to bind on a non-loopback address that may not be reachable.
