### PR TITLE
feat(core): Automatic memory configutation enhanced to incude flight memory

### DIFF
--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -536,15 +536,21 @@ filodb {
       # This buffer size is used for Arrow Flight metadata serialization.
       kryo-arrow-buf-len = 16 KB
 
-      # Allocator limit for Flight server
-      allocator-limit = 1 GB
+      # Fraction of the root allocator root-allocator-max-memory which should be the limit for Flight server allocator
+      # server.fraction-allocator-limit + client.fraction-allocator-limit should be 1 to limit each.
+      # If you want to allow them to race with each other, their sum can exceed 1
+      fraction-allocator-limit = 0.75
 
       # Off heap allocator limit for each Flight request
       per-request-allocator-limit = 50 MB
     }
+
     client {
-      # Maximum memory for all flight clients
-      allocator-limit = 500 MB
+      # Fraction of the root allocator root-allocator-max-memory which should be the limit for Flight client allocator
+      # shared across all flight clients
+      # server.fraction-allocator-limit + client.fraction-allocator-limit should be 1 to limit each.
+      # If you want to allow them to race with each other, their sum can exceed 1
+      fraction-allocator-limit = 0.25
 
       # Request timeout
       request-timeout = 60s
@@ -1061,14 +1067,14 @@ filodb {
       # memory dedicated for proper functioning of OS
       os-memory-needs = 500MB
 
-      # NOTE: In the three configs below,
-      # lucene-memory-percent + native-memory-manager-percent + block-memory-manager-percent
+      # NOTE: In the four configs below,
+      # lucene-memory-percent + native-memory-manager-percent + block-memory-manager-percent +
       # should equal 100
-      ##############################################################
-      #                    #                     #                 #
-      #  LuceneMemPercent  # NativeMemPercent    # BlockMemPercent #
-      #                    #                     #                 #
-      ##############################################################
+      ##################################################################################
+      #                    #                     #                 #                   #
+      #  LuceneMemPercent  # NativeMemPercent    # BlockMemPercent # FlightRPCPercent  #
+      #                    #                     #                 #                   #
+      ##################################################################################
 
       # Memory percent of available-memory reserved for Lucene memory maps.
       # Note we do not use this config to explicitly allocate space for lucene.
@@ -1084,6 +1090,10 @@ filodb {
       # This is divvied amongst datasets on the node per configuration for dataset
       # The shards of the dataset on the node get even amount of memory from this fraction
       block-memory-manager-percent = 71
+
+      # Memory percent of available-memory reserved for flight RPC root allocator (used for flight based query RPCs).
+      # Should be non-zero if flight RPC is enabled.
+      flight-rpc-memory-percent = 0
     }
 
     # Settings for Tantivy backed indexes

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -1058,41 +1058,57 @@ filodb {
     ingestion-buffer-mem-size = 200MB
 
     memory-alloc {
-      # automatic memory allocation is enabled if true
+      # When true, each subsystem's off-heap limit is derived automatically from the
+      # node/container's total RAM instead of being set by hand.
+      # Requires min-num-nodes-in-cluster to be set so per-shard block memory can be
+      # calculated.  See AutoMemoryAllocUtil for the full calculation logic.
       automatic-alloc-enabled = false
 
-      # if not provided this is calculated as ContainerOrNodeMemory - os-memory-needs - CurrentJVMHeapMemory
+      # Off-heap budget available to FiloDB, in bytes.
+      # When omitted, this is computed at runtime as:
+      #   containerTotalPhysicalMemory  (from OperatingSystemMXBean)
+      #     - JVM max heap              (-Xmx / Runtime.maxMemory)
+      #     - os-memory-needs           (see below)
+      # Override this when the container memory reported by the JVM is wrong (e.g.
+      # when cgroup limits differ from host RAM) or in tests for reproducibility.
       # available-memory-bytes = 5GB
 
-      # memory dedicated for proper functioning of OS
+      # RAM to leave untouched for OS use (kernel, page-cache overhead, etc.).
+      # Only used in the runtime calculation above; ignored if available-memory-bytes
+      # is set explicitly.
       os-memory-needs = 500MB
 
-      # NOTE: In the four configs below,
-      # lucene-memory-percent + native-memory-manager-percent + block-memory-manager-percent +
-      # should equal 100
-      ##################################################################################
-      #                    #                     #                 #                   #
-      #  LuceneMemPercent  # NativeMemPercent    # BlockMemPercent # FlightRPCPercent  #
-      #                    #                     #                 #                   #
-      ##################################################################################
+      # The four percent values below partition the available memory into named pools.
+      # They MUST sum to exactly 100 (within 0.001 floating-point tolerance); FiloDB
+      # will refuse to start if automatic-alloc-enabled = true and the sum is wrong.
+      #
+      # ┌──────────────────┬──────────────────────┬──────────────────┬─────────────────────┐
+      # │ lucene-memory    │ native-memory-manager│ block-memory-    │ flight-rpc-memory   │
+      # │ -percent         │ -percent             │ manager-percent  │ -percent            │
+      # │ (soft OS reserve)│ (partKeys, chunkMaps,│ (encoded chunks, │ (Arrow Flight root  │
+      # │                  │  writeBuffers)       │  split by shard) │  allocator)         │
+      # └──────────────────┴──────────────────────┴──────────────────┴─────────────────────┘
 
-      # Memory percent of available-memory reserved for Lucene memory maps.
-      # Note we do not use this config to explicitly allocate space for lucene.
-      # But reserving this space ensures that more of the lucene memory maps are stored in memory
+      # Soft reserve for Lucene / Tantivy memory-mapped index files.
+      # FiloDB does NOT explicitly allocate this memory; it is simply left unallocated
+      # so the OS page-cache can keep index pages warm.  Increase if index queries are
+      # slow due to page-cache eviction under memory pressure.
       lucene-memory-percent = 5
 
-      # memory percent of available-memory reserved for native memory manager
-      # (used for partKeys, chunkMaps, chunkInfos, writeBuffers)
+      # Explicitly allocated for the NativeMemoryManager, which holds:
+      # partition keys, chunk maps, chunk infos, and ingestion write-buffers.
       native-memory-manager-percent = 24
 
-      # Memory percent of available-memory reserved for block memory manager
-      # (used for storing chunks)
-      # This is divvied amongst datasets on the node per configuration for dataset
-      # The shards of the dataset on the node get even amount of memory from this fraction
+      # Explicitly allocated for the BlockMemoryManager, which stores encoded columnar
+      # chunks.  This pool is shared across all datasets configured on the node; each
+      # dataset claims its slice via store.shard-mem-percent.  Per-shard allocation is:
+      #   availableMemory × (this% / 100) × (shard-mem-percent / 100)
+      #     / ceil(numShards / min-num-nodes-in-cluster)
       block-memory-manager-percent = 71
 
-      # Memory percent of available-memory reserved for flight RPC root allocator (used for flight based query RPCs).
-      # Should be non-zero if flight RPC is enabled.
+      # Explicitly allocated for the Arrow Flight root allocator, shared by the Flight
+      # server and client.  Leave at 0 when Flight is disabled (grpc.start-grpc-service
+      # = false or flight.server.enabled = false).
       flight-rpc-memory-percent = 0
     }
 

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -1107,8 +1107,7 @@ filodb {
       block-memory-manager-percent = 71
 
       # Explicitly allocated for the Arrow Flight root allocator, shared by the Flight
-      # server and client.  Leave at 0 when Flight is disabled (grpc.start-grpc-service
-      # = false or flight.server.enabled = false).
+      # server and client.  Leave at 0 when Flight is disabled (flight.server.enabled = false).
       flight-rpc-memory-percent = 0
     }
 

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -519,7 +519,7 @@ filodb {
   flight {
 
     # Maximum memory for Flight server root allocator (in bytes)
-    root-allocator-max-memory = 2 GB
+    root-allocator-max-memory = 500 MB
 
     # zstd compression for Flight (better than gzip)
     # disabled by default since I still see allocations without much decrease in latency
@@ -536,10 +536,14 @@ filodb {
       # This buffer size is used for Arrow Flight metadata serialization.
       kryo-arrow-buf-len = 16 KB
 
-      # Fraction of the root allocator root-allocator-max-memory which should be the limit for Flight server allocator
+      # Fraction of the root allocator root-allocator-max-memory which should be the limit for Flight server allocator.
+      # Used if filodb.memstore.memory-alloc.automatic-alloc-enabled = true
       # server.fraction-allocator-limit + client.fraction-allocator-limit should be 1 to limit each.
       # If you want to allow them to race with each other, their sum can exceed 1
       fraction-allocator-limit = 0.75
+
+      # Explicit value used if filodb.memstore.memory-alloc.automatic-alloc-enabled = false
+      allocator-limit = 300 MB
 
       # Off heap allocator limit for each Flight request
       per-request-allocator-limit = 50 MB
@@ -548,9 +552,13 @@ filodb {
     client {
       # Fraction of the root allocator root-allocator-max-memory which should be the limit for Flight client allocator
       # shared across all flight clients
+      # Used if filodb.memstore.memory-alloc.automatic-alloc-enabled = true
       # server.fraction-allocator-limit + client.fraction-allocator-limit should be 1 to limit each.
       # If you want to allow them to race with each other, their sum can exceed 1
       fraction-allocator-limit = 0.25
+
+      # Explicit value used if filodb.memstore.memory-alloc.automatic-alloc-enabled = false
+      allocator-limit = 200 MB
 
       # Request timeout
       request-timeout = 60s

--- a/core/src/main/scala/filodb.core/Utils.scala
+++ b/core/src/main/scala/filodb.core/Utils.scala
@@ -19,28 +19,6 @@ object Utils extends StrictLogging {
     else System.nanoTime()
   }
 
-  def calculateAvailableOffHeapMemory(filodbConfig: Config): Long = {
-    val containerMemory = ManagementFactory.getOperatingSystemMXBean()
-      .asInstanceOf[com.sun.management.OperatingSystemMXBean].getTotalPhysicalMemorySize()
-    val currentJavaHeapMemory = Runtime.getRuntime().maxMemory()
-    val osMemoryNeeds = filodbConfig.getMemorySize("memstore.memory-alloc.os-memory-needs").toBytes
-    logger.info(s"Detected available memory containerMemory=$containerMemory" +
-      s" currentJavaHeapMemory=$currentJavaHeapMemory osMemoryNeeds=$osMemoryNeeds")
-
-    logger.info(s"Memory Alloc Options: " +
-      s"${filodbConfig.getConfig("memstore.memory-alloc").root().render(ConfigRenderOptions.concise())}")
-
-    val availableMem = if (filodbConfig.hasPath("memstore.memory-alloc.available-memory-bytes")) {
-      val avail = filodbConfig.getMemorySize("memstore.memory-alloc.available-memory-bytes").toBytes
-      logger.info(s"Using automatic-memory-config using overridden memory-alloc.available-memory $avail")
-      avail
-    } else {
-      logger.info(s"Using automatic-memory-config using without available memory override")
-      containerMemory - currentJavaHeapMemory - osMemoryNeeds
-    }
-    logger.info(s"Available memory calculated or configured as $availableMem")
-    availableMem
-  }
 
   // Recursively delete a folder
   def deleteRecursively(f: File, deleteRoot: Boolean = false): Try[Boolean] = {

--- a/core/src/main/scala/filodb.core/memstore/AutoMemoryAllocUtil.scala
+++ b/core/src/main/scala/filodb.core/memstore/AutoMemoryAllocUtil.scala
@@ -1,0 +1,78 @@
+package filodb.core.memstore
+
+import java.lang.management.ManagementFactory
+
+import com.typesafe.config.{Config, ConfigRenderOptions}
+import com.typesafe.scalalogging.StrictLogging
+
+import filodb.core.DatasetRef
+import filodb.core.store.StoreConfig
+
+object AutoMemoryAllocUtil extends StrictLogging {
+
+  def isAutoMemoryConfigEnabled(filodbConfig: Config): Boolean = {
+    val enabled = filodbConfig.getBoolean("memstore.memory-alloc.automatic-alloc-enabled")
+    if (enabled) {
+      val nativeMemoryManagerPercent = filodbConfig.getDouble("memstore.memory-alloc.native-memory-manager-percent")
+      val blockMemoryManagerPercent = filodbConfig.getDouble("memstore.memory-alloc.block-memory-manager-percent")
+      val flightRpcMemoryPercent = filodbConfig.getDouble("memstore.memory-alloc.flight-rpc-memory-percent")
+      val lucenePercent = filodbConfig.getDouble("memstore.memory-alloc.lucene-memory-percent")
+      require(Math.abs(nativeMemoryManagerPercent + blockMemoryManagerPercent + lucenePercent +
+        flightRpcMemoryPercent - 100) < 0.001,
+        s"isAutoMemoryConfigEnabled but configured Block($nativeMemoryManagerPercent), " +
+          s"Native($blockMemoryManagerPercent), Flight($flightRpcMemoryPercent) and " +
+          s"Lucene($lucenePercent) memory percents don't sum to 100.0")
+    }
+    enabled
+  }
+
+  def getFlightRPCMemoryAllocSize(filodbConfig: Config): Long = {
+    val availableMemoryBytes: Long = calculateAvailableOffHeapMemory(filodbConfig)
+    val flightRpcMemoryPercent = filodbConfig.getDouble("memstore.memory-alloc.flight-rpc-memory-percent")
+    (availableMemoryBytes * flightRpcMemoryPercent / 100).toLong
+  }
+
+  def getIngestionMemoryAllocSize(filodbConfig: Config): Long = {
+    val availableMemoryBytes: Long = calculateAvailableOffHeapMemory(filodbConfig)
+    val nativeMemoryManagerPercent = filodbConfig.getDouble("memstore.memory-alloc.native-memory-manager-percent")
+    (availableMemoryBytes * nativeMemoryManagerPercent / 100).toLong
+  }
+
+  def getPerShardBlockMemoryAllocSize(filodbConfig: Config, numShards: Int,
+                                      datasetRef: DatasetRef, storeConfig: StoreConfig): Long = {
+    val numNodes = filodbConfig.getInt("min-num-nodes-in-cluster")
+    val availableMemoryBytes: Long = calculateAvailableOffHeapMemory(filodbConfig)
+    val blockMemoryManagerPercent = filodbConfig.getDouble("memstore.memory-alloc.block-memory-manager-percent")
+    val blockMemForDatasetPercent = storeConfig.shardMemPercent // fraction of block memory for this dataset
+    val numShardsPerNode = Math.ceil(numShards / numNodes.toDouble)
+    logger.info(s"Calculating Block memory size with automatic allocation strategy. " +
+      s"Dataset dataset=$datasetRef has blockMemForDatasetPercent=$blockMemForDatasetPercent " +
+      s"numShardsPerNode=$numShardsPerNode")
+    (availableMemoryBytes * blockMemoryManagerPercent *
+      blockMemForDatasetPercent / 100 / 100 / numShardsPerNode).toLong
+  }
+
+  private def calculateAvailableOffHeapMemory(filodbConfig: Config): Long = {
+    val containerMemory = ManagementFactory.getOperatingSystemMXBean()
+      .asInstanceOf[com.sun.management.OperatingSystemMXBean].getTotalPhysicalMemorySize()
+    val currentJavaHeapMemory = Runtime.getRuntime().maxMemory()
+    val osMemoryNeeds = filodbConfig.getMemorySize("memstore.memory-alloc.os-memory-needs").toBytes
+    logger.info(s"Detected available memory containerMemory=$containerMemory" +
+      s" currentJavaHeapMemory=$currentJavaHeapMemory osMemoryNeeds=$osMemoryNeeds")
+
+    logger.info(s"Memory Alloc Options: " +
+      s"${filodbConfig.getConfig("memstore.memory-alloc").root().render(ConfigRenderOptions.concise())}")
+
+    val availableMem = if (filodbConfig.hasPath("memstore.memory-alloc.available-memory-bytes")) {
+      val avail = filodbConfig.getMemorySize("memstore.memory-alloc.available-memory-bytes").toBytes
+      logger.info(s"Using automatic-memory-config using overridden memory-alloc.available-memory $avail")
+      avail
+    } else {
+      logger.info(s"Using automatic-memory-config using without available memory override")
+      containerMemory - currentJavaHeapMemory - osMemoryNeeds
+    }
+    logger.info(s"Available memory calculated or configured as $availableMem")
+    availableMem
+  }
+
+}

--- a/core/src/main/scala/filodb.core/memstore/AutoMemoryAllocUtil.scala
+++ b/core/src/main/scala/filodb.core/memstore/AutoMemoryAllocUtil.scala
@@ -6,7 +6,6 @@ import com.typesafe.config.{Config, ConfigRenderOptions}
 import com.typesafe.scalalogging.StrictLogging
 
 import filodb.core.DatasetRef
-import filodb.core.query.FlightAllocator.filodbConfig
 import filodb.core.store.StoreConfig
 
 /**
@@ -120,6 +119,10 @@ object AutoMemoryAllocUtil extends StrictLogging {
   private lazy val currentJavaHeapMemory = Runtime.getRuntime().maxMemory()
 
   private def calculateAvailableOffHeapMemory(filodbConfig: Config): Long = {
+    require(isAutoMemoryConfigEnabled(filodbConfig), s"Automatic memory allocation is not enabled in config but" +
+      s"calculateAvailableOffHeapMemory method was called")
+    // If Xmx is not set, maxMemory() returns Long.MaxValue, which is not useful for calculating available memory.
+    require(currentJavaHeapMemory < Long.MaxValue, s"Xmx was not set but auto memory configuration was enabled")
     val osMemoryNeeds = filodbConfig.getMemorySize("memstore.memory-alloc.os-memory-needs").toBytes
     logger.info(s"Detected available memory containerMemory=$containerMemory" +
       s" currentJavaHeapMemory=$currentJavaHeapMemory osMemoryNeeds=$osMemoryNeeds")

--- a/core/src/main/scala/filodb.core/memstore/AutoMemoryAllocUtil.scala
+++ b/core/src/main/scala/filodb.core/memstore/AutoMemoryAllocUtil.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.{Config, ConfigRenderOptions}
 import com.typesafe.scalalogging.StrictLogging
 
 import filodb.core.DatasetRef
+import filodb.core.query.FlightAllocator.filodbConfig
 import filodb.core.store.StoreConfig
 
 /**
@@ -82,6 +83,16 @@ object AutoMemoryAllocUtil extends StrictLogging {
     val availableMemoryBytes: Long = calculateAvailableOffHeapMemory(filodbConfig)
     val flightRpcMemoryPercent = filodbConfig.getDouble("memstore.memory-alloc.flight-rpc-memory-percent")
     (availableMemoryBytes * flightRpcMemoryPercent / 100).toLong
+  }
+
+  def getFlightServerMemoryAllocSize(filodbConfig: Config): Long = {
+    (filodbConfig.getDouble("flight.server.fraction-allocator-limit") *
+      getFlightRPCMemoryAllocSize(filodbConfig)).toLong
+  }
+
+  def getFlightClientMemoryAllocSize(filodbConfig: Config): Long = {
+    (filodbConfig.getDouble("flight.client.fraction-allocator-limit") *
+      getFlightRPCMemoryAllocSize(filodbConfig)).toLong
   }
 
   def getIngestionMemoryAllocSize(filodbConfig: Config): Long = {

--- a/core/src/main/scala/filodb.core/memstore/AutoMemoryAllocUtil.scala
+++ b/core/src/main/scala/filodb.core/memstore/AutoMemoryAllocUtil.scala
@@ -71,8 +71,8 @@ object AutoMemoryAllocUtil extends StrictLogging {
       val lucenePercent = filodbConfig.getDouble("memstore.memory-alloc.lucene-memory-percent")
       require(Math.abs(nativeMemoryManagerPercent + blockMemoryManagerPercent + lucenePercent +
         flightRpcMemoryPercent - 100) < 0.001,
-        s"isAutoMemoryConfigEnabled but configured Block($nativeMemoryManagerPercent), " +
-          s"Native($blockMemoryManagerPercent), Flight($flightRpcMemoryPercent) and " +
+        s"isAutoMemoryConfigEnabled but configured Native($nativeMemoryManagerPercent), " +
+          s"Block($blockMemoryManagerPercent), Flight($flightRpcMemoryPercent) and " +
           s"Lucene($lucenePercent) memory percents don't sum to 100.0")
     }
     enabled
@@ -104,10 +104,11 @@ object AutoMemoryAllocUtil extends StrictLogging {
       blockMemForDatasetPercent / 100 / 100 / numShardsPerNode).toLong
   }
 
+  private lazy val containerMemory = ManagementFactory.getOperatingSystemMXBean()
+    .asInstanceOf[com.sun.management.OperatingSystemMXBean].getTotalPhysicalMemorySize()
+  private lazy val currentJavaHeapMemory = Runtime.getRuntime().maxMemory()
+
   private def calculateAvailableOffHeapMemory(filodbConfig: Config): Long = {
-    val containerMemory = ManagementFactory.getOperatingSystemMXBean()
-      .asInstanceOf[com.sun.management.OperatingSystemMXBean].getTotalPhysicalMemorySize()
-    val currentJavaHeapMemory = Runtime.getRuntime().maxMemory()
     val osMemoryNeeds = filodbConfig.getMemorySize("memstore.memory-alloc.os-memory-needs").toBytes
     logger.info(s"Detected available memory containerMemory=$containerMemory" +
       s" currentJavaHeapMemory=$currentJavaHeapMemory osMemoryNeeds=$osMemoryNeeds")

--- a/core/src/main/scala/filodb.core/memstore/AutoMemoryAllocUtil.scala
+++ b/core/src/main/scala/filodb.core/memstore/AutoMemoryAllocUtil.scala
@@ -8,6 +8,58 @@ import com.typesafe.scalalogging.StrictLogging
 import filodb.core.DatasetRef
 import filodb.core.store.StoreConfig
 
+/**
+ * Utility for automatic off-heap memory allocation across FiloDB's subsystems.
+ *
+ * When `memstore.memory-alloc.automatic-alloc-enabled = true`, each subsystem's memory
+ * limit is derived from a single "available memory" figure rather than being configured
+ * individually.  This makes it easy to right-size a deployment just by stating the
+ * total budget and letting the percentages do the rest.
+ *
+ * == Available memory ==
+ * Available memory is the off-heap budget for FiloDB. It is either read directly from
+ * config (`memstore.memory-alloc.available-memory-bytes`, useful for testing or when
+ * the container memory is misreported by the JVM) or calculated at runtime as:
+ *
+ *   availableMemory = containerTotalPhysicalMemory - JVM max heap - os-memory-needs
+ *
+ * `containerTotalPhysicalMemory` comes from [[java.lang.management.OperatingSystemMXBean]]
+ * and reflects the total RAM visible to the container or host.
+ * `JVM max heap` is `Runtime.getRuntime.maxMemory()` (-Xmx).
+ * `os-memory-needs` is a configurable reserve for the OS (default 500 MB).
+ *
+ * == Memory pools ==
+ * The available memory is divided into four named pools.  Their percents must sum to
+ * exactly 100 (within a 0.001 floating-point tolerance):
+ *
+ *   lucene-memory-percent        – soft reserve for Lucene/Tantivy memory-mapped index
+ *                                  files; not explicitly allocated, just left untouched
+ *                                  so the OS page-cache can keep index pages warm.
+ *   native-memory-manager-percent – explicitly allocated for the NativeMemoryManager,
+ *                                   which holds partition keys, chunk maps, chunk infos,
+ *                                   and ingestion write-buffers.
+ *   block-memory-manager-percent  – explicitly allocated for the BlockMemoryManager,
+ *                                   which stores encoded columnar chunks. This pool is
+ *                                   shared across all datasets; each dataset's shard
+ *                                   claims a slice (see below).
+ *   flight-rpc-memory-percent     – explicitly allocated for the Arrow Flight root
+ *                                   allocator. Must be non-zero when Flight is enabled.
+ *
+ * == Per-shard block memory ==
+ * [[getPerShardBlockMemoryAllocSize]] divides the block-memory pool down to the shard
+ * level using:
+ *
+ *   perShardBytes =
+ *     availableMemory
+ *       × (block-memory-manager-percent / 100)
+ *       × (store.shard-mem-percent / 100)   // dataset's share of the block pool
+ *       / ceil(numShards / min-num-nodes-in-cluster)
+ *
+ * `shard-mem-percent` allows multiple datasets on the same node to split the block
+ * pool (e.g. 50 / 50 for two datasets).  `min-num-nodes-in-cluster` is used to infer
+ * how many shards land on a typical node; ceiling is taken so nodes that receive an
+ * extra shard are not over-provisioned.
+ */
 object AutoMemoryAllocUtil extends StrictLogging {
 
   def isAutoMemoryConfigEnabled(filodbConfig: Config): Boolean = {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesMemStore.scala
@@ -49,16 +49,10 @@ extends TimeSeriesStore with StrictLogging {
     new CompositeEvictionPolicy(ensureTspHeadroomPercent, ensureNmmHeadroomPercent))
 
   private[memstore] lazy val ingestionMemory = {
-    if (filodbConfig.getBoolean("memstore.memory-alloc.automatic-alloc-enabled")) {
-      val availableMemoryBytes: Long = Utils.calculateAvailableOffHeapMemory(filodbConfig)
-      val nativeMemoryManagerPercent = filodbConfig.getDouble("memstore.memory-alloc.native-memory-manager-percent")
-      val blockMemoryManagerPercent = filodbConfig.getDouble("memstore.memory-alloc.block-memory-manager-percent")
-      val lucenePercent = filodbConfig.getDouble("memstore.memory-alloc.lucene-memory-percent")
-      require(Math.abs(nativeMemoryManagerPercent + blockMemoryManagerPercent + lucenePercent - 100) < 0.001,
-        s"Configured Block($nativeMemoryManagerPercent), Native($blockMemoryManagerPercent) " +
-        s"and Lucene($lucenePercent) memory percents don't sum to 100.0")
-      (availableMemoryBytes * nativeMemoryManagerPercent / 100).toLong
-    } else filodbConfig.getMemorySize("memstore.ingestion-buffer-mem-size").toBytes
+    if (AutoMemoryAllocUtil.isAutoMemoryConfigEnabled(filodbConfig))
+      AutoMemoryAllocUtil.getIngestionMemoryAllocSize(filodbConfig)
+    else
+      filodbConfig.getMemorySize("memstore.ingestion-buffer-mem-size").toBytes
   }
 
   private[this] lazy val ingestionMemFactory: NativeMemoryManager = {

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -421,17 +421,8 @@ class TimeSeriesShard(val ref: DatasetRef,
     reporter = UncaughtExceptionReporter(logger.error("Uncaught Exception in TimeSeriesShard.ingestSched", _)))
 
   private[memstore] val blockMemorySize = {
-    val size = if (filodbConfig.getBoolean("memstore.memory-alloc.automatic-alloc-enabled")) {
-      val numNodes = filodbConfig.getInt("min-num-nodes-in-cluster")
-      val availableMemoryBytes: Long = Utils.calculateAvailableOffHeapMemory(filodbConfig)
-      val blockMemoryManagerPercent = filodbConfig.getDouble("memstore.memory-alloc.block-memory-manager-percent")
-      val blockMemForDatasetPercent = storeConfig.shardMemPercent // fraction of block memory for this dataset
-      val numShardsPerNode = Math.ceil(numShards / numNodes.toDouble)
-      logger.info(s"Calculating Block memory size with automatic allocation strategy. " +
-        s"Dataset dataset=$ref has blockMemForDatasetPercent=$blockMemForDatasetPercent " +
-        s"numShardsPerNode=$numShardsPerNode")
-      (availableMemoryBytes * blockMemoryManagerPercent *
-        blockMemForDatasetPercent / 100 / 100 / numShardsPerNode).toLong
+    val size = if (AutoMemoryAllocUtil.isAutoMemoryConfigEnabled(filodbConfig)) {
+      AutoMemoryAllocUtil.getPerShardBlockMemoryAllocSize(filodbConfig, numShards, ref, storeConfig)
     } else {
       storeConfig.shardMemSize
     }

--- a/core/src/main/scala/filodb.core/query/FlightAllocator.scala
+++ b/core/src/main/scala/filodb.core/query/FlightAllocator.scala
@@ -12,7 +12,7 @@ import filodb.core.memstore.AutoMemoryAllocUtil
 import filodb.core.metrics.FilodbMetrics
 import filodb.memory.data.Shutdown
 
-object FlightAllocator {
+object FlightAllocator extends StrictLogging {
 
   val filodbConfig = GlobalConfig.systemConfig.getConfig("filodb")
 
@@ -22,7 +22,11 @@ object FlightAllocator {
     else
       filodbConfig.getBytes("flight.root-allocator-max-memory")
 
-  lazy private val rootAllocator = new RootAllocator(rootAllocatorMaxSize)
+  lazy private val rootAllocator = {
+    require(rootAllocatorMaxSize > 0, s"Flight root allocator max size must be > 0, but was $rootAllocatorMaxSize")
+    logger.info(s"Creating flight root allocator with limit: $rootAllocatorMaxSize bytes")
+    new RootAllocator(rootAllocatorMaxSize)
+  }
   private val flightServerMaxAlloc =
     filodbConfig.getBytes("flight.server.fraction-allocator-limit") * rootAllocatorMaxSize
   private val flightClientMaxAlloc =
@@ -57,10 +61,17 @@ object FlightAllocator {
     }
   }
 
-  lazy val serverAllocator: BufferAllocator = rootAllocator.newChildAllocator("FilodbFlightServer",
-                                                                  serverAllocationListener, 0, flightServerMaxAlloc)
-  lazy val clientAllocator: BufferAllocator = rootAllocator.newChildAllocator("FilodbFlightClient",
-                                                                  clientAllocationListener, 0, flightClientMaxAlloc)
+  lazy val serverAllocator: BufferAllocator = {
+    logger.info(s"Creating flight server allocator with limit: $flightServerMaxAlloc bytes")
+    rootAllocator.newChildAllocator("FilodbFlightServer",
+      serverAllocationListener, 0, flightServerMaxAlloc)
+
+  }
+  lazy val clientAllocator: BufferAllocator = {
+    logger.info(s"Creating flight client allocator with limit: $flightClientMaxAlloc bytes")
+    rootAllocator.newChildAllocator("FilodbFlightClient",
+      clientAllocationListener, 0, flightClientMaxAlloc)
+  }
 
   /**
    * Use only for unit testing

--- a/core/src/main/scala/filodb.core/query/FlightAllocator.scala
+++ b/core/src/main/scala/filodb.core/query/FlightAllocator.scala
@@ -8,15 +8,25 @@ import monix.execution.atomic.AtomicBoolean
 import org.apache.arrow.memory.{AllocationListener, BufferAllocator, RootAllocator}
 
 import filodb.core.GlobalConfig
+import filodb.core.memstore.AutoMemoryAllocUtil
 import filodb.core.metrics.FilodbMetrics
 import filodb.memory.data.Shutdown
 
 object FlightAllocator {
 
-  private val rootAllocatorMaxSize = GlobalConfig.systemConfig.getBytes("filodb.flight.root-allocator-max-memory")
+  val filodbConfig = GlobalConfig.systemConfig.getConfig("filodb")
+
+  private val rootAllocatorMaxSize: Long =
+    if (AutoMemoryAllocUtil.isAutoMemoryConfigEnabled(filodbConfig))
+      AutoMemoryAllocUtil.getFlightRPCMemoryAllocSize(filodbConfig)
+    else
+      filodbConfig.getBytes("flight.root-allocator-max-memory")
+
   lazy private val rootAllocator = new RootAllocator(rootAllocatorMaxSize)
-  private val flightServerMaxAlloc = GlobalConfig.systemConfig.getBytes("filodb.flight.server.allocator-limit")
-  private val flightClientMaxAlloc = GlobalConfig.systemConfig.getBytes("filodb.flight.client.allocator-limit")
+  private val flightServerMaxAlloc =
+    filodbConfig.getBytes("flight.server.fraction-allocator-limit") * rootAllocatorMaxSize
+  private val flightClientMaxAlloc =
+    filodbConfig.getBytes("flight.client.fraction-allocator-limit") * rootAllocatorMaxSize
 
   /**
    * We need metrics to track both total allocated memory (counter) and currently used memory (up-down counter which

--- a/core/src/main/scala/filodb.core/query/FlightAllocator.scala
+++ b/core/src/main/scala/filodb.core/query/FlightAllocator.scala
@@ -27,10 +27,17 @@ object FlightAllocator extends StrictLogging {
     logger.info(s"Creating flight root allocator with limit: $rootAllocatorMaxSize bytes")
     new RootAllocator(rootAllocatorMaxSize)
   }
-  private val flightServerMaxAlloc =
-    filodbConfig.getBytes("flight.server.fraction-allocator-limit") * rootAllocatorMaxSize
-  private val flightClientMaxAlloc =
-    filodbConfig.getBytes("flight.client.fraction-allocator-limit") * rootAllocatorMaxSize
+  private val flightServerMaxAlloc: Long = if (AutoMemoryAllocUtil.isAutoMemoryConfigEnabled(filodbConfig)) {
+    AutoMemoryAllocUtil.getFlightServerMemoryAllocSize(filodbConfig)
+  } else {
+    filodbConfig.getBytes("flight.server.allocator-limit")
+  }
+
+  private val flightClientMaxAlloc: Long = if (AutoMemoryAllocUtil.isAutoMemoryConfigEnabled(filodbConfig)) {
+    AutoMemoryAllocUtil.getFlightClientMemoryAllocSize(filodbConfig)
+  } else {
+    filodbConfig.getBytes("flight.client.allocator-limit")
+  }
 
   /**
    * We need metrics to track both total allocated memory (counter) and currently used memory (up-down counter which

--- a/core/src/test/resources/application_test.conf
+++ b/core/src/test/resources/application_test.conf
@@ -107,7 +107,6 @@ filodb {
       enabled = false
       host = "0.0.0.0"
       port = 8815
-      max-memory = 100 MB
       kryo-arrow-buf-len = 16 kB
       allocator-limit = 50 MB
       per-request-allocator-limit = 5 MB

--- a/core/src/test/scala/filodb.core/memstore/AutoMemoryAllocUtilSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/AutoMemoryAllocUtilSpec.scala
@@ -19,7 +19,9 @@ class AutoMemoryAllocUtilSpec extends AnyFunSpec with Matchers {
     lucenePercent: Double  = 5.0,
     flightPercent: Double  = 0.0,
     numNodes: Int         = 2,
-    overrideAvailableMemory: Boolean = true
+    overrideAvailableMemory: Boolean = true,
+    serverFraction: Double = 0.6,
+    clientFraction: Double = 0.4
   ): Config = {
     val availableMemLine =
       if (overrideAvailableMemory) s"available-memory-bytes = ${availableMemoryBytes}b" else ""
@@ -35,6 +37,10 @@ class AutoMemoryAllocUtilSpec extends AnyFunSpec with Matchers {
          |    lucene-memory-percent         = $lucenePercent
          |    flight-rpc-memory-percent     = $flightPercent
          |    $availableMemLine
+         |  }
+         |  flight {
+         |    server.fraction-allocator-limit = $serverFraction
+         |    client.fraction-allocator-limit = $clientFraction
          |  }
          |}
          |""".stripMargin
@@ -251,6 +257,180 @@ class AutoMemoryAllocUtilSpec extends AnyFunSpec with Matchers {
           AutoMemoryAllocUtil.getPerShardBlockMemoryAllocSize(cfg, 4, DatasetRef(name), storeConf)
         }
       }
+    }
+  }
+
+  // ── getFlightServerMemoryAllocSize ──────────────────────────────────────────
+
+  describe("getFlightServerMemoryAllocSize") {
+
+    it("returns the server fraction of the total Flight RPC memory") {
+      val availMem       = 10L * 1024 * 1024 * 1024 // 10 GB
+      val flightPct      = 10.0
+      val serverFraction = 0.6
+      val cfg = makeConfig(
+        availableMemoryBytes = availMem,
+        nativePercent  = 24, blockPercent = 61, lucenePercent = 5, flightPercent = flightPct,
+        serverFraction = serverFraction
+      )
+      val expectedFlightRpc = (availMem * flightPct / 100).toLong
+      val expected          = (serverFraction * expectedFlightRpc).toLong
+      AutoMemoryAllocUtil.getFlightServerMemoryAllocSize(cfg) shouldEqual expected
+    }
+
+    it("returns 0 when flight-rpc-memory-percent is 0") {
+      val cfg = makeConfig(flightPercent = 0, serverFraction = 0.6)
+      AutoMemoryAllocUtil.getFlightServerMemoryAllocSize(cfg) shouldEqual 0L
+    }
+
+    it("returns 0 when server fraction-allocator-limit is 0.0") {
+      val availMem = 8L * 1024 * 1024 * 1024 // 8 GB
+      val cfg = makeConfig(
+        availableMemoryBytes = availMem,
+        nativePercent = 24, blockPercent = 61, lucenePercent = 5, flightPercent = 10,
+        serverFraction = 0.0, clientFraction = 1.0
+      )
+      AutoMemoryAllocUtil.getFlightServerMemoryAllocSize(cfg) shouldEqual 0L
+    }
+
+    it("equals the full Flight RPC size when server fraction-allocator-limit is 1.0") {
+      val availMem = 8L * 1024 * 1024 * 1024 // 8 GB
+      val cfg = makeConfig(
+        availableMemoryBytes = availMem,
+        nativePercent = 24, blockPercent = 61, lucenePercent = 5, flightPercent = 10,
+        serverFraction = 1.0, clientFraction = 0.0
+      )
+      val expectedFlightRpc = AutoMemoryAllocUtil.getFlightRPCMemoryAllocSize(cfg)
+      AutoMemoryAllocUtil.getFlightServerMemoryAllocSize(cfg) shouldEqual expectedFlightRpc
+    }
+
+    it("scales linearly with the server fraction-allocator-limit") {
+      val availMem = 10L * 1024 * 1024 * 1024 // 10 GB
+      val cfgHalf = makeConfig(
+        availableMemoryBytes = availMem,
+        nativePercent = 24, blockPercent = 61, lucenePercent = 5, flightPercent = 10,
+        serverFraction = 0.5
+      )
+      val cfgQuarter = makeConfig(
+        availableMemoryBytes = availMem,
+        nativePercent = 24, blockPercent = 61, lucenePercent = 5, flightPercent = 10,
+        serverFraction = 0.25
+      )
+      val resultHalf    = AutoMemoryAllocUtil.getFlightServerMemoryAllocSize(cfgHalf)
+      val resultQuarter = AutoMemoryAllocUtil.getFlightServerMemoryAllocSize(cfgQuarter)
+      // quarter should be half of half (within 1 byte rounding tolerance)
+      (resultHalf / 2 - resultQuarter).abs should be <= 1L
+    }
+
+    it("scales linearly with the available memory") {
+      val cfg4GB = makeConfig(
+        availableMemoryBytes = 4L * 1024 * 1024 * 1024,
+        nativePercent = 24, blockPercent = 61, lucenePercent = 5, flightPercent = 10,
+        serverFraction = 0.6
+      )
+      val cfg8GB = makeConfig(
+        availableMemoryBytes = 8L * 1024 * 1024 * 1024,
+        nativePercent = 24, blockPercent = 61, lucenePercent = 5, flightPercent = 10,
+        serverFraction = 0.6
+      )
+      val result4 = AutoMemoryAllocUtil.getFlightServerMemoryAllocSize(cfg4GB)
+      val result8 = AutoMemoryAllocUtil.getFlightServerMemoryAllocSize(cfg8GB)
+      // Two independent .toLong truncations can cause a 1-byte rounding gap
+      (result8 - result4 * 2).abs should be <= 1L
+    }
+  }
+
+  // ── getFlightClientMemoryAllocSize ──────────────────────────────────────────
+
+  describe("getFlightClientMemoryAllocSize") {
+
+    it("returns the client fraction of the total Flight RPC memory") {
+      val availMem       = 10L * 1024 * 1024 * 1024 // 10 GB
+      val flightPct      = 10.0
+      val clientFraction = 0.4
+      val cfg = makeConfig(
+        availableMemoryBytes = availMem,
+        nativePercent  = 24, blockPercent = 61, lucenePercent = 5, flightPercent = flightPct,
+        clientFraction = clientFraction
+      )
+      val expectedFlightRpc = (availMem * flightPct / 100).toLong
+      val expected          = (clientFraction * expectedFlightRpc).toLong
+      AutoMemoryAllocUtil.getFlightClientMemoryAllocSize(cfg) shouldEqual expected
+    }
+
+    it("returns 0 when flight-rpc-memory-percent is 0") {
+      val cfg = makeConfig(flightPercent = 0, clientFraction = 0.4)
+      AutoMemoryAllocUtil.getFlightClientMemoryAllocSize(cfg) shouldEqual 0L
+    }
+
+    it("returns 0 when client fraction-allocator-limit is 0.0") {
+      val availMem = 8L * 1024 * 1024 * 1024 // 8 GB
+      val cfg = makeConfig(
+        availableMemoryBytes = availMem,
+        nativePercent = 24, blockPercent = 61, lucenePercent = 5, flightPercent = 10,
+        serverFraction = 1.0, clientFraction = 0.0
+      )
+      AutoMemoryAllocUtil.getFlightClientMemoryAllocSize(cfg) shouldEqual 0L
+    }
+
+    it("equals the full Flight RPC size when client fraction-allocator-limit is 1.0") {
+      val availMem = 8L * 1024 * 1024 * 1024 // 8 GB
+      val cfg = makeConfig(
+        availableMemoryBytes = availMem,
+        nativePercent = 24, blockPercent = 61, lucenePercent = 5, flightPercent = 10,
+        serverFraction = 0.0, clientFraction = 1.0
+      )
+      val expectedFlightRpc = AutoMemoryAllocUtil.getFlightRPCMemoryAllocSize(cfg)
+      AutoMemoryAllocUtil.getFlightClientMemoryAllocSize(cfg) shouldEqual expectedFlightRpc
+    }
+
+    it("scales linearly with the client fraction-allocator-limit") {
+      val availMem = 10L * 1024 * 1024 * 1024 // 10 GB
+      val cfgHalf = makeConfig(
+        availableMemoryBytes = availMem,
+        nativePercent = 24, blockPercent = 61, lucenePercent = 5, flightPercent = 10,
+        clientFraction = 0.5
+      )
+      val cfgQuarter = makeConfig(
+        availableMemoryBytes = availMem,
+        nativePercent = 24, blockPercent = 61, lucenePercent = 5, flightPercent = 10,
+        clientFraction = 0.25
+      )
+      val resultHalf    = AutoMemoryAllocUtil.getFlightClientMemoryAllocSize(cfgHalf)
+      val resultQuarter = AutoMemoryAllocUtil.getFlightClientMemoryAllocSize(cfgQuarter)
+      // quarter should be half of half (within 1 byte rounding tolerance)
+      (resultHalf / 2 - resultQuarter).abs should be <= 1L
+    }
+
+    it("scales linearly with the available memory") {
+      val cfg4GB = makeConfig(
+        availableMemoryBytes = 4L * 1024 * 1024 * 1024,
+        nativePercent = 24, blockPercent = 61, lucenePercent = 5, flightPercent = 10,
+        clientFraction = 0.4
+      )
+      val cfg8GB = makeConfig(
+        availableMemoryBytes = 8L * 1024 * 1024 * 1024,
+        nativePercent = 24, blockPercent = 61, lucenePercent = 5, flightPercent = 10,
+        clientFraction = 0.4
+      )
+      val result4 = AutoMemoryAllocUtil.getFlightClientMemoryAllocSize(cfg4GB)
+      val result8 = AutoMemoryAllocUtil.getFlightClientMemoryAllocSize(cfg8GB)
+      // Two independent .toLong truncations can cause a 1-byte rounding gap
+      (result8 - result4 * 2).abs should be <= 1L
+    }
+
+    it("server and client allocations sum to the total Flight RPC size when fractions sum to 1.0") {
+      val availMem = 10L * 1024 * 1024 * 1024 // 10 GB
+      val cfg = makeConfig(
+        availableMemoryBytes = availMem,
+        nativePercent = 24, blockPercent = 61, lucenePercent = 5, flightPercent = 10,
+        serverFraction = 0.6, clientFraction = 0.4
+      )
+      val flightRpc = AutoMemoryAllocUtil.getFlightRPCMemoryAllocSize(cfg)
+      val server    = AutoMemoryAllocUtil.getFlightServerMemoryAllocSize(cfg)
+      val client    = AutoMemoryAllocUtil.getFlightClientMemoryAllocSize(cfg)
+      // Both fractions apply independently to the same flightRpc total; rounding can cause a 1-byte gap.
+      (server + client - flightRpc).abs should be <= 1L
     }
   }
 }

--- a/core/src/test/scala/filodb.core/memstore/AutoMemoryAllocUtilSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/AutoMemoryAllocUtilSpec.scala
@@ -1,0 +1,256 @@
+package filodb.core.memstore
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import filodb.core.DatasetRef
+import filodb.core.store.StoreConfig
+
+class AutoMemoryAllocUtilSpec extends AnyFunSpec with Matchers {
+
+  // Builds a filodb-scoped config with automatic memory alloc settings.
+  // Uses available-memory-bytes override so tests are deterministic (no actual JMX calls).
+  private def makeConfig(
+    enabled: Boolean = true,
+    availableMemoryBytes: Long = 10L * 1024 * 1024 * 1024, // 10 GB
+    nativePercent: Double = 24.0,
+    blockPercent: Double  = 71.0,
+    lucenePercent: Double  = 5.0,
+    flightPercent: Double  = 0.0,
+    numNodes: Int         = 2,
+    overrideAvailableMemory: Boolean = true
+  ): Config = {
+    val availableMemLine =
+      if (overrideAvailableMemory) s"available-memory-bytes = ${availableMemoryBytes}b" else ""
+    ConfigFactory.parseString(
+      s"""
+         |filodb {
+         |  min-num-nodes-in-cluster = $numNodes
+         |  memstore.memory-alloc {
+         |    automatic-alloc-enabled      = $enabled
+         |    os-memory-needs              = 500MB
+         |    native-memory-manager-percent = $nativePercent
+         |    block-memory-manager-percent  = $blockPercent
+         |    lucene-memory-percent         = $lucenePercent
+         |    flight-rpc-memory-percent     = $flightPercent
+         |    $availableMemLine
+         |  }
+         |}
+         |""".stripMargin
+    ).getConfig("filodb")
+  }
+
+  private def makeStoreConfig(shardMemPercent: Double = 100.0): StoreConfig =
+    StoreConfig(ConfigFactory.parseString(
+      s"""
+         |flush-interval   = 10 minutes
+         |shard-mem-size   = 100MB
+         |shard-mem-percent = $shardMemPercent
+         |""".stripMargin
+    ))
+
+  // ── isAutoMemoryConfigEnabled ───────────────────────────────────────────────
+
+  describe("isAutoMemoryConfigEnabled") {
+
+    it("returns false when automatic-alloc-enabled is false (percents not validated)") {
+      val cfg = makeConfig(enabled = false)
+      AutoMemoryAllocUtil.isAutoMemoryConfigEnabled(cfg) shouldEqual false
+    }
+
+    it("returns true when enabled and percents (no flight) sum exactly to 100") {
+      val cfg = makeConfig(nativePercent = 24, blockPercent = 71, lucenePercent = 5, flightPercent = 0)
+      AutoMemoryAllocUtil.isAutoMemoryConfigEnabled(cfg) shouldEqual true
+    }
+
+    it("returns true when enabled and percents including flight sum exactly to 100") {
+      val cfg = makeConfig(nativePercent = 24, blockPercent = 66, lucenePercent = 5, flightPercent = 5)
+      AutoMemoryAllocUtil.isAutoMemoryConfigEnabled(cfg) shouldEqual true
+    }
+
+    it("throws IllegalArgumentException when percents sum to less than 100") {
+      val cfg = makeConfig(nativePercent = 24, blockPercent = 70, lucenePercent = 5, flightPercent = 0) // 99
+      an[IllegalArgumentException] should be thrownBy {
+        AutoMemoryAllocUtil.isAutoMemoryConfigEnabled(cfg)
+      }
+    }
+
+    it("throws IllegalArgumentException when percents sum to more than 100") {
+      val cfg = makeConfig(nativePercent = 30, blockPercent = 71, lucenePercent = 5, flightPercent = 0) // 106
+      an[IllegalArgumentException] should be thrownBy {
+        AutoMemoryAllocUtil.isAutoMemoryConfigEnabled(cfg)
+      }
+    }
+
+    it("accepts percents that sum to 100 within floating-point tolerance (< 0.001 delta)") {
+      // 24.333 + 70.667 + 5.0 + 0.0 = 100.000 exactly in FP arithmetic – close enough
+      val cfg = makeConfig(nativePercent = 24.333, blockPercent = 70.667, lucenePercent = 5.0, flightPercent = 0.0)
+      AutoMemoryAllocUtil.isAutoMemoryConfigEnabled(cfg) shouldEqual true
+    }
+  }
+
+  // ── getFlightRPCMemoryAllocSize ─────────────────────────────────────────────
+
+  describe("getFlightRPCMemoryAllocSize") {
+
+    it("returns 0 when flight-rpc-memory-percent is 0") {
+      val cfg = makeConfig(flightPercent = 0)
+      AutoMemoryAllocUtil.getFlightRPCMemoryAllocSize(cfg) shouldEqual 0L
+    }
+
+    it("computes the correct byte count from available memory and flight percent") {
+      val availMem = 10L * 1024 * 1024 * 1024 // 10 GB
+      val cfg = makeConfig(
+        availableMemoryBytes = availMem,
+        nativePercent = 24, blockPercent = 66, lucenePercent = 5, flightPercent = 5
+      )
+      val expected = (availMem * 5.0 / 100).toLong
+      AutoMemoryAllocUtil.getFlightRPCMemoryAllocSize(cfg) shouldEqual expected
+    }
+
+    it("scales linearly with flight-rpc-memory-percent") {
+      val availMem = 8L * 1024 * 1024 * 1024 // 8 GB
+      val cfg10 = makeConfig(availableMemoryBytes = availMem,
+        nativePercent = 19, blockPercent = 61, lucenePercent = 10, flightPercent = 10)
+      val cfg20 = makeConfig(availableMemoryBytes = availMem,
+        nativePercent = 19, blockPercent = 51, lucenePercent = 10, flightPercent = 20)
+
+      val result10 = AutoMemoryAllocUtil.getFlightRPCMemoryAllocSize(cfg10)
+      val result20 = AutoMemoryAllocUtil.getFlightRPCMemoryAllocSize(cfg20)
+      result20 shouldEqual result10 * 2
+    }
+  }
+
+  // ── getIngestionMemoryAllocSize ─────────────────────────────────────────────
+
+  describe("getIngestionMemoryAllocSize") {
+
+    it("computes the correct byte count from available memory and native percent") {
+      val availMem = 10L * 1024 * 1024 * 1024 // 10 GB
+      val cfg = makeConfig(availableMemoryBytes = availMem, nativePercent = 24)
+      val expected = (availMem * 24.0 / 100).toLong
+      AutoMemoryAllocUtil.getIngestionMemoryAllocSize(cfg) shouldEqual expected
+    }
+
+    it("scales linearly with native-memory-manager-percent") {
+      val availMem = 8L * 1024 * 1024 * 1024 // 8 GB
+      val cfg24 = makeConfig(availableMemoryBytes = availMem,
+        nativePercent = 24, blockPercent = 71, lucenePercent = 5, flightPercent = 0)
+      val cfg48 = makeConfig(availableMemoryBytes = availMem,
+        nativePercent = 48, blockPercent = 47, lucenePercent = 5, flightPercent = 0)
+
+      val result24 = AutoMemoryAllocUtil.getIngestionMemoryAllocSize(cfg24)
+      val result48 = AutoMemoryAllocUtil.getIngestionMemoryAllocSize(cfg48)
+      result48 shouldEqual result24 * 2
+    }
+
+    it("uses the available-memory-bytes override rather than real system memory") {
+      val override1 = 4L * 1024 * 1024 * 1024  // 4 GB
+      val override2 = 8L * 1024 * 1024 * 1024  // 8 GB
+      val nativePct  = 24.0
+
+      val result1 = AutoMemoryAllocUtil.getIngestionMemoryAllocSize(
+        makeConfig(availableMemoryBytes = override1, nativePercent = nativePct))
+      val result2 = AutoMemoryAllocUtil.getIngestionMemoryAllocSize(
+        makeConfig(availableMemoryBytes = override2, nativePercent = nativePct))
+
+      result2 shouldEqual result1 * 2
+      result1 shouldEqual (override1 * nativePct / 100).toLong
+    }
+
+    it("falls back to system memory when available-memory-bytes is not set, and result is positive") {
+      // No available-memory-bytes override: reads containerMemory from JMX.
+      val cfg = makeConfig(nativePercent = 24, overrideAvailableMemory = false)
+      val result = AutoMemoryAllocUtil.getIngestionMemoryAllocSize(cfg)
+      result should be > 0L
+    }
+  }
+
+  // ── getPerShardBlockMemoryAllocSize ─────────────────────────────────────────
+
+  describe("getPerShardBlockMemoryAllocSize") {
+
+    it("distributes block memory evenly across shards per node") {
+      val availMem  = 10L * 1024 * 1024 * 1024 // 10 GB
+      val numNodes  = 2
+      val numShards = 8
+      val blockPct  = 71.0
+      val shardPct  = 100.0
+
+      val cfg         = makeConfig(availableMemoryBytes = availMem, blockPercent = blockPct, numNodes = numNodes)
+      val storeConfig = makeStoreConfig(shardPct)
+      val datasetRef  = DatasetRef("prometheus")
+
+      // numShardsPerNode = ceil(8/2) = 4
+      val numShardsPerNode = Math.ceil(numShards / numNodes.toDouble)
+      val expected = (availMem * blockPct / 100 * shardPct / 100 / numShardsPerNode).toLong
+
+      AutoMemoryAllocUtil.getPerShardBlockMemoryAllocSize(cfg, numShards, datasetRef, storeConfig) shouldEqual expected
+    }
+
+    it("gives less memory per shard when the total number of shards increases") {
+      val cfg        = makeConfig()
+      val storeConf  = makeStoreConfig()
+      val datasetRef = DatasetRef("prometheus")
+
+      val result4  = AutoMemoryAllocUtil.getPerShardBlockMemoryAllocSize(cfg, 4,  datasetRef, storeConf)
+      val result8  = AutoMemoryAllocUtil.getPerShardBlockMemoryAllocSize(cfg, 8,  datasetRef, storeConf)
+      val result16 = AutoMemoryAllocUtil.getPerShardBlockMemoryAllocSize(cfg, 16, datasetRef, storeConf)
+
+      result4  should be > result8
+      result8  should be > result16
+    }
+
+    it("halves per-shard memory when shardMemPercent is halved (within 1 byte of truncation)") {
+      val availMem  = 10L * 1024 * 1024 * 1024
+      val numShards = 4
+      val cfg        = makeConfig(availableMemoryBytes = availMem)
+      val datasetRef = DatasetRef("prometheus")
+
+      val result100 = AutoMemoryAllocUtil.getPerShardBlockMemoryAllocSize(cfg, numShards, datasetRef, makeStoreConfig(100.0))
+      val result50  = AutoMemoryAllocUtil.getPerShardBlockMemoryAllocSize(cfg, numShards, datasetRef, makeStoreConfig(50.0))
+
+      // The two values are computed independently and both apply .toLong, so rounding
+      // can differ by at most 1. Use a tolerance of 2 bytes instead of exact equality.
+      (result50 * 2 - result100).abs should be <= 2L
+    }
+
+    it("uses ceiling when shards don't divide evenly across nodes") {
+      // 7 shards / 3 nodes = 2.33 → ceil = 3 shards per node
+      val availMem  = 6L * 1024 * 1024 * 1024 // 6 GB
+      val numNodes  = 3
+      val numShards = 7
+      val blockPct  = 70.0
+      val shardPct  = 100.0
+
+      val cfg = makeConfig(
+        availableMemoryBytes = availMem,
+        blockPercent = blockPct,
+        lucenePercent = 5.0,
+        nativePercent = 25.0,
+        flightPercent = 0.0,
+        numNodes = numNodes
+      )
+      val storeConfig = makeStoreConfig(shardPct)
+      val datasetRef  = DatasetRef("prometheus")
+
+      val numShardsPerNode = Math.ceil(numShards / numNodes.toDouble) // 3.0
+      val expected = (availMem * blockPct / 100 * shardPct / 100 / numShardsPerNode).toLong
+
+      AutoMemoryAllocUtil.getPerShardBlockMemoryAllocSize(cfg, numShards, datasetRef, storeConfig) shouldEqual expected
+    }
+
+    it("correctly names the dataset in the log message (no exception thrown for any DatasetRef)") {
+      val cfg        = makeConfig()
+      val storeConf  = makeStoreConfig()
+
+      // Exercise a few different dataset names – the method just uses them for logging
+      Seq("prometheus", "metrics", "timeseries_ds").foreach { name =>
+        noException should be thrownBy {
+          AutoMemoryAllocUtil.getPerShardBlockMemoryAllocSize(cfg, 4, DatasetRef(name), storeConf)
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
+++ b/core/src/test/scala/filodb.core/memstore/TimeSeriesMemStoreSpec.scala
@@ -340,6 +340,7 @@ class TimeSeriesMemStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfte
         |      lucene-memory-percent = 10
         |      native-memory-manager-percent = 30
         |      block-memory-manager-percent = 60
+        |      flight-rpc-memory-percent = 0
         |    }
         |}
         |""".stripMargin).withFallback(config)


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Add `flight-rpc-memory-percent` as a fourth segment in the automatic memory
  allocation scheme, alongside Lucene, native (ingestion), and block memory.
  The four percentages must sum to 100 when auto-alloc is enabled; the new
  segment defaults to 0, keeping existing deployments unaffected.

  Changes:
  - Extract `AutoMemoryAllocUtil` object from `Utils.scala` with dedicated
    helpers: `getFlightRPCMemoryAllocSize`, `getIngestionMemoryAllocSize`,
    `getPerShardBlockMemoryAllocSize`, `calculateAvailableOffHeapMemory`
  - Replace absolute `allocator-limit` values for Flight server/client with
    `fraction-allocator-limit` ratios (default 0.75 / 0.25) derived from the
    root allocator budget computed by auto-alloc, so limits scale with the
    node's actual memory rather than being hard-coded
  - Update `TimeSeriesMemStore` and `TimeSeriesShard` to call the new util
  - Add `AutoMemoryAllocUtilSpec` with 256 lines of coverage