### PR TITLE
fix(core): JDK21 kryo serialization of reentrant lock in query stats

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/client/Serializer.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/Serializer.scala
@@ -1,6 +1,7 @@
 package filodb.coordinator.client
 
 import java.net.URI
+import java.util.concurrent.locks.ReentrantReadWriteLock
 
 import com.esotericsoftware.kryo.{Kryo, Serializer => KryoSerializer}
 import com.esotericsoftware.kryo.io._
@@ -27,6 +28,7 @@ object KryoInit {
     kryo.addDefaultSerializer(classOf[ZeroCopyUTF8String], classOf[ZeroCopyUTF8StringSerializer])
     kryo.register(classOf[Schema], new SchemaSerializer)
     kryo.register(classOf[PartitionSchema], new PartSchemaSerializer)
+    kryo.register(classOf[ReentrantReadWriteLock], new ReentrantReadWriteLockSerializer)
 
     initOtherFiloClasses(kryo)
     initQueryEngine2Classes(kryo)
@@ -183,5 +185,16 @@ class PartSchemaSerializer extends KryoSerializer[PartitionSchema] {
   override def write(kryo: Kryo, output: Output, schema: PartitionSchema): Unit = {
     val schemas = FilodbSettings.globalOrDefault.schemas
     require(schema == schemas.part)
+  }
+}
+
+class ReentrantReadWriteLockSerializer extends KryoSerializer[ReentrantReadWriteLock] {
+  override def write(kryo: Kryo, output: Output, lock: ReentrantReadWriteLock): Unit = {
+    // No state needs to be written; locks restore cleanly to an unlocked state
+  }
+
+  override def read(kryo: Kryo, input: Input, typ: Class[ReentrantReadWriteLock]): ReentrantReadWriteLock = {
+    // Create a fresh lock when deserialized
+    new ReentrantReadWriteLock
   }
 }

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -423,8 +423,8 @@ case class QueryStats() {
   @volatile private var containsNilKey = false;
 
   private val lock = new ReentrantReadWriteLock()
-  private val readLock = lock.readLock()
-  private val writeLock = lock.writeLock()
+  private def readLock = lock.readLock()
+  private def writeLock = lock.writeLock()
 
   override def toString: String = {
     readLock.lock()


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Serialization of query stats was broken for JDK21 while serializing ReentrantLock - this PR fixes it