### PR TITLE
fix(coord): Query warnings and partial result details need to be in flight response

### DIFF
--- a/coordinator/src/main/scala/filodb/coordinator/flight/FlightPlanDispatcher.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FlightPlanDispatcher.scala
@@ -14,7 +14,7 @@ import org.apache.arrow.vector.{VectorLoader, VectorSchemaRoot, VectorUnloader}
 import filodb.coordinator.QueryScheduler
 import filodb.core.QueryTimeoutException
 import filodb.core.memstore.FiloSchedulers
-import filodb.core.query.{QuerySession, QueryStats, ResultSchema}
+import filodb.core.query.{QuerySession, QueryStats, QueryWarnings, ResultSchema}
 import filodb.core.store.ChunkSource
 import filodb.query.{QueryError, QueryResponse, QueryResult, StreamQueryResponse}
 import filodb.query.ProtoConverters._
@@ -71,6 +71,9 @@ case class FlightPlanDispatcher(location: Location,
         var resultSchema: Option[ResultSchema] = None
         var footerStats: Option[QueryStats] = None
         var footerThrowable: Option[Throwable] = None
+        var footerMayBePartial: Boolean = false
+        var footerPartialResultReason: Option[String] = None
+        var footerWarnings: QueryWarnings = QueryWarnings()
         val vsrs = mutable.ListBuffer[VectorSchemaRoot]()
         var canceled = false
         // Order of messages: ResultSchema, zero or more RVs with metadata, QueryStats, Throwable (if error)
@@ -111,9 +114,16 @@ case class FlightPlanDispatcher(location: Location,
             } else if (meta.hasFooter) {
               val footer = meta.getFooter
               footerStats = Some(footer.getQueryStats.fromProto)
-              footerThrowable = if (footer.hasThrowable) Some(footer.getThrowable.fromProto) else None
+              footerThrowable = if (footer.hasThrowable) Some(footer.getThrowable.fromProto)
+                                else None
+              footerMayBePartial = footer.getMayBePartial
+              footerPartialResultReason = if (footer.hasPartialResultReason) Some(footer.getPartialResultReason)
+                                          else None
+              footerWarnings = if (footer.hasWarnings) footer.getWarnings.fromProto
+                               else QueryWarnings()
               qLogger.debug(s"FlightPlanDispatcher received footer for queryPlanId=${plan.planId} with stats: " +
-                s"${footerStats.get}, throwable: $footerThrowable")
+                s"${footerStats.get}, throwable: $footerThrowable, mayBePartial: $footerMayBePartial, " +
+                s"warnings: $footerWarnings")
             } else {
               qLogger.warn(s"FlightPlanDispatcher received metadata with unknown type for queryPlanId=${plan.planId}")
             }
