### PR TITLE
fix(downsampler): replace Kamon.stopModules() with Thread.sleep to av…

### DIFF
--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
@@ -93,8 +93,8 @@ class DSIndexJob(dsSettings: DownsamplerSettings,
 
     // quick & dirty hack to ensure that the completed metric gets published
     if (dsSettings.shouldSleepForMetricsFlush)
-      Await.result(Kamon.stopModules(), 62.seconds)
-
+    // KamonShutdownHook.registerShutdownHook() is set. We should not call Kamon.stopModules() again.
+      Thread.sleep(62000) // quick & dirty hack to ensure that the completed metric gets published
   }
 
   def migrateWithDownsamplePartKeys(partKeys: Observable[PartKeyRecord], shard: Int,

--- a/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/index/DSIndexJob.scala
@@ -3,9 +3,7 @@ package filodb.downsampler.index
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.Await
-import scala.concurrent.duration.DurationInt
 
-import kamon.Kamon
 import monix.reactive.Observable
 
 import filodb.cassandra.columnstore.CassandraColumnStore

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.32.4"
+version in ThisBuild := "0.9.32.5"


### PR DESCRIPTION
…oid double shutdown (#2281)

KamonShutdownHook.registerShutdownHook() is already registered, so calling Kamon.stopModules() a second time caused a conflict. Use Thread.sleep instead to preserve the metrics flush delay.

**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** (link exiting issues here : https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)



**New behavior :**



**BREAKING CHANGES**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

Breaking changes may include:
- Any schema changes to any Cassandra tables
- The serialized format for Dataset and Column (see .toString methods)
- Over the wire formats for Akka messages / case classes
- Changes to the HTTP public API
- Changes to query parsing / PromQL parsing

**Other information**: