### PR TITLE
feat(core): add write-to-pk-ut-table config to skip PkUT table writes

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/columnstore/CassandraColumnStore.scala
@@ -206,14 +206,19 @@ extends ColumnStore with CassandraChunkSource with StrictLogging {
   // Future optimization: group by token range and batch?
   def write(ref: DatasetRef,
             chunksets: Observable[ChunkSet],
-            diskTimeToLiveSeconds: Long = 259200): Future[Response] = {
+            diskTimeToLiveSeconds: Long = 259200,
+            writeToIngestionTimeIndex: Boolean = true): Future[Response] = {
     chunksets.mapParallelUnordered(writeParallelism) { chunkset =>
       val start = System.currentTimeMillis()
       val partBytes = BinaryRegionLarge.asNewByteArray(chunkset.partition)
            val future =
              for { writeChunksResp   <- writeChunks(ref, partBytes, chunkset, diskTimeToLiveSeconds)
                    if writeChunksResp == Success
-                   writeIndicesResp  <- writeIndices(ref, partBytes, chunkset, writeTimeIndexTtlSeconds)
+                   // Skip the ingestion_time_index (write-time index) write when disabled for this dataset.
+                   // Chunks are still persisted; a skipped index write yields Success so the flow is unchanged.
+                   writeIndicesResp  <- if (writeToIngestionTimeIndex)
+                                          writeIndices(ref, partBytes, chunkset, writeTimeIndexTtlSeconds)
+                                        else Future.successful(Success)
                    if writeIndicesResp == Success
              } yield {
                writeChunksetLatency.record(System.currentTimeMillis() - start)

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -118,6 +118,11 @@
 
         # Whether the partkeysbyupdatetime (PkUT) table is written on part key flush (default true).
         # write-to-pk-ut-table = false  # skip PkUT table writes for this dataset (safe when downsampling is disabled)
+
+        # Whether the ingestion_time_index (write-time index) table is written on chunk flush (default true).
+        # The downsample Spark job queries this raw index (getChunksByIngestionTimeRange) to find chunks to
+        # downsample, so only disable it when downsampling does not consume this index.
+        # write-to-ingestion-time-index = false  # skip ingestion_time_index writes for this dataset
       }
       downsample {
         # Resolutions for downsampled data ** in ascending order **

--- a/conf/timeseries-dev-source.conf
+++ b/conf/timeseries-dev-source.conf
@@ -115,6 +115,9 @@
 
         # Set to true to enable processing of duplicate samples. Default behavior is to drop duplicates.
         accept-duplicate-samples = false
+
+        # Whether the partkeysbyupdatetime (PkUT) table is written on part key flush (default true).
+        # write-to-pk-ut-table = false  # skip PkUT table writes for this dataset (safe when downsampling is disabled)
       }
       downsample {
         # Resolutions for downsampled data ** in ascending order **

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -874,11 +874,6 @@ filodb {
       # switch to enable/disable calculation of cardinality in downsample cluster
       metering-enabled = false
 
-      # Whether the partkeysbyupdatetime (PkUT) table is updated on part key flush. The PkUT table is only
-      # consumed by the downsampler's DSIndexJob, so this can be set to false to avoid wasted writes when
-      # downsampling is disabled.
-      write-to-pk-ut-table = true
-
     }
 
     # If non-empty, partition will be downsampled only if it matches one of the allow filters

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -874,6 +874,11 @@ filodb {
       # switch to enable/disable calculation of cardinality in downsample cluster
       metering-enabled = false
 
+      # Whether the partkeysbyupdatetime (PkUT) table is updated on part key flush. The PkUT table is only
+      # consumed by the downsampler's DSIndexJob, so this can be set to false to avoid wasted writes when
+      # downsampling is disabled.
+      write-to-pk-ut-table = true
+
     }
 
     # If non-empty, partition will be downsampled only if it matches one of the allow filters

--- a/core/src/main/resources/filodb-defaults.conf
+++ b/core/src/main/resources/filodb-defaults.conf
@@ -813,6 +813,11 @@ filodb {
 
     chunk-downsampler-enabled = true
 
+    # Whether the downsample dataset's ingestion_time_index (write-time index) is written when persisting
+    # downsampled chunks. This index is consumed by repair/ChunkCopier and re-downsampling, so only set false
+    # when those do not rely on it.
+    write-to-ingestion-time-index = true
+
     # we can update downsample partition keys table as we flush newly ingested buffers
     # in raw, this would allow us not to run separate downsample index jobs all together
     # by default the option is false, ie the downsample index job needs to run

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1634,7 +1634,8 @@ class TimeSeriesShard(val ref: DatasetRef,
     logger.debug(s"Created flush ChunkSets stream for group ${flushGroup.groupNum} in " +
       s"dataset=$ref shard=$shardNum")
 
-    colStore.write(ref, chunkSetStream, storeConfig.diskTTLSeconds).recover { case e =>
+    colStore.write(ref, chunkSetStream, storeConfig.diskTTLSeconds,
+      storeConfig.writeToIngestionTimeIndex).recover { case e =>
       logger.error(s"Critical! Chunk persistence failed after retries and skipped in dataset=$ref " +
         s"shard=$shardNum", e)
       shardStats.flushesFailedChunkWrite.increment()

--- a/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/memstore/TimeSeriesShard.scala
@@ -1609,7 +1609,7 @@ class TimeSeriesShard(val ref: DatasetRef,
     val updateHour = System.currentTimeMillis() / 1000 / 60 / 60
     colStore.writePartKeys(ref, shardNum,
       Observable.fromIteratorUnsafe(partKeyRecords),
-      storeConfig.diskTTLSeconds, updateHour).map { resp =>
+      storeConfig.diskTTLSeconds, updateHour, storeConfig.writeToPkUTTable).map { resp =>
       if (flushGroup.dirtyPartsToFlush.length > 0) {
         logger.info(s"Finished flush of partKeys numPartKeys=${flushGroup.dirtyPartsToFlush.length}" +
           s" resp=$resp for dataset=$ref shard=$shardNum")

--- a/core/src/main/scala/filodb.core/store/ChunkSink.scala
+++ b/core/src/main/scala/filodb.core/store/ChunkSink.scala
@@ -36,10 +36,14 @@ trait ChunkSink {
    * @param ref the DatasetRef for the chunks to write to
    * @param chunksets an Observable stream of chunksets to write
    * @param diskTimeToLive the time for chunksets to live on disk (Cassandra)
+   * @param writeToIngestionTimeIndex whether to also write the ingestion_time_index (write-time index) table.
+   *        Defaults to true. When false, only chunks are written and the index write is skipped; this is only
+   *        safe when downsampling does not consume the raw ingestion_time_index (see StoreConfig).
    * @return Success when the chunksets stream ends and is completely written.
    *         Future.failure(exception) if an exception occurs.
    */
-  def write(ref: DatasetRef, chunksets: Observable[ChunkSet], diskTimeToLive: Long = 259200): Future[Response]
+  def write(ref: DatasetRef, chunksets: Observable[ChunkSet], diskTimeToLive: Long = 259200,
+            writeToIngestionTimeIndex: Boolean = true): Future[Response]
 
   /**
     * Used to bootstrap lucene index with partition keys for a shard
@@ -163,7 +167,8 @@ class NullColumnStore(implicit sched: Scheduler) extends ColumnStore with Strict
   // in-memory store of partition keys
   val partitionKeys = new ConcurrentHashMap[DatasetRef, scala.collection.mutable.Set[Types.PartitionKey]]().asScala
 
-  def write(ref: DatasetRef, chunksets: Observable[ChunkSet], diskTimeToLive: Long): Future[Response] = {
+  def write(ref: DatasetRef, chunksets: Observable[ChunkSet], diskTimeToLive: Long,
+            writeToIngestionTimeIndex: Boolean = true): Future[Response] = {
     chunksets.foreach { chunkset =>
       val totalBytes = chunkset.chunks.map(_.limit()).sum
       sinkStats.addChunkWriteStats(chunkset.chunks.length, totalBytes, chunkset.info.numRows)

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -40,7 +40,11 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              estimatedIngestResolutionMillis: Int,
                              // Zeroes memory when it is first allocated.
                              // NOTE: this will incur a memset(); memory will be eagerly allocated if enabled.
-                             clearAllocations: Boolean) {
+                             clearAllocations: Boolean,
+                             // Whether the partkeysbyupdatetime (PkUT) table is updated on part key flush.
+                             // The PkUT table is only consumed by the downsampler's DSIndexJob, so this can be
+                             // set false to avoid wasted writes when downsampling is disabled.
+                             writeToPkUTTable: Boolean = true) {
   import collection.JavaConverters._
   def toConfig: Config =
     ConfigFactory.parseMap(Map("flush-interval" -> (flushInterval.toSeconds + "s"),
@@ -65,7 +69,8 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "metering-enabled" -> meteringEnabled,
                                "accept-duplicate-samples" -> acceptDuplicateSamples,
                                "ingest-resolution-millis" -> estimatedIngestResolutionMillis,
-                               "clear-allocations" -> clearAllocations).asJava)
+                               "clear-allocations" -> clearAllocations,
+                               "write-to-pk-ut-table" -> writeToPkUTTable).asJava)
 }
 
 final case class AssignShardConfig(address: String, shardList: Seq[Int])
@@ -104,6 +109,7 @@ object StoreConfig {
                                            |time-aligned-chunks-enabled = false
                                            |ingest-resolution-millis = 60000
                                            |clear-allocations = false
+                                           |write-to-pk-ut-table = true
                                            |""".stripMargin)
   /** Pass in the config inside the store {}  */
   def apply(storeConfig: Config): StoreConfig = {
@@ -144,7 +150,8 @@ object StoreConfig {
                 config.getBoolean("metering-enabled"),
                 config.getBoolean("accept-duplicate-samples"),
                 config.getInt("ingest-resolution-millis"),
-                config.getBoolean("clear-allocations"))
+                config.getBoolean("clear-allocations"),
+                config.getBoolean("write-to-pk-ut-table"))
   }
 }
 

--- a/core/src/main/scala/filodb.core/store/IngestionConfig.scala
+++ b/core/src/main/scala/filodb.core/store/IngestionConfig.scala
@@ -44,7 +44,12 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                              // Whether the partkeysbyupdatetime (PkUT) table is updated on part key flush.
                              // The PkUT table is only consumed by the downsampler's DSIndexJob, so this can be
                              // set false to avoid wasted writes when downsampling is disabled.
-                             writeToPkUTTable: Boolean = true) {
+                             writeToPkUTTable: Boolean = true,
+                             // Whether the ingestion_time_index (write-time index) table is written on chunk flush.
+                             // This raw index is what the downsample Spark job queries (getChunksByIngestionTimeRange)
+                             // to find chunks to downsample, so it is only safe to set false when downsampling does not
+                             // consume it (same rationale as write-to-pk-ut-table).
+                             writeToIngestionTimeIndex: Boolean = true) {
   import collection.JavaConverters._
   def toConfig: Config =
     ConfigFactory.parseMap(Map("flush-interval" -> (flushInterval.toSeconds + "s"),
@@ -70,7 +75,8 @@ final case class StoreConfig(flushInterval: FiniteDuration,
                                "accept-duplicate-samples" -> acceptDuplicateSamples,
                                "ingest-resolution-millis" -> estimatedIngestResolutionMillis,
                                "clear-allocations" -> clearAllocations,
-                               "write-to-pk-ut-table" -> writeToPkUTTable).asJava)
+                               "write-to-pk-ut-table" -> writeToPkUTTable,
+                               "write-to-ingestion-time-index" -> writeToIngestionTimeIndex).asJava)
 }
 
 final case class AssignShardConfig(address: String, shardList: Seq[Int])
@@ -110,6 +116,7 @@ object StoreConfig {
                                            |ingest-resolution-millis = 60000
                                            |clear-allocations = false
                                            |write-to-pk-ut-table = true
+                                           |write-to-ingestion-time-index = true
                                            |""".stripMargin)
   /** Pass in the config inside the store {}  */
   def apply(storeConfig: Config): StoreConfig = {
@@ -151,7 +158,8 @@ object StoreConfig {
                 config.getBoolean("accept-duplicate-samples"),
                 config.getInt("ingest-resolution-millis"),
                 config.getBoolean("clear-allocations"),
-                config.getBoolean("write-to-pk-ut-table"))
+                config.getBoolean("write-to-pk-ut-table"),
+                config.getBoolean("write-to-ingestion-time-index"))
   }
 }
 

--- a/core/src/test/scala/filodb.core/store/StoreConfigSpec.scala
+++ b/core/src/test/scala/filodb.core/store/StoreConfigSpec.scala
@@ -32,4 +32,23 @@ class StoreConfigSpec extends AnyFunSpec with Matchers {
       roundTripped.writeToPkUTTable shouldEqual false
     }
   }
+
+  describe("StoreConfig write-to-ingestion-time-index") {
+    it("should default to true when the key is absent (falls back to code default)") {
+      storeConf("").writeToIngestionTimeIndex shouldEqual true
+    }
+
+    it("should honor a per-dataset override of write-to-ingestion-time-index = false") {
+      storeConf("write-to-ingestion-time-index = false").writeToIngestionTimeIndex shouldEqual false
+    }
+
+    it("should honor an explicit write-to-ingestion-time-index = true") {
+      storeConf("write-to-ingestion-time-index = true").writeToIngestionTimeIndex shouldEqual true
+    }
+
+    it("should round-trip writeToIngestionTimeIndex through toConfig") {
+      val roundTripped = StoreConfig(storeConf("write-to-ingestion-time-index = false").toConfig)
+      roundTripped.writeToIngestionTimeIndex shouldEqual false
+    }
+  }
 }

--- a/core/src/test/scala/filodb.core/store/StoreConfigSpec.scala
+++ b/core/src/test/scala/filodb.core/store/StoreConfigSpec.scala
@@ -1,0 +1,35 @@
+package filodb.core.store
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class StoreConfigSpec extends AnyFunSpec with Matchers {
+  // Minimal store block: flush-interval and shard-mem-size have no defaults and must be supplied.
+  private def storeConf(extra: String): StoreConfig =
+    StoreConfig(ConfigFactory.parseString(
+      s"""
+         |flush-interval = 1h
+         |shard-mem-size = 100MB
+         |$extra
+         |""".stripMargin))
+
+  describe("StoreConfig write-to-pk-ut-table") {
+    it("should default to true when the key is absent (falls back to code default)") {
+      storeConf("").writeToPkUTTable shouldEqual true
+    }
+
+    it("should honor a per-dataset override of write-to-pk-ut-table = false") {
+      storeConf("write-to-pk-ut-table = false").writeToPkUTTable shouldEqual false
+    }
+
+    it("should honor an explicit write-to-pk-ut-table = true") {
+      storeConf("write-to-pk-ut-table = true").writeToPkUTTable shouldEqual true
+    }
+
+    it("should round-trip writeToPkUTTable through toConfig") {
+      val roundTripped = StoreConfig(storeConf("write-to-pk-ut-table = false").toConfig)
+      roundTripped.writeToPkUTTable shouldEqual false
+    }
+  }
+}

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/BatchDownsampler.scala
@@ -432,6 +432,10 @@ class BatchDownsampler(val settings: DownsamplerSettings,
 
 
   def persistDownsampledChunks(downsampledChunksToPersist: DataFrame): Unit = {
+    // Read once outside the Spark closure; when false the downsample ingestion_time_index write is skipped
+    // while downsampled chunks are still persisted (safe only when repair/ChunkCopier/re-downsampling do not
+    // rely on that index).
+    val writeToIngestionTimeIndex = settings.writeToIngestionTimeIndex
     downsampledChunksToPersist.foreach { row =>
       val res = Duration.apply(row.getString(0)).asInstanceOf[FiniteDuration]
       val chunkTable = downsampleCassandraColStore.getOrCreateChunkTable(
@@ -449,17 +453,19 @@ class BatchDownsampler(val settings: DownsamplerSettings,
         Duration.Inf
       )
 
-      val indexTable = downsampleCassandraColStore
-        .getOrCreateIngestionTimeIndexTable(downsampleRefsByRes(res))
-      val indexInsert = indexTable.writeIndexCql.bind(ByteBuffer.wrap(row.getAs[Array[Byte]](1)),
-        row.getLong(5): java.lang.Long,
-        row.getLong(6): java.lang.Long,
-        ByteBuffer.wrap(row.getAs[Array[Byte]](7)),
-        downsampleCassandraColStore.writeTimeIndexTtlSeconds: java.lang.Integer)
-      Await.result(
-        indexTable.connector.execStmtWithRetries(indexInsert.setConsistencyLevel(ConsistencyLevel.ALL)),
-        Duration.Inf
-      )
+      if (writeToIngestionTimeIndex) {
+        val indexTable = downsampleCassandraColStore
+          .getOrCreateIngestionTimeIndexTable(downsampleRefsByRes(res))
+        val indexInsert = indexTable.writeIndexCql.bind(ByteBuffer.wrap(row.getAs[Array[Byte]](1)),
+          row.getLong(5): java.lang.Long,
+          row.getLong(6): java.lang.Long,
+          ByteBuffer.wrap(row.getAs[Array[Byte]](7)),
+          downsampleCassandraColStore.writeTimeIndexTtlSeconds: java.lang.Integer)
+        Await.result(
+          indexTable.connector.execStmtWithRetries(indexInsert.setConsistencyLevel(ConsistencyLevel.ALL)),
+          Duration.Inf
+        )
+      }
       ()
     }
   }

--- a/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
+++ b/spark-jobs/src/main/scala/filodb/downsampler/chunk/DownsamplerSettings.scala
@@ -32,6 +32,11 @@ class DownsamplerSettings(conf: Config = ConfigFactory.empty()) extends Serializ
 
   @transient lazy val chunkDownsamplerIsEnabled = downsamplerConfig.getBoolean("chunk-downsampler-enabled")
 
+  // Whether the downsample dataset's ingestion_time_index (write-time index) is written when persisting
+  // downsampled chunks. This index is consumed by repair/ChunkCopier and re-downsampling, so only set false
+  // when those do not rely on it. Default true keeps behavior unchanged.
+  @transient lazy val writeToIngestionTimeIndex = downsamplerConfig.getBoolean("write-to-ingestion-time-index")
+
   @transient lazy val cassandraConfig = filodbConfig.getConfig("cassandra")
 
   @transient lazy val rawDatasetName = downsamplerConfig.getString("raw-dataset-name")

--- a/spark-jobs/src/test/scala/filodb/downsampler/chunk/DownsamplerSettingsSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/downsampler/chunk/DownsamplerSettingsSpec.scala
@@ -1,0 +1,18 @@
+package filodb.downsampler.chunk
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class DownsamplerSettingsSpec extends AnyFunSpec with Matchers {
+  describe("DownsamplerSettings write-to-ingestion-time-index") {
+    it("should default to true when the key is absent (falls back to filodb-defaults)") {
+      new DownsamplerSettings(ConfigFactory.empty()).writeToIngestionTimeIndex shouldEqual true
+    }
+
+    it("should honor an override of write-to-ingestion-time-index = false") {
+      val conf = ConfigFactory.parseString("filodb.downsampler.write-to-ingestion-time-index = false")
+      new DownsamplerSettings(conf).writeToIngestionTimeIndex shouldEqual false
+    }
+  }
+}


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?

Add an explicit, operator-controlled `write-to-pk-ut-table` boolean to StoreConfig (default true). The partkeysbyupdatetime (PkUT) table is only consumed by the downsampler's DSIndexJob, so when downsampling is disabled the per-flush write is wasted work. Operators can now set this false to skip it.

Changes:
- StoreConfig gains a `writeToPkUTTable` field (default true), parsed from the HOCON key `write-to-pk-ut-table`, included in `toConfig` for round-trip serialization, and present in the inline default config string.
- `write-to-pk-ut-table = true` added (documented) to the store-config defaults block in filodb-defaults.conf.
- TimeSeriesShard.writeDirtyPartKeys now passes storeConfig.writeToPkUTTable as the trailing arg to colStore.writePartKeys (previously relied on the method default of true).

The flag is an explicit config, not derived from DownsampleConfig. Default behavior is unchanged: absent or true still writes the PkUT table exactly as before. The downsample path in DownsamplableOnDemandPagingShard is untouched (it still explicitly passes false).