### PR TITLE
fix(downsampler): replace Kamon.stopModules() with Thread.sleep to avoid double shutdown

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
@@ -93,8 +93,8 @@ class DSIndexJob(dsSettings: DownsamplerSettings,
 
     // quick & dirty hack to ensure that the completed metric gets published
     if (dsSettings.shouldSleepForMetricsFlush)
-      Await.result(Kamon.stopModules(), 62.seconds)
-
+    // KamonShutdownHook.registerShutdownHook() is set. We should not call Kamon.stopModules() again.
+      Thread.sleep(62000) // quick & dirty hack to ensure that the completed metric gets published
   }
 
   def migrateWithDownsamplePartKeys(partKeys: Observable[PartKeyRecord], shard: Int): Int = {


### PR DESCRIPTION
KamonShutdownHook.registerShutdownHook() is already registered, so calling Kamon.stopModules() a second time caused a conflict. Use Thread.sleep instead to preserve the metrics flush delay.

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
  DSIndexJob calls Kamon.stopModules() to introduce a delay and ensure metrics are flushed before the job exits. However, KamonShutdownHook.registerShutdownHook() is already registered elsewhere, which means stopModules() gets called a second time on shutdown — causing a conflict/double-shutdown. 
  
**New behavior :**
Replace Await.result(Kamon.stopModules(), 62.seconds) with Thread.sleep(62000) to preserve the metrics flush delay without triggering a second Kamon shutdown cycle.


**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: