### PR TITLE
fix(query): Check result bytes needed a guard for the multi-parition query scenario

### DIFF
--- a/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
+++ b/query/src/main/scala/filodb/query/exec/MultiSchemaPartitionsExec.scala
@@ -213,15 +213,19 @@ final case class MultiSchemaPartitionsExec(queryContext: QueryContext,
 
   override def checkResultBytes(resultSize: Long, queryConfig: QueryConfig, queryWarnings: QueryWarnings): Unit = {
     super.checkResultBytes(resultSize, queryConfig, queryWarnings)
-    finalPlan.lookupRes.foreach(plr =>
-      if (plr.dataBytesScannedCtr.get() > queryContext.plannerParams.warnLimits.rawScannedBytes) {
-        queryWarnings.updateRawScannedBytes(plr.dataBytesScannedCtr.get())
-        val msg =
-          s"Query scanned ${plr.dataBytesScannedCtr.get()} bytes, which exceeds a max warn limit of " +
-            s"${queryContext.plannerParams.warnLimits.rawScannedBytes} bytes allowed to be scanned per shard. "
-        qLogger.info(queryContext.getQueryLogLine(msg))
-      }
-    )
+    // finalPlan can be null in Multi Partition queries where the FiloDBMultiPartitionFlightProducer needs
+    // to route the query to the right shard and the finalPlan is not created in that case.  So check for null.
+    if (finalPlan != null) {
+      finalPlan.lookupRes.foreach(plr =>
+        if (plr.dataBytesScannedCtr.get() > queryContext.plannerParams.warnLimits.rawScannedBytes) {
+          queryWarnings.updateRawScannedBytes(plr.dataBytesScannedCtr.get())
+          val msg =
+            s"Query scanned ${plr.dataBytesScannedCtr.get()} bytes, which exceeds a max warn limit of " +
+              s"${queryContext.plannerParams.warnLimits.rawScannedBytes} bytes allowed to be scanned per shard. "
+          qLogger.info(queryContext.getQueryLogLine(msg))
+        }
+      )
+    }
   }
 }
 


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Was getting an NPE in checkResultBytes when FiloDBMultiPartitionFlightProducer would process the MultiSchemaPartitionsExec  plan since finalPlan would not be created. Adding guard for that