### PR TITLE
feat(multiple): Preparing for JDK21 by making compatible changes in JDK11 itself

### DIFF
--- a/coordinator/src/main/scala/filodb.coordinator/QueryScheduler.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/QueryScheduler.scala
@@ -1,11 +1,10 @@
 package filodb.coordinator
 
-
 import java.lang.Thread.UncaughtExceptionHandler
-import java.util.concurrent.{ForkJoinPool, ForkJoinWorkerThread}
+import java.util.concurrent.{Executors, ForkJoinPool, ForkJoinWorkerThread}
 
 import com.typesafe.scalalogging.StrictLogging
-import monix.execution.Scheduler
+import monix.execution.{Scheduler, UncaughtExceptionReporter}
 import monix.execution.schedulers.SchedulerService
 
 import filodb.core.GlobalConfig
@@ -26,17 +25,67 @@ object QueryScheduler extends StrictLogging {
       }
     }
   }
+
+  // UncaughtExceptionReporter.apply receives only the Throwable; delegate to exceptionHandler
+  // with the current thread so the same logging + haltAndCatchFire logic applies.
+  private val exceptionReporter = UncaughtExceptionReporter(e =>
+                  exceptionHandler.uncaughtException(Thread.currentThread(), e))
   val queryScheduler: SchedulerService = createInstrumentedQueryScheduler()
 
-  val flightIoScheduler: SchedulerService = Scheduler.io(FlightIoSchedName, reporter = (ex: Throwable) => {
-    logger.error("Uncaught Exception in Flight IO Scheduler", ex)
-    ex match {
-      case ie: InternalError => Shutdown.haltAndCatchFire(ie)
-      case _ => {
-        /* Do nothing. */
-      }
+  val flightIoScheduler: SchedulerService = createFlightIoScheduler()
+
+  /**
+   * Creates a scheduler for Arrow Flight I/O.
+   *
+   * On Java 21+ this uses a virtual-thread-per-task executor (zero OS-thread overhead
+   * per blocked I/O call).  On Java 11 it falls back to a plain `Scheduler.io` backed
+   * by a cached thread pool, which is functionally equivalent for our purposes.
+   *
+   * Virtual-thread APIs are invoked via reflection so the source compiles on JDK 11
+   * without needing a multi-release jar or compiler flags.
+   */
+  private def createFlightIoScheduler(): SchedulerService = {
+    val majorVersion = {
+      val v = System.getProperty("java.specification.version", "11")
+      if (v.startsWith("1.")) v.split("\\.")(1).toInt else v.toInt
     }
-  })
+    if (majorVersion >= 21) {
+      try {
+        // Reflectively equivalent to:
+        //   Thread.ofVirtual()
+        //     .name(FlightIoSchedName, 0L)
+        //     .uncaughtExceptionHandler(exceptionHandler)
+        //     .factory()
+        // scalastyle:off null
+        val ofVirtual  = classOf[Thread].getMethod("ofVirtual").invoke(null)
+        val named      = ofVirtual.getClass
+                           .getMethod("name", classOf[String], java.lang.Long.TYPE)
+                           .invoke(ofVirtual, FlightIoSchedName, java.lang.Long.valueOf(0L))
+        val withHandler = named.getClass
+                            .getMethod("uncaughtExceptionHandler", classOf[UncaughtExceptionHandler])
+                            .invoke(named, exceptionHandler)
+        val factory    = withHandler.getClass
+                           .getMethod("factory")
+                           .invoke(withHandler)
+                           .asInstanceOf[java.util.concurrent.ThreadFactory]
+        // Reflectively equivalent to: Executors.newThreadPerTaskExecutor(factory)
+        val executor   = classOf[Executors]
+                           .getMethod("newThreadPerTaskExecutor", classOf[java.util.concurrent.ThreadFactory])
+                           .invoke(null, factory)
+                           .asInstanceOf[java.util.concurrent.ExecutorService]
+        logger.info(s"$FlightIoSchedName: using virtual-thread-per-task executor (Java $majorVersion)")
+        Scheduler.apply(executor, exceptionReporter)
+      } catch {
+        case e: Exception =>
+          logger.warn(s"$FlightIoSchedName: failed to create virtual-thread executor, " +
+            s"falling back to Scheduler.io", e)
+          Scheduler.io(name = FlightIoSchedName, reporter = exceptionReporter)
+      }
+    } else {
+      logger.info(s"$FlightIoSchedName: using Scheduler.io (Java $majorVersion < 21)")
+      Scheduler.io(name = FlightIoSchedName, reporter = exceptionReporter)
+    }
+  }
 
   /**
    * Instrumentation adds following metrics on the Query Scheduler
@@ -54,20 +103,18 @@ object QueryScheduler extends StrictLogging {
   private def createInstrumentedQueryScheduler(): SchedulerService = {
     val numSchedThreads = Math.ceil(GlobalConfig.systemConfig.getDouble("filodb.query.threads-factor")
       * sys.runtime.availableProcessors).toInt
-    val schedName = s"$QuerySchedName"
 
     val threadFactory = new ForkJoinPool.ForkJoinWorkerThreadFactory {
       def newThread(pool: ForkJoinPool): ForkJoinWorkerThread = {
         val thread = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool)
         thread.setDaemon(true)
-        thread.setUncaughtExceptionHandler(exceptionHandler)
-        thread.setName(s"$schedName-${thread.getPoolIndex}")
+        thread.setName(QuerySchedName)
         thread
       }
     }
     val executor = new ForkJoinPool(numSchedThreads, threadFactory, exceptionHandler, true)
 
-    Scheduler.apply(FilodbMetrics.instrumentExecutor(executor, schedName))
+    Scheduler.apply(FilodbMetrics.instrumentExecutor(executor, QuerySchedName), exceptionReporter)
   }
 
 }

--- a/coordinator/src/main/scala/filodb.coordinator/client/Serializer.scala
+++ b/coordinator/src/main/scala/filodb.coordinator/client/Serializer.scala
@@ -1,6 +1,7 @@
 package filodb.coordinator.client
 
 import java.net.URI
+import java.util.concurrent.locks.ReentrantReadWriteLock
 
 import com.esotericsoftware.kryo.{Kryo, Serializer => KryoSerializer}
 import com.esotericsoftware.kryo.io._
@@ -27,6 +28,7 @@ object KryoInit {
     kryo.addDefaultSerializer(classOf[ZeroCopyUTF8String], classOf[ZeroCopyUTF8StringSerializer])
     kryo.register(classOf[Schema], new SchemaSerializer)
     kryo.register(classOf[PartitionSchema], new PartSchemaSerializer)
+    kryo.register(classOf[ReentrantReadWriteLock], new ReentrantReadWriteLockSerializer)
 
     initOtherFiloClasses(kryo)
     initQueryEngine2Classes(kryo)
@@ -183,5 +185,16 @@ class PartSchemaSerializer extends KryoSerializer[PartitionSchema] {
   override def write(kryo: Kryo, output: Output, schema: PartitionSchema): Unit = {
     val schemas = FilodbSettings.globalOrDefault.schemas
     require(schema == schemas.part)
+  }
+}
+
+class ReentrantReadWriteLockSerializer extends KryoSerializer[ReentrantReadWriteLock] {
+  override def write(kryo: Kryo, output: Output, lock: ReentrantReadWriteLock): Unit = {
+    // No state needs to be written; locks restore cleanly to an unlocked state
+  }
+
+  override def read(kryo: Kryo, input: Input, typ: Class[ReentrantReadWriteLock]): ReentrantReadWriteLock = {
+    // Create a fresh lock when deserialized
+    new ReentrantReadWriteLock
   }
 }

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducer.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducer.scala
@@ -1,17 +1,15 @@
 package filodb.coordinator.flight
 
 import java.net.InetAddress
-import java.util
-import java.util.{Collections, Optional}
+import java.util.Collections
 import java.util.concurrent.Executors
 
+import scala.annotation.nowarn
+
 import akka.actor.ActorRef
-import com.github.luben.zstd.{ZstdInputStream, ZstdOutputStream}
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
-import io.grpc.{BindableService, CallOptions, Channel, ClientCall, ClientInterceptor, Compressor,
-  CompressorRegistry, Decompressor, DecompressorRegistry, ForwardingClientCall, Metadata, MethodDescriptor,
-  Server, ServerBuilder, ServerCall, ServerCallHandler, ServerInterceptor}
+import io.grpc.{BindableService, Server}
 import io.grpc.netty.NettyServerBuilder
 import monix.eval.Task
 import org.apache.arrow.flight._
@@ -23,6 +21,7 @@ import filodb.core.memstore.TimeSeriesStore
 import filodb.core.query._
 import filodb.query.{QueryError, QueryResponse}
 import filodb.query.exec.ExecPlan
+
 
 /**
  * FiloDB Flight Producer for single-partition queries - serves Flight RPCs for FiloDB single-partition queries
@@ -113,15 +112,10 @@ object FiloDBSinglePartitionFlightProducer extends StrictLogging {
     val port = akkaPortToFlightPort(allConfig.getInt("akka.remote.netty.tcp.port"))
     val location = Location.forGrpcInsecure(host, port)
     val executor = Executors.newCachedThreadPool()
-    val noAuthHandler = new ServerAuthHandler {
-      override def isValid(token: Array[Byte]): Optional[String] = Optional.of("")
-      override def authenticate(outgoing: ServerAuthHandler.ServerAuthSender,
-                                incoming: util.Iterator[Array[Byte]]): Boolean = true
-    }
-
+    @nowarn
     val svc: BindableService = FlightGrpcUtils.createFlightService(FlightAllocator.serverAllocator,
       new FiloDBSinglePartitionFlightProducer(memStore, FlightAllocator.serverAllocator, location, allConfig),
-      noAuthHandler,
+      ServerAuthHandler.NO_OP,
       executor)
 
     val server1 = NettyServerBuilder.forPort(port)

--- a/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/client/SerializationSpec.scala
@@ -444,5 +444,42 @@ class SerializationSpec extends ActorTest(SerializationSpecConfig.getNewSystem) 
     roundSrv.containersIterator.length shouldEqual oneSrv.containersIterator.length
     oneSrv.containersIterator.length shouldEqual 1
   }
-}
 
+  it("should round-trip QueryStats correctly via Kryo") {
+    val qsSer = QueryStats()
+    val key1 = Seq("hey")
+    val key2 = Seq("woah", "hello")
+
+    qsSer.getSamplesScannedCounter(key1).addAndGet(1)
+    qsSer.getCpuNanosCounter(key1).addAndGet(2)
+    qsSer.getDataBytesScannedCounter(key1).addAndGet(3)
+    qsSer.getTimeSeriesScannedCounter(key1).addAndGet(4)
+    qsSer.getResultBytesCounter(key1).addAndGet(5)
+
+    qsSer.getSamplesScannedCounter(key2).addAndGet(11)
+    qsSer.getCpuNanosCounter(key2).addAndGet(22)
+    qsSer.getDataBytesScannedCounter(key2).addAndGet(33)
+    qsSer.getTimeSeriesScannedCounter(key2).addAndGet(44)
+    qsSer.getResultBytesCounter(key2).addAndGet(55)
+
+    // Wrapping inside QueryError so KryoSerializer is used.
+    val err = QueryError("dummy-id", qsSer, new RuntimeException("Something broke :("))
+
+    val qsDeser = roundTrip(err).asInstanceOf[QueryError].queryStats
+
+    qsDeser.getSamplesScannedCounter(key1).get() shouldEqual 1
+    qsDeser.getCpuNanosCounter(key1).get() shouldEqual 2
+    qsDeser.getDataBytesScannedCounter(key1).get() shouldEqual 3
+    qsDeser.getTimeSeriesScannedCounter(key1).get() shouldEqual 4
+    qsDeser.getResultBytesCounter(key1).get() shouldEqual 5
+
+    qsDeser.getSamplesScannedCounter(key2).get() shouldEqual 11
+    qsDeser.getCpuNanosCounter(key2).get() shouldEqual 22
+    qsDeser.getDataBytesScannedCounter(key2).get() shouldEqual 33
+    qsDeser.getTimeSeriesScannedCounter(key2).get() shouldEqual 44
+    qsDeser.getResultBytesCounter(key2).get() shouldEqual 55
+
+    // Make sure locks are not left null after deserialization.
+    qsDeser.keys()
+  }
+}

--- a/core/src/main/scala/filodb.core/query/QueryContext.scala
+++ b/core/src/main/scala/filodb.core/query/QueryContext.scala
@@ -570,8 +570,8 @@ case class QueryStats() {
   @volatile private var containsNilKey = false;
 
   private val lock = new ReentrantReadWriteLock()
-  private val readLock = lock.readLock()
-  private val writeLock = lock.writeLock()
+  private def readLock = lock.readLock()
+  private def writeLock = lock.writeLock()
 
   override def toString: String = {
     readLock.lock()

--- a/core/src/main/scala/filodb.memory/format/UnsafeUtils.scala
+++ b/core/src/main/scala/filodb.memory/format/UnsafeUtils.scala
@@ -26,8 +26,14 @@ object UnsafeUtils {
   val arayOffset = unsafe.arrayBaseOffset(classOf[Array[Byte]])
 
   // These are specific to JDK8, definitely not guaranteed for other versions
-  val byteBufArrayField = unsafe.objectFieldOffset(classOf[ByteBuffer].getDeclaredField("hb"))
-  val byteBufOffsetField = unsafe.objectFieldOffset(classOf[ByteBuffer].getDeclaredField("offset"))
+  // In JDK 21, objectFieldOffset(Field) is deprecated, but we need it for ByteBuffer internal access
+  @SuppressWarnings(Array("deprecation"))
+  private def getFieldOffset(fieldName: String): Long = {
+    unsafe.objectFieldOffset(classOf[ByteBuffer].getDeclaredField(fieldName))
+  }
+
+  val byteBufArrayField = getFieldOffset("hb")
+  val byteBufOffsetField = getFieldOffset("offset")
 
   /** Translate ByteBuffer into base, offset, numBytes */
   //scalastyle:off method.name

--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/HllSketchAgg.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/HllSketchAgg.scala
@@ -7,34 +7,36 @@ import org.apache.spark.sql.{Encoder, Encoders}
 import org.apache.spark.sql.expressions.Aggregator
 
 case class HllSketchAgg(lgK: Int = 12, tgt: TgtHllType = TgtHllType.HLL_4)
-  extends Aggregator[String, HllSketch, Array[Byte]] with Serializable {
+  extends Aggregator[String, Array[Byte], Array[Byte]] with Serializable {
 
   // buffer zero: a fresh updatable sketch
-  override def zero: HllSketch = new HllSketch(lgK, tgt)
+  override def zero: Array[Byte] = new HllSketch(lgK, tgt).toCompactByteArray
 
   // add single input to the sketch
-  override def reduce(buffer: HllSketch, input: String): HllSketch = {
+  override def reduce(buffer: Array[Byte], input: String): Array[Byte] = {
     if (input != null) {
-      buffer.update(input.getBytes(StandardCharsets.UTF_8))
-    }
-    buffer
+      val sketch = HllSketch.heapify(buffer)
+      sketch.update(input.getBytes(StandardCharsets.UTF_8))
+      sketch.toCompactByteArray
+    } else buffer
   }
 
   // merge two sketches using Union (safe/easy path)
-  override def merge(b1: HllSketch, b2: HllSketch): HllSketch = {
-    val union = new Union(Math.max(lgK, Math.max(b1.getLgConfigK, b2.getLgConfigK)))
-    union.update(b1)
-    union.update(b2)
-    union.getResult(tgt)
+  override def merge(b1: Array[Byte], b2: Array[Byte]): Array[Byte] = {
+    val s1 = HllSketch.heapify(b1)
+    val s2 = HllSketch.heapify(b2)
+    val union = new Union(Math.max(lgK, Math.max(s1.getLgConfigK, s2.getLgConfigK)))
+    union.update(s1)
+    union.update(s2)
+    union.getResult(tgt).toCompactByteArray
   }
 
-  override def finish(reduction: HllSketch): Array[Byte] = {
+  override def finish(reduction: Array[Byte]): Array[Byte] = {
     // Use compact representation (smaller) for storage/transfers
-    reduction.toCompactByteArray
+    reduction
   }
 
   // encoders
-  override def bufferEncoder: Encoder[HllSketch] = Encoders.kryo[HllSketch]
+  override def bufferEncoder: Encoder[Array[Byte]] = Encoders.BINARY
   override def outputEncoder: Encoder[Array[Byte]] = Encoders.BINARY
 }
-

--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/HllSketchMergeAgg.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/HllSketchMergeAgg.scala
@@ -10,28 +10,32 @@ import org.apache.spark.sql.expressions.Aggregator
  * sketches built per salt bucket into the final per-(ws, label) sketch.
  */
 case class HllSketchMergeAgg(lgK: Int = 12, tgt: TgtHllType = TgtHllType.HLL_4)
-  extends Aggregator[Array[Byte], HllSketch, Array[Byte]] with Serializable {
+  extends Aggregator[Array[Byte], Array[Byte], Array[Byte]] with Serializable {
 
-  override def zero: HllSketch = new HllSketch(lgK, tgt)
+  override def zero: Array[Byte] = new HllSketch(lgK, tgt).toCompactByteArray
 
-  override def reduce(buffer: HllSketch, input: Array[Byte]): HllSketch = {
+  override def reduce(buffer: Array[Byte], input: Array[Byte]): Array[Byte] = {
     if (input != null) {
-      val union = new Union(Math.max(lgK, buffer.getLgConfigK))
-      union.update(buffer)
-      union.update(HllSketch.heapify(input))
-      union.getResult(tgt)
+      val s1 = HllSketch.heapify(buffer)
+      val s2 = HllSketch.heapify(input)
+      val union = new Union(Math.max(lgK, Math.max(s1.getLgConfigK, s2.getLgConfigK)))
+      union.update(s1)
+      union.update(s2)
+      union.getResult(tgt).toCompactByteArray
     } else buffer
   }
 
-  override def merge(b1: HllSketch, b2: HllSketch): HllSketch = {
-    val union = new Union(Math.max(lgK, Math.max(b1.getLgConfigK, b2.getLgConfigK)))
-    union.update(b1)
-    union.update(b2)
-    union.getResult(tgt)
+  override def merge(b1: Array[Byte], b2: Array[Byte]): Array[Byte] = {
+    val s1 = HllSketch.heapify(b1)
+    val s2 = HllSketch.heapify(b2)
+    val union = new Union(Math.max(lgK, Math.max(s1.getLgConfigK, s2.getLgConfigK)))
+    union.update(s1)
+    union.update(s2)
+    union.getResult(tgt).toCompactByteArray
   }
 
-  override def finish(reduction: HllSketch): Array[Byte] = reduction.toCompactByteArray
+  override def finish(reduction: Array[Byte]): Array[Byte] = reduction
 
-  override def bufferEncoder: Encoder[HllSketch]   = Encoders.kryo[HllSketch]
+  override def bufferEncoder: Encoder[Array[Byte]] = Encoders.BINARY
   override def outputEncoder: Encoder[Array[Byte]] = Encoders.BINARY
 }

--- a/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelChurnFinderSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelChurnFinderSpec.scala
@@ -27,6 +27,7 @@ class LabelChurnFinderSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
   implicit val defaultPatience = PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
 
   val baseConf = ConfigFactory.parseFile(new File("conf/timeseries-filodb-server.conf")).resolve()
+  var sparkSession: SparkSession = _
 
   val now = 1752700000000L
   val jobConfig = ConfigFactory.parseString(
@@ -67,6 +68,9 @@ class LabelChurnFinderSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
 
   override def afterAll(): Unit = {
     offheapMem.free()
+    if (sparkSession != null) {
+      sparkSession.stop()
+    }
   }
 
   it("should simulate bulk part key records being written into raw for processing") {
@@ -96,9 +100,19 @@ class LabelChurnFinderSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
     }
   }
 
-  it ("should run LCF job for one namespace and workspace") {
+  private def localSparkConf(): SparkConf = {
     val sparkConf = new SparkConf(loadDefaults = true)
     sparkConf.setMaster("local[2]")
+    // Pin driver/executor to loopback so tests pass regardless of WiFi/VPN state.
+    // Without this, InetAddress.getLocalHost resolves to the WiFi IP on macOS,
+    // causing Spark internal RPC to bind on a non-loopback address that may not be reachable.
+    sparkConf.set("spark.driver.host", "127.0.0.1")
+    sparkConf.set("spark.driver.bindAddress", "127.0.0.1")
+    sparkConf
+  }
+
+  it ("should run LCF job for one namespace and workspace") {
+    val sparkConf = localSparkConf()
     val filterConfig = ConfigFactory.parseString(
       s"""
          |filodb.labelchurnfinder.pk-filters.0._ns_ = bulk_ns0
@@ -107,12 +121,12 @@ class LabelChurnFinderSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
     val settings2 = new DownsamplerSettings(filterConfig.withFallback(jobConfig.withFallback(baseConf)))
     val lcf = new LabelChurnFinder(settings2)
     sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-    val spark = SparkSession.builder()
+    sparkSession = SparkSession.builder()
       .appName("LabelChurnFinder")
       .config(sparkConf)
       .getOrCreate()
 
-    val result = lcf.countsFromSketches(lcf.computeLabelStats(spark)).collect()
+    val result = lcf.countsFromSketches(lcf.computeLabelStats(sparkSession)).collect()
     result.length shouldEqual 6
     val cards = result.map { row => (row.getAs[String](WsCol),
                                      row.getAs[String](LabelCol),
@@ -126,12 +140,10 @@ class LabelChurnFinderSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
       ("bulk_ws", "_metric_", 1, 1),
       ("bulk_ws", "pod", numPods/2, numPods/2),
     )
-    spark.stop()
   }
 
   it ("should run LCF job for multiple namespaces and workspaces") {
-    val sparkConf = new SparkConf(loadDefaults = true)
-    sparkConf.setMaster("local[2]")
+    val sparkConf = localSparkConf()
     val filterConfig = ConfigFactory.parseString(
       s"""
          |filodb.labelchurnfinder.pk-filters.0._ns_ = "bulk_ns.*"
@@ -140,11 +152,11 @@ class LabelChurnFinderSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
     val settings2 = new DownsamplerSettings(filterConfig.withFallback(jobConfig.withFallback(baseConf)))
     val lcf = new LabelChurnFinder(settings2)
     sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-    val spark = SparkSession.builder()
+    sparkSession = SparkSession.builder()
       .appName("LabelChurnFinder")
       .config(sparkConf)
       .getOrCreate()
-    val result = lcf.countsFromSketches(lcf.computeLabelStats(spark)).collect()
+    val result = lcf.countsFromSketches(lcf.computeLabelStats(sparkSession)).collect()
     result.length shouldEqual 6
     val cards = result.map { row => (row.getAs[String](WsCol),
                                      row.getAs[String](LabelCol),
@@ -158,12 +170,10 @@ class LabelChurnFinderSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
       ("bulk_ws", "_metric_", 1, 1),
       ("bulk_ws", "pod", numPods/2, numPods/2),
     )
-    spark.stop()
   }
 
   it ("should run LCF job for different time range") {
-    val sparkConf = new SparkConf(loadDefaults = true)
-    sparkConf.setMaster("local[2]")
+    val sparkConf = localSparkConf()
     val filterConfig = ConfigFactory.parseString(
       s"""
          |filodb.labelchurnfinder.pk-filters.0._ns_ = "bulk_ns.*"
@@ -173,11 +183,11 @@ class LabelChurnFinderSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
     val settings2 = new DownsamplerSettings(filterConfig.withFallback(jobConfig.withFallback(baseConf)))
     val lcf = new LabelChurnFinder(settings2)
     sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-    val spark = SparkSession.builder()
+    sparkSession = SparkSession.builder()
       .appName("LabelChurnFinder")
       .config(sparkConf)
       .getOrCreate()
-    val result = lcf.countsFromSketches(lcf.computeLabelStats(spark)).collect()
+    val result = lcf.countsFromSketches(lcf.computeLabelStats(sparkSession)).collect()
     result.length shouldEqual 6
     val cards = result.map { row => (row.getAs[String](WsCol),
                                      row.getAs[String](LabelCol),
@@ -191,14 +201,12 @@ class LabelChurnFinderSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
       ("bulk_ws", "_metric_", 1, 1),
       ("bulk_ws", "pod", numPods/2, numPods/2)
     )
-    spark.stop()
   }
 
   it ("should call publishLabelStats when actionOnLabelStats is invoked") {
-    val sparkConf = new SparkConf(loadDefaults = true)
-    sparkConf.setMaster("local[2]")
+    val sparkConf = localSparkConf()
     sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-    val spark = SparkSession.builder()
+    sparkSession = SparkSession.builder()
       .appName("LabelChurnFinder")
       .config(sparkConf)
       .getOrCreate()
@@ -219,6 +227,7 @@ class LabelChurnFinderSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
     sketch7d.update("value3")
 
     // Create a test DataFrame with valid HLL sketches
+    val spark = sparkSession
     import spark.implicits._
     val testDf = Seq(
       ("ws1", "All", "pod", 100L, 200L, 300L,
@@ -231,8 +240,6 @@ class LabelChurnFinderSpec extends AnyFunSpec with Matchers with BeforeAndAfterA
 
     // Verify publishLabelStats was called once
     verify(mockProducer, times(1)).publishLabelStats(any[DataFrame])
-
-    spark.stop()
   }
 
 }

--- a/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelStatsKafkaProducerSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelStatsKafkaProducerSpec.scala
@@ -25,12 +25,24 @@ class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAn
 
   var spark: SparkSession = _
 
-  override def beforeAll(): Unit = {
+  private def localSparkConf(): SparkConf = {
     val sparkConf = new SparkConf(loadDefaults = false)
+    sparkConf.setMaster("local[2]")
       .setMaster("local[2]")
       .setAppName("LabelStatsKafkaProducerSpec")
       .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
       .set("spark.ui.enabled", "false")
+    // Pin driver/executor to loopback so tests pass regardless of WiFi/VPN state.
+    // Without this, InetAddress.getLocalHost resolves to the WiFi IP on macOS,
+    // causing Spark internal RPC to bind on a non-loopback address that may not be reachable.
+    sparkConf.set("spark.driver.host", "127.0.0.1")
+    sparkConf.set("spark.driver.bindAddress", "127.0.0.1")
+    sparkConf
+  }
+
+
+  override def beforeAll(): Unit = {
+    val sparkConf = localSparkConf()
 
     spark = SparkSession.builder()
       .config(sparkConf)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Prepare for JDK21 by making changes in code without upgrading to JDK21 yet.
Also using virtual threads with reflection based on Java runtime. This allows us to compile code with Java 11 compatibility thus not forcing all library dependents to upgrade to JDK21 in lock step.

I am essentially bringing code changes from develop-jdk21 branch into here without build upgrades to JDK21.