@@ -127,7 +137,7 @@ case class FlightPlanDispatcher(location: Location,
         } else {
           val srvs = ArrowSerializedRangeVectorOps.convertVsrsIntoArrowSrvs(vsrs.toSeq, resultSchema.get)
           QueryResult(plan.queryContext.queryId, resultSchema.get, srvs,
-            footerStats.getOrElse(QueryStats()))
+            footerStats.getOrElse(QueryStats()), footerWarnings, footerMayBePartial, footerPartialResultReason)
         }
       }
     }.onErrorHandle { ex =>

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FlightProtoSerDeser.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FlightProtoSerDeser.scala
@@ -4,7 +4,8 @@ import org.apache.arrow.memory.ArrowBuf
 
 import filodb.coordinator.flight.ArrowSerializedRangeVectorOps.{maxNumRows, VsrPopulationState}
 import filodb.core.binaryrecord2.SingleRecordBuilder
-import filodb.core.query.{FlightAllocator, QueryStats, RangeVectorKey, ResultSchema, RvRange, SerializableRangeVector}
+import filodb.core.query.{FlightAllocator, QueryStats, QueryWarnings, RangeVectorKey,
+                          ResultSchema, RvRange, SerializableRangeVector}
 import filodb.grpc.{GrpcMultiPartitionQueryService, ProtoRangeVector}
 import filodb.memory.format.UnsafeUtils
 import filodb.query.ProtoConverters._
@@ -72,10 +73,16 @@ object FlightProtoSerDeser {
         .setResultSchema(resultSchema.toProto)).build().toByteArray, fAllocator)
 
   def serializeFooterToArrowBuf(queryStats: QueryStats, throwable: Option[Throwable],
-                                 fAllocator: FlightAllocator): ArrowBuf = {
+                                 fAllocator: FlightAllocator,
+                                 mayBePartial: Boolean = false,
+                                 partialResultReason: Option[String] = None,
+                                 warnings: QueryWarnings = QueryWarnings()): ArrowBuf = {
     val footerBuilder = GrpcMultiPartitionQueryService.FlightResultFooter.newBuilder()
       .setQueryStats(queryStats.toProto)
+      .setMayBePartial(mayBePartial)
+      .setWarnings(warnings.toProto)
     throwable.foreach(t => footerBuilder.setThrowable(t.toProto))
+    partialResultReason.foreach(footerBuilder.setPartialResultReason)
     toArrowBuf(GrpcMultiPartitionQueryService.FlightMetadata.newBuilder()
       .setFooter(footerBuilder.build()).build().toByteArray, fAllocator)
   }

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FlightQueryResultStreaming.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FlightQueryResultStreaming.scala
@@ -346,18 +346,23 @@ trait FlightQueryResultStreaming extends StrictLogging {
             }.map { _ =>
               FiloSchedulers.assertThreadName(FiloSchedulers.FlightIoSchedName)
               sendRespFooterAndComplete(listener, flightAllocator, execPlan,
-                                        querySpan, res.queryStats, None)
+                                        querySpan, res.queryStats, None,
+                                        res.mayBePartial, res.partialResultReason, res.warnings)
             }
           }
       }
     }
 
+    // scalastyle:off parameter.number
     def sendRespFooterAndComplete(listener: ServerStreamListener,
                                   flightAllocator: FlightAllocator,
                                   execPlan: ExecPlan,
                                   queryExecuteSpan: Span,
                                   s: QueryStats,
-                                  t: Option[Throwable]): Unit = {
+                                  t: Option[Throwable],
+                                  mayBePartial: Boolean = false,
+                                  partialResultReason: Option[String] = None,
+                                  warnings: QueryWarnings = QueryWarnings()): Unit = {
       t.foreach { e =>
         logQueryErrors(e, execPlan)
         queryExecuteSpan.fail(e.getMessage)
@@ -366,9 +371,10 @@ trait FlightQueryResultStreaming extends StrictLogging {
       // 10% room for precisely this
       // checkAllocatorLimits(flightAllocator, execPlan.queryContext)
       logger.debug(s"Sending response footer for queryPlanId=${execPlan.planId} and completing " +
-        s"stream for queryStats=$s, throwable=$t")
+        s"stream for queryStats=$s, throwable=$t, mayBePartial=$mayBePartial, warnings=$warnings")
       // ownership of metadata buf is now with flight listener and hence not closed here
-      listener.putMetadata(FlightProtoSerDeser.serializeFooterToArrowBuf(s, t, flightAllocator))
+      listener.putMetadata(FlightProtoSerDeser.serializeFooterToArrowBuf(s, t, flightAllocator,
+        mayBePartial, partialResultReason, warnings))
       listener.completed()
     }
   }

--- a/grpc/src/main/protobuf/query_service.proto
+++ b/grpc/src/main/protobuf/query_service.proto
@@ -1157,8 +1157,11 @@ message FlightResultHeader {
 }
 
 message FlightResultFooter {
-  QueryResultStats queryStats  = 1;
-  optional Throwable throwable = 2;
+  QueryResultStats queryStats           = 1;
+  optional Throwable throwable          = 2;
+  bool mayBePartial                     = 3;
+  optional string partialResultReason   = 4;
+  optional QueryWarnings warnings       = 5;
 }
 
 message FlightMetadata {


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Flight RPC response did not propagate warnings and partial result flags up the call hierarchy. This PR enables that.