### PR TITLE
feat(query): per-dispatch latency metric tagged by local vs remote

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/ActorPlanDispatcher.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/ActorPlanDispatcher.scala
@@ -44,7 +44,8 @@ case class ActorPlanDispatcher(target: ActorRef, clusterName: String) extends Pl
     ep
   }
 
-  def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)(implicit sched: Scheduler): Task[QueryResponse] = {
+  def doDispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
+                (implicit sched: Scheduler): Task[QueryResponse] = {
     // "source" is unused (the param exists to support InProcessDispatcher).
     val queryTimeElapsed = System.currentTimeMillis() - plan.execPlan.queryContext.submitTime
     val remainingTime = plan.clientParams.deadlineMs - queryTimeElapsed
@@ -95,7 +96,7 @@ case class ActorPlanDispatcher(target: ActorRef, clusterName: String) extends Pl
     }
   }
 
-  def dispatchStreaming(plan: ExecPlanWithClientParams, source: ChunkSource)
+  def doDispatchStreaming(plan: ExecPlanWithClientParams, source: ChunkSource)
                        (implicit sched: Scheduler): Observable[StreamQueryResponse] = {
     // "source" is unused (the param exists to support InProcessDispatcher).
     val queryTimeElapsed = System.currentTimeMillis() - plan.execPlan.queryContext.submitTime

--- a/coordinator/src/main/scala/filodb.coordinator/GrpcPlanDispatcher.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/GrpcPlanDispatcher.scala
@@ -32,7 +32,7 @@ case class GrpcPlanDispatcher(endpoint: String, requestTimeoutMs: Long) extends 
 
   val clusterName = InetAddress.getLocalHost().getHostName()
 
-  override def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)(implicit sched: Scheduler):
+  override def doDispatch(plan: ExecPlanWithClientParams, source: ChunkSource)(implicit sched: Scheduler):
   Task[QueryResponse] = {
     // "source" is unused (the param exists to support InProcessDispatcher).
     val queryTimeElapsed = System.currentTimeMillis() - plan.execPlan.queryContext.submitTime
@@ -120,7 +120,7 @@ case class GrpcPlanDispatcher(endpoint: String, requestTimeoutMs: Long) extends 
   // for these GRPC dispatchers, we need to implement this method. Currently, it does not make sense to implement
   // streaming in this dispatcher.
 
-  def dispatchStreaming
+  def doDispatchStreaming
   (plan: ExecPlanWithClientParams, source: ChunkSource)
   (implicit sched: Scheduler): Observable[StreamQueryResponse] = {
     ???

--- a/coordinator/src/main/scala/filodb/coordinator/RemoteActorPlanDispatcher.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/RemoteActorPlanDispatcher.scala
@@ -16,7 +16,7 @@ import filodb.query.exec.{ExecPlanWithClientParams, PlanDispatcher}
 // is instantiated and utilized to fulfill dispatch.
 case class RemoteActorPlanDispatcher(path: String, clusterName: String) extends PlanDispatcher {
 
-  override def dispatch(
+  override def doDispatch(
      plan: ExecPlanWithClientParams, source: ChunkSource
   )(implicit sched: Scheduler): Task[QueryResponse] = {
     val serialization = akka.serialization.SerializationExtension(ActorSystemHolder.system)
@@ -28,10 +28,10 @@ case class RemoteActorPlanDispatcher(path: String, clusterName: String) extends 
     } else {
       ActorPlanDispatcher(deserializedActorRef, clusterName)
     }
-    dispatcher.dispatch(plan, source)
+    dispatcher.doDispatch(plan, source)
   }
 
-  def dispatchStreaming
+  def doDispatchStreaming
   (plan: ExecPlanWithClientParams, source: ChunkSource)
   (implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
 

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FlightPlanDispatcher.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FlightPlanDispatcher.scala
@@ -26,7 +26,7 @@ case class FlightPlanDispatcher(location: Location,
 
   import filodb.query.Query.qLogger
 
-  override def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
+  override def doDispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
                        (implicit sched: Scheduler): Task[QueryResponse] = {
     // Check remaining time similar to GrpcPlanDispatcher
     val queryTimeElapsed = System.currentTimeMillis() - plan.execPlan.queryContext.submitTime
@@ -148,7 +148,7 @@ case class FlightPlanDispatcher(location: Location,
     }.executeOn(QueryScheduler.flightIoScheduler).asyncBoundary
   }
 
-  def dispatchStreaming(plan: ExecPlanWithClientParams, source: ChunkSource)
+  def doDispatchStreaming(plan: ExecPlanWithClientParams, source: ChunkSource)
                        (implicit sched: Scheduler): Observable[StreamQueryResponse] = {
     // TODO: Implement streaming dispatch when needed
     // This would follow similar pattern but return Observable instead of Task

--- a/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/InProcessPlanDispatcher.scala
@@ -29,7 +29,7 @@ case class InProcessPlanDispatcher(queryConfig: QueryConfig) extends PlanDispatc
   val clusterName = InetAddress.getLocalHost().getHostName()
   lazy val partition = extractPartition(clusterName)
 
-  override def dispatch(plan: ExecPlanWithClientParams,
+  override def doDispatch(plan: ExecPlanWithClientParams,
                         source: ChunkSource)(implicit sched: Scheduler): Task[QueryResponse] = {
     lazy val emptyPartialResult = QueryResult(plan.execPlan.queryContext.queryId, ResultSchema.empty, Nil,
       QueryStats(), QueryWarnings(), true, Some("Result may be partial since query on some shards timed out"))
@@ -80,7 +80,7 @@ case class InProcessPlanDispatcher(queryConfig: QueryConfig) extends PlanDispatc
 
   override def isLocalCall: Boolean = true
 
-  override def dispatchStreaming(plan: ExecPlanWithClientParams,
+  override def doDispatchStreaming(plan: ExecPlanWithClientParams,
                                  source: ChunkSource)
                                 (implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
 }

--- a/query/src/main/scala/filodb/query/exec/PlanDispatcher.scala
+++ b/query/src/main/scala/filodb/query/exec/PlanDispatcher.scala
@@ -1,15 +1,28 @@
 package filodb.query.exec
 
+import java.util.concurrent.TimeUnit
+
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
 
 import filodb.core.GlobalConfig
+import filodb.core.metrics.FilodbMetrics
 import filodb.core.store.ChunkSource
 import filodb.query.{QueryResponse, StreamQueryResponse}
 
 object PlanDispatcher {
   val streamingResultsEnabled = GlobalConfig.systemConfig.getBoolean("filodb.query.streaming-query-results-enabled")
+
+  /**
+    * Latency of dispatching an ExecPlan, measured at the dispatcher itself — the universal choke point that every
+    * dispatch (top-level and child) flows through, regardless of whether it was reached via
+    * QueryPlanner.dispatchExecPlan or a direct `execPlan.dispatcher.dispatch(...)` call. Tagged with:
+    *   - `dispatch`: "local" (in-process) | "remote" (actor/grpc/flight), derived from [[PlanDispatcher.isLocalCall]]
+    *   - `dataset`
+    * Exported to Prometheus as `query_dispatch_latency_seconds`.
+    */
+  lazy val dispatchLatency = FilodbMetrics.timeHistogram("query-dispatch-latency", TimeUnit.NANOSECONDS)
 }
 
 /**
@@ -18,10 +31,37 @@ object PlanDispatcher {
   */
 trait PlanDispatcher extends java.io.Serializable {
   def clusterName: String
-  def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
-              (implicit sched: Scheduler): Task[QueryResponse]
-
-  def dispatchStreaming(plan: ExecPlanWithClientParams, source: ChunkSource)
-                       (implicit sched: Scheduler): Observable[StreamQueryResponse]
   def isLocalCall: Boolean
+
+  /** Metric label for [[PlanDispatcher.dispatchLatency]]: "local" for in-process dispatch, "remote" otherwise. */
+  def dispatchType: String = if (isLocalCall) "local" else "remote"
+
+  /**
+    * Dispatch the plan, recording dispatch latency labeled by [[dispatchType]]. `final` so the measurement cannot
+    * be bypassed; implementations provide the actual dispatch behavior in [[doDispatch]].
+    */
+  final def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
+                    (implicit sched: Scheduler): Task[QueryResponse] = {
+    val startNanos = System.nanoTime()
+    doDispatch(plan, source).guarantee(Task.eval {
+      PlanDispatcher.dispatchLatency.record(System.nanoTime() - startNanos,
+        Map("dispatch" -> dispatchType, "dataset" -> plan.execPlan.dataset.dataset))
+    })
+  }
+
+  final def dispatchStreaming(plan: ExecPlanWithClientParams, source: ChunkSource)
+                             (implicit sched: Scheduler): Observable[StreamQueryResponse] = {
+    val startNanos = System.nanoTime()
+    doDispatchStreaming(plan, source).guarantee(Task.eval {
+      PlanDispatcher.dispatchLatency.record(System.nanoTime() - startNanos,
+        Map("dispatch" -> dispatchType, "dataset" -> plan.execPlan.dataset.dataset))
+    })
+  }
+
+  /** Actual dispatch implementation; wrapped by [[dispatch]] for latency measurement. */
+  def doDispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
+                (implicit sched: Scheduler): Task[QueryResponse]
+
+  def doDispatchStreaming(plan: ExecPlanWithClientParams, source: ChunkSource)
+                         (implicit sched: Scheduler): Observable[StreamQueryResponse]
 }

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinExecSpec.scala
@@ -37,14 +37,14 @@ class BinaryJoinExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
 
   val dummyDispatcher = new PlanDispatcher {
 
-    override def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
+    override def doDispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???
 
     override def isLocalCall: Boolean = true
 
-    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+    override def doDispatchStreaming(plan: ExecPlanWithClientParams,
                                    source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
   }
 

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinGroupingSpec.scala
@@ -38,13 +38,13 @@ class BinaryJoinGroupingSpec extends AnyFunSpec with Matchers with ScalaFutures 
   val rand = new Random()
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
+    override def doDispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???
 
     override def isLocalCall: Boolean = true
-    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+    override def doDispatchStreaming(plan: ExecPlanWithClientParams,
                                    source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
   }
 

--- a/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/BinaryJoinSetOperatorSpec.scala
@@ -41,13 +41,13 @@ class BinaryJoinSetOperatorSpec extends AnyFunSpec with Matchers with ScalaFutur
 
   val dummyDispatcher = new PlanDispatcher {
 
-    override def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
+    override def doDispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???
 
     override def isLocalCall: Boolean = true
-    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+    override def doDispatchStreaming(plan: ExecPlanWithClientParams,
                                    source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
   }
   val resultSchema = ResultSchema(MetricsTestData.timeseriesSchema.infosFromIDs(0 to 1), 1)

--- a/query/src/test/scala/filodb/query/exec/ExecPlanSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/ExecPlanSpec.scala
@@ -44,9 +44,9 @@ class ExecPlanSpec extends AnyFunSpec with Matchers with ScalaFutures {
     override def dataset: DatasetRef = ???
     override def dispatcher: PlanDispatcher = planDispatcher.getOrElse(new PlanDispatcher {
       override def clusterName: String = ???
-      override def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
+      override def doDispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
                            (implicit sched: Scheduler): Task[QueryResponse] = ???
-      override def dispatchStreaming(plan: ExecPlanWithClientParams, source: ChunkSource)
+      override def doDispatchStreaming(plan: ExecPlanWithClientParams, source: ChunkSource)
                                     (implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
       // Force serialization by making this false, in case of true, no such filtering is performed
       override def isLocalCall: Boolean = false

--- a/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/InProcessPlanDispatcherSpec.scala
@@ -220,7 +220,7 @@ class InProcessPlanDispatcherSpec extends AnyFunSpec
 
 case class DummyDispatcher(memStore: TimeSeriesMemStore, querySession: QuerySession) extends PlanDispatcher {
   // run locally withing any check.
-  override def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
+  override def doDispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
                        (implicit sched: Scheduler): Task[QueryResponse] = {
     plan.execPlan.execute(memStore, querySession)
   }
@@ -228,7 +228,7 @@ case class DummyDispatcher(memStore: TimeSeriesMemStore, querySession: QuerySess
   override def clusterName: String = ???
 
   override def isLocalCall: Boolean = true
-  override def dispatchStreaming(plan: ExecPlanWithClientParams,
+  override def doDispatchStreaming(plan: ExecPlanWithClientParams,
                                  source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = {
     plan.execPlan.executeStreaming(memStore, querySession)
   }

--- a/query/src/test/scala/filodb/query/exec/LocalPartitionDistConcatExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/LocalPartitionDistConcatExecSpec.scala
@@ -28,7 +28,7 @@ object LocalPartitionDistConcatExecSpec {
   val queryConfig = QueryConfig(config.getConfig("query"))
   val querySession = QuerySession(QueryContext(), queryConfig)
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
+    override def doDispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = {
       plan.execPlan.execute(source, querySession)(global)
     }
@@ -37,7 +37,7 @@ object LocalPartitionDistConcatExecSpec {
 
     override def isLocalCall: Boolean = true
 
-    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+    override def doDispatchStreaming(plan: ExecPlanWithClientParams,
                                    source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
   }
 

--- a/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MetadataExecSpec.scala
@@ -114,7 +114,7 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
   }
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
+    override def doDispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = plan.execPlan.execute(memStore,
       QuerySession(QueryContext(), queryConfig,
         preventRangeVectorSerialization = plan.clientParams.preventRangeVectorSerialization))(sched)
@@ -123,20 +123,20 @@ class MetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures with B
 
     override def isLocalCall: Boolean = true
 
-    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+    override def doDispatchStreaming(plan: ExecPlanWithClientParams,
                                    source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
   }
 
   val executeDispatcher = new PlanDispatcher {
     override def isLocalCall: Boolean = true
     override def clusterName: String = ???
-    override def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
+    override def doDispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = {
       plan.execPlan.execute(memStore, querySession.copy(
         preventRangeVectorSerialization = plan.clientParams.preventRangeVectorSerialization))(sched)
     }
 
-    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+    override def doDispatchStreaming(plan: ExecPlanWithClientParams,
                                    source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
   }
 

--- a/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/MultiSchemaPartitionsExecSpec.scala
@@ -25,14 +25,14 @@ import monix.reactive.Observable
 
 object MultiSchemaPartitionsExecSpec {
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
+    override def doDispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???
 
     override def isLocalCall: Boolean = false
 
-    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+    override def doDispatchStreaming(plan: ExecPlanWithClientParams,
                                    source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
   }
 

--- a/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/PromQlRemoteExecSpec.scala
@@ -22,14 +22,14 @@ class PromQlRemoteExecSpec extends AnyFunSpec with Matchers with ScalaFutures {
     options = DatasetOptions(Seq("__name__", "job"), "__name__")).get
 
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
+    override def doDispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???
 
     override def isLocalCall: Boolean = true
 
-    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+    override def doDispatchStreaming(plan: ExecPlanWithClientParams,
                                    source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
   }
 

--- a/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/RemoteMetadataExecSpec.scala
@@ -109,12 +109,12 @@ class RemoteMetadataExecSpec extends AnyFunSpec with Matchers with ScalaFutures 
   val executeDispatcher = new PlanDispatcher {
     override def isLocalCall: Boolean = true
     override def clusterName: String = ???
-    override def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
+    override def doDispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = {
       plan.execPlan.execute(memStore, querySession)(sched)
     }
 
-    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+    override def doDispatchStreaming(plan: ExecPlanWithClientParams,
                                    source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = {
       plan.execPlan.executeStreaming(memStore, querySession)(sched)
     }

--- a/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
+++ b/query/src/test/scala/filodb/query/exec/SplitLocalPartitionDistConcatExecSpec.scala
@@ -26,14 +26,14 @@ import filodb.query.{QueryResponse, QueryResult, StreamQueryResponse}
 
 object SplitLocalPartitionDistConcatExecSpec {
   val dummyDispatcher = new PlanDispatcher {
-    override def dispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
+    override def doDispatch(plan: ExecPlanWithClientParams, source: ChunkSource)
                          (implicit sched: Scheduler): Task[QueryResponse] = ???
 
     override def clusterName: String = ???
 
     override def isLocalCall: Boolean = true
 
-    override def dispatchStreaming(plan: ExecPlanWithClientParams,
+    override def doDispatchStreaming(plan: ExecPlanWithClientParams,
                                    source: ChunkSource)(implicit sched: Scheduler): Observable[StreamQueryResponse] = ???
   }
 


### PR DESCRIPTION
## What
Adds a single dispatch-latency metric measured at the `PlanDispatcher` itself, tagged by whether the dispatch is local (in-process) or remote (actor / grpc / flight).

Exported to Prometheus as `query_dispatch_latency_seconds{dispatch="local"|"remote", dataset=...}`.

## Why
We wanted to compare query dispatch latency across transport paths. Measuring at `QueryPlanner.dispatchExecPlan` is leaky — some code calls `execPlan.dispatcher.dispatch(...)` directly (e.g. `PromQLGrpcServer.executePlan`, the Flight producer, and internal child-plan dispatch), bypassing it. The dispatcher is the single choke point that every dispatch flows through, so the measurement belongs there.

## How
- `PlanDispatcher.dispatch` / `dispatchStreaming` are now `final` template methods that record latency and delegate the actual work to abstract `doDispatch` / `doDispatchStreaming`.
- The metric is labeled via the existing `PlanDispatcher.isLocalCall` (`dispatch=local|remote`) plus `dataset`.
- All implementations — `InProcessPlanDispatcher`, `ActorPlanDispatcher`, `RemoteActorPlanDispatcher`, `GrpcPlanDispatcher`, `FlightPlanDispatcher` — and the test dummy dispatchers implement `doDispatch` / `doDispatchStreaming` instead of `dispatch` / `dispatchStreaming`.
- `RemoteActorPlanDispatcher` delegates to the inner dispatcher's `doDispatch` to avoid double-counting its wrapped dispatch.

## Notes
- The local/remote distinction is a dispatcher-intrinsic property (`isLocalCall`); no field is added to `QueryContext` / proto, so there are no cross-node (Kryo/proto) serialization concerns.
- Measurement is per-dispatch, so the histogram captures every dispatch (top-level and child), broken down by `local`/`remote`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
