### PR TITLE
bug(coord): Arrow Flight RPC — query-limit safety, VSR memory fix, and hot-path optimizations

### DIFF
--- a/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
@@ -34,20 +34,20 @@ object ArrowSerializedRangeVectorOps {
   // FIXME this should not be hard-coded
   val maxVecLen = 1048576 // 1 MB
   val maxNumRows = maxVecLen / 15
+  val maxVsrs = 50
 
   def emptyVectorSchemaRoot(allocator: BufferAllocator): VectorSchemaRoot = {
     VectorSchemaRoot.create(arrowSrvSchema, allocator)
   }
 
   case class VsrPopulationState(var flightVsr: VectorSchemaRoot = null,
-                                var currentVsr: VectorSchemaRoot = null,
-                                var currentIsRvkVec: BitVector = null,
-                                var currentRvkBrVec: VarBinaryVector = null,
-                                var rowNum: Int = -1,
-                                var bytesRemaining: Int = maxVecLen,
-                                // FIXME hard coded 5
-                                freeVsrs: MpscArrayQueue[VectorSchemaRoot] = new MpscArrayQueue[VectorSchemaRoot](5),
-                                finishedVsrs: ArrayBuffer[VectorSchemaRoot] = ArrayBuffer.empty)   {
+                        var currentVsr: VectorSchemaRoot = null,
+                        var currentIsRvkVec: BitVector = null,
+                        var currentRvkBrVec: VarBinaryVector = null,
+                        var rowNum: Int = -1,
+                        var bytesRemaining: Int = maxVecLen,
+                        freeVsrs: MpscArrayQueue[VectorSchemaRoot] = new MpscArrayQueue[VectorSchemaRoot](maxVsrs),
+                        finishedVsrs: ArrayBuffer[VectorSchemaRoot] = ArrayBuffer.empty)   {
 
     def finishAndGetCurrentVsr(): VectorSchemaRoot = {
       if (currentVsr != null) {
@@ -187,13 +187,15 @@ object ArrowSerializedRangeVectorOps {
         val startNs = Utils.currentThreadCpuTimeNanos
         try {
           ChunkMap.validateNoSharedLocks(execPlan)
+          val canRemoveEmptyRows = SerializedRangeVector.canRemoveEmptyRows(rv.outputRange, recordSchema)
+          lazy val col1Type = recordSchema.columns(1).colType
           Using.resource(rv.rows()) { rows =>
             while (rows.hasNext) {
               val nextRow = rows.next()
               // Don't encode empty-histogram / NaN data over the wire
-              if (!SerializedRangeVector.canRemoveEmptyRows(rv.outputRange, recordSchema) ||
-                recordSchema.columns(1).colType == DoubleColumn && !java.lang.Double.isNaN(nextRow.getDouble(1)) ||
-                recordSchema.columns(1).colType == HistogramColumn && !nextRow.getHistogram(1).isEmpty) {
+              if (!canRemoveEmptyRows ||
+                col1Type == DoubleColumn && !java.lang.Double.isNaN(nextRow.getDouble(1)) ||
+                col1Type == HistogramColumn && !nextRow.getHistogram(1).isEmpty) {
                 addFromReader(nextRow)
               } else {
                 addNullRow()

--- a/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
@@ -40,6 +40,18 @@ object ArrowSerializedRangeVectorOps {
     VectorSchemaRoot.create(arrowSrvSchema, allocator)
   }
 
+  /**
+   * Holds the state of the VSR population process, including the current VSR being populated, the current row number,
+   * and the remaining bytes in the current VSR. It also maintains a queue of free VSRs and a list of finished VSRs.
+   * @param flightVsr the VSR owned by flight, which is used to hold the serialized data for the current flight request
+   * @param currentVsr the VSR currently being populated with data from the RangeVector
+   * @param currentIsRvkVec the isRvkVector BitVector cached from current VSR
+   * @param currentRvkBrVec the rvkBrVector VarBinaryVector cached from current VSR
+   * @param rowNum the last row number populated in the current VSR, -1 if no rows have been populated yet
+   * @param bytesRemaining the number of bytes remaining in the current VSR, initialized to maxVecLen
+   * @param freeVsrs a queue of free VSRs that can be reused for future population
+   * @param finishedVsrs a list of finished VSRs that have been populated and are ready to be sent back to the client
+   */
   case class VsrPopulationState(var flightVsr: VectorSchemaRoot = null,
                         var currentVsr: VectorSchemaRoot = null,
                         var currentIsRvkVec: BitVector = null,
@@ -107,13 +119,15 @@ object ArrowSerializedRangeVectorOps {
                                  allocator: BufferAllocator,
                                  state: VsrPopulationState): Unit = {
 
-    // TODO update metrics & query statistics on result bytes during RV serialization
-
-    def addNewVsr(): Unit = {
-      if (state.currentVsr != null) {
+    def updateVsrLengthInState(): Unit = {
         state.currentIsRvkVec.setValueCount(state.rowNum)
         state.currentRvkBrVec.setValueCount(state.rowNum)
         state.currentVsr.setRowCount(state.rowNum)
+    }
+
+    def addNewVsr(): Unit = {
+      if (state.currentVsr != null) {
+        updateVsrLengthInState()
         state.finishedVsrs += state.currentVsr
       }
 
@@ -178,9 +192,7 @@ object ArrowSerializedRangeVectorOps {
         // If the RV has formulated rows, serialize the entire RV as a single proto object
         // and skip row iteration and BR building
         FlightProtoSerDeser.serializeSrvToArrowVsr(srv, state) { () => addNewVsr() }
-        state.currentIsRvkVec.setValueCount(state.rowNum)
-        state.currentRvkBrVec.setValueCount(state.rowNum)
-        state.currentVsr.setRowCount(state.rowNum)
+        updateVsrLengthInState()
       case _ =>
         // Serialize the RV key and output range as a proto header row, then iterate data rows
         FlightProtoSerDeser.serializeRvKeyToArrowVsr(rv.key, rv.outputRange, state) { () => addNewVsr() }
@@ -201,9 +213,7 @@ object ArrowSerializedRangeVectorOps {
                 addNullRow()
               }
             }
-            state.currentIsRvkVec.setValueCount(state.rowNum)
-            state.currentRvkBrVec.setValueCount(state.rowNum)
-            state.currentVsr.setRowCount(state.rowNum)
+            updateVsrLengthInState()
           }
         } finally {
           ChunkMap.releaseAllSharedLocks()

--- a/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
@@ -33,7 +33,7 @@ object ArrowSerializedRangeVectorOps {
 
   // TODO later, this should not be hard-coded
   private[flight] val maxVecLen = 1048576 // 1 MB
-  private[flight] val maxNumRows = maxVecLen / 15 // assume 15 bytes per row on average, so we don't exceed maxVecLen
+  val maxNumRows = maxVecLen / 15 // assume 15 bytes per row on average, so we don't exceed maxVecLen
   private[flight] val maxVsrs = 50
 
   def emptyVectorSchemaRoot(allocator: BufferAllocator): VectorSchemaRoot = {

--- a/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
@@ -31,10 +31,10 @@ object ArrowSerializedRangeVectorOps {
     new Schema(util.Arrays.asList(isRvk, rvkBr))
   }
 
-  // FIXME this should not be hard-coded
-  val maxVecLen = 1048576 // 1 MB
-  val maxNumRows = maxVecLen / 15
-  val maxVsrs = 50
+  // TODO later, this should not be hard-coded
+  private[flight] val maxVecLen = 1048576 // 1 MB
+  private[flight] val maxNumRows = maxVecLen / 15 // assume 15 bytes per row on average, so we don't exceed maxVecLen
+  private[flight] val maxVsrs = 50
 
   def emptyVectorSchemaRoot(allocator: BufferAllocator): VectorSchemaRoot = {
     VectorSchemaRoot.create(arrowSrvSchema, allocator)
@@ -230,9 +230,13 @@ object ArrowSerializedRangeVectorOps {
    * marker rows) are skipped in O(1) rather than tested one bit at a time. Arrow bit buffers are
    * always allocated padded to an 8-byte boundary, so reading a full trailing word past `rowCount`
    * is always in-bounds; the `rowIndex < rowCount` guard just discards any padding bits.
+   *
+   * @param bufAddr the address of the BitVector's data buffer
+   * @param rowCount the number of rows in the BitVector (the number of valid bits to consider)
+   * @param f the function to invoke with each set-bit row index
    */
   private def cforSetBitPositions(bufAddr: Long, rowCount: Int)(f: Int => Unit): Unit = {
-    val numWords = (rowCount + 63) >> 6
+    val numWords = (rowCount + 63) >> 6 // ceil(rowCount / 64.0) in integer math
     cforRange (0 until numWords) { wordIdx =>
       var bits = UnsafeUtils.getLong(bufAddr + (wordIdx.toLong << 3))
       while (bits != 0L) {

--- a/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorOps.scala
@@ -223,6 +223,26 @@ object ArrowSerializedRangeVectorOps {
 
   }
 
+  /**
+   * Invokes `f` with each set-bit row index (ascending) in a bit-packed Arrow BitVector's data
+   * buffer at `bufAddr`, without testing cleared bits individually. Reads the buffer one 64-bit
+   * word at a time so runs of unset bits (the common case: many data rows between sparse RVK
+   * marker rows) are skipped in O(1) rather than tested one bit at a time. Arrow bit buffers are
+   * always allocated padded to an 8-byte boundary, so reading a full trailing word past `rowCount`
+   * is always in-bounds; the `rowIndex < rowCount` guard just discards any padding bits.
+   */
+  private def cforSetBitPositions(bufAddr: Long, rowCount: Int)(f: Int => Unit): Unit = {
+    val numWords = (rowCount + 63) >> 6
+    cforRange (0 until numWords) { wordIdx =>
+      var bits = UnsafeUtils.getLong(bufAddr + (wordIdx.toLong << 3))
+      while (bits != 0L) {
+        val rowIndex = (wordIdx << 6) + java.lang.Long.numberOfTrailingZeros(bits)
+        if (rowIndex < rowCount) f(rowIndex)
+        bits &= bits - 1 // clear the lowest set bit
+      }
+    }
+  }
+
   def convertVsrsIntoArrowSrvs(vsrs: Seq[VectorSchemaRoot],
                                schema: ResultSchema): Seq[SerializableRangeVector] = {
     val result = ArrayBuffer[SerializableRangeVector]()
@@ -234,49 +254,57 @@ object ArrowSerializedRangeVectorOps {
     var currentNumDataRows = 0
     lazy val rs = schema.toRecordSchema
 
-    // Iterate through all VSRs and rows to find RV boundaries
-    cforRange ( 0 until vsrs.size) { vsrIndex =>
-      val vsr = vsrs(vsrIndex)
-      val isRvkVec = vsr.getVector(0).asInstanceOf[BitVector]
-      val rvkBrVec = vsr.getVector(1).asInstanceOf[VarBinaryVector]
-
-      cforRange (0 until vsr.getRowCount) { rowIndex =>
-        if (isRvkVec.get(rowIndex) == 1) {
-          // Found a new RV key row — flush the previous RV if any
-          if (currentKey != null) {
-            result += new ArrowSerializedRangeVector(
-              currentKey, vsrs, rs, currentStartVsrIndex,
-              currentStartRowIndex, currentNumDataRows, currentRvRange)
-          }
-
-          val proto = FlightProtoSerDeser.deserializeFromBytes(rvkBrVec.get(rowIndex))
-          if (proto.hasSrv) {
-            currentKey = null
-            currentRvRange = None
-            result += proto.getSrv.fromProto
-          } else if (proto.hasRvKey) {
-            val rvKeyProto = proto.getRvKey
-            val (base, offset, _) = UnsafeUtils.BOLfromBuffer(rvKeyProto.getRvKey.asReadOnlyByteBuffer())
-            currentKey = BrMapRangeVectorKey(base, offset)
-            currentRvRange = if (rvKeyProto.hasRvRange) Some(rvKeyProto.getRvRange.fromProto) else None
-            currentStartVsrIndex = vsrIndex
-            currentStartRowIndex = rowIndex
-            currentNumDataRows = 0
-          } else {
-            throw new IllegalStateException(s"Invalid RV metadata in VSR at index $vsrIndex, row $rowIndex")
-          }
-        } else {
-          currentNumDataRows += 1
-        }
+    def flushCurrentRv(): Unit = {
+      if (currentKey != null) {
+        result += new ArrowSerializedRangeVector(
+          currentKey, vsrs, rs, currentStartVsrIndex,
+          currentStartRowIndex, currentNumDataRows, currentRvRange)
       }
     }
 
-    // Flush the last RV
-    if (currentKey != null) {
-      result += new ArrowSerializedRangeVector(
-        currentKey, vsrs, rs, currentStartVsrIndex,
-        currentStartRowIndex, currentNumDataRows, currentRvRange)
+    // Iterate through all VSRs, jumping directly between RV-key marker rows instead of testing
+    // every row's isRvk bit individually (see cforSetBitPositions). All rows between markers are
+    // known to be data rows, so their count is derived from position arithmetic, not counted one
+    // at a time.
+    cforRange ( 0 until vsrs.size) { vsrIndex =>
+      val vsr = vsrs(vsrIndex)
+      val rowCount = vsr.getRowCount
+      val isRvkVec = vsr.getVector(0).asInstanceOf[BitVector]
+      val rvkBrVec = vsr.getVector(1).asInstanceOf[VarBinaryVector]
+
+      var afterLastMarker = 0
+      cforSetBitPositions(isRvkVec.getDataBufferAddress, rowCount) { rowIndex =>
+        // Rows [afterLastMarker, rowIndex), since the previous marker (or the start of this VSR),
+        // are data rows belonging to whatever RV is currently open.
+        if (currentKey != null) currentNumDataRows += rowIndex - afterLastMarker
+        // Found a new RV key row — flush the previous RV if any
+        flushCurrentRv()
+
+        val proto = FlightProtoSerDeser.deserializeFromBytes(rvkBrVec.get(rowIndex))
+        if (proto.hasSrv) {
+          currentKey = null
+          currentRvRange = None
+          result += proto.getSrv.fromProto
+        } else if (proto.hasRvKey) {
+          val rvKeyProto = proto.getRvKey
+          val (base, offset, _) = UnsafeUtils.BOLfromBuffer(rvKeyProto.getRvKey.asReadOnlyByteBuffer())
+          currentKey = BrMapRangeVectorKey(base, offset)
+          currentRvRange = if (rvKeyProto.hasRvRange) Some(rvKeyProto.getRvRange.fromProto) else None
+          currentStartVsrIndex = vsrIndex
+          currentStartRowIndex = rowIndex
+          currentNumDataRows = 0
+        } else {
+          throw new IllegalStateException(s"Invalid RV metadata in VSR at index $vsrIndex, row $rowIndex")
+        }
+        afterLastMarker = rowIndex + 1
+      }
+      // Remaining rows after the last marker (or all rows, if this VSR had none) are data rows
+      // for whatever RV is still open.
+      if (currentKey != null) currentNumDataRows += rowCount - afterLastMarker
     }
+
+    // Flush the last RV
+    flushCurrentRv()
 
     result.toSeq
   }

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FlightQueryResultStreaming.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FlightQueryResultStreaming.scala
@@ -71,7 +71,7 @@ trait FlightQueryResultStreaming extends StrictLogging {
   private val queryConfig = QueryConfig(sysConfig.getConfig("filodb.query"))
   protected val queryScheduler: Scheduler = QueryScheduler.queryScheduler
 
-  // scalastyle:off method.length
+  // scalastyle:off method.length cyclomatic.complexity
   def executePhysicalPlanAndRespond(flightContext: FlightProducer.CallContext,
                                     execPlan: ExecPlan,
                                     listener: ServerStreamListener): Unit = {
@@ -215,6 +215,45 @@ trait FlightQueryResultStreaming extends StrictLogging {
                 throw new IllegalStateException("FlightAllocator is already closed, cannot create VectorSchemaRoot")
               }
             }.bracket { state =>
+              // Sends all VSRs in state.finishedVsrs over Flight and returns each to the free pool.
+              // Each VSR is removed from finishedVsrs BEFORE sending so that, if checkResultBytes (or
+              // any step inside) throws, the bracket release finds only cleanly tracked VSRs:
+              //   • finishedVsrs — remaining unsent VSRs, closed by the bracket
+              //   • freeVsrs     — already sent VSRs, closed by the bracket
+              // The VSR that triggered the exception is closed inline in the catch before re-throwing.
+              def drainFinishedVsrs(resultSize: Long, label: String): Long = {
+                FiloSchedulers.assertThreadName(FiloSchedulers.FlightIoSchedName)
+                var bytes = resultSize
+                while (state.finishedVsrs.nonEmpty) {
+                  val vsr = state.finishedVsrs.remove(0) // take ownership; no longer in finishedVsrs
+                  try {
+                    val unloader = new VectorUnloader(vsr)
+                    val loader = new VectorLoader(state.flightVsr)
+                    Using.resource(unloader.getRecordBatch) { rb =>
+                      val vsrBytes = rb.computeBodyLength()
+                      bytes += vsrBytes
+                      res.queryStats.getResultBytesCounter(Nil).addAndGet(vsrBytes)
+                      execPlan.checkResultBytes(bytes, queryConfig, res.warnings)
+                      loader.load(rb)
+                    }
+                    logger.debug(s"Putting $label vsr into flight response for " +
+                      s"queryPlanId=${execPlan.planId} rowCount=${state.flightVsr.getRowCount} " +
+                      s"vectorSize0=${state.flightVsr.getVector(0).getValueCount} " +
+                      s"vectorSize1=${state.flightVsr.getVector(1).getValueCount}")
+                    listener.putNext()
+                    val offered = state.freeVsrs.offer(vsr) // return to free pool for reuse
+                    if (!offered) Shutdown.haltAndCatchFire(
+                      new IllegalStateException("Failed to add VSR to free pool"))
+                  } catch {
+                    case t: Throwable =>
+                      // vsr is not in finishedVsrs or freeVsrs; close here so bracket can't leak it.
+                      // Any remaining finishedVsrs items are closed by the bracket release.
+                      vsr.close()
+                      throw t
+                  }
+                }
+                bytes
+              }
               FiloSchedulers.assertThreadName(FiloSchedulers.FlightIoSchedName)
               listener.start(state.flightVsr)
               var numResultSamples = 0
@@ -241,6 +280,8 @@ trait FlightQueryResultStreaming extends StrictLogging {
                     throw new IllegalStateException("should not reach here since RVs are all serializable")
                 }
                 execPlan.checkSamplesLimit(numResultSamples, res.warnings)
+                // load each result vsr into the flightVsr and send it over the wire to listener
+                // ownership of the VSR is now with flight listener and hence not closed here
                 Observable.fromIterable(resultVsrs).map { vsr =>
                   val unloader = new VectorUnloader(vsr)
                   val loader = new VectorLoader(state.flightVsr)
@@ -292,59 +333,48 @@ trait FlightQueryResultStreaming extends StrictLogging {
                       throw new IllegalStateException("FlightAllocator is already closed, cannot populate VSRs")
                     }
                   }.executeOn(queryScheduler).asyncBoundary.map { _ =>
-                    FiloSchedulers.assertThreadName(FiloSchedulers.FlightIoSchedName)
-                    // unload each finishedVsr into vec and putNext to listener
-                    state.finishedVsrs.foreach { vsr =>
-                      val unloader = new VectorUnloader(vsr)
-                      val loader = new VectorLoader(state.flightVsr)
-                      Using.resource(unloader.getRecordBatch) { rb =>
-                        val vsrBytes = rb.computeBodyLength()
-                        resultSize += vsrBytes
-                        res.queryStats.getResultBytesCounter(Nil).addAndGet(vsrBytes)
-                        execPlan.checkResultBytes(resultSize, queryConfig, res.warnings)
-                        loader.load(rb)
-                      }
-                      logger.debug(s"Putting next vsr into flight response for " +
-                        s"queryPlanId=${execPlan.planId} rowCount=${state.flightVsr.getRowCount} " +
-                        s"vectorSize0=${state.flightVsr.getVector(0).getValueCount} " +
-                        s"vectorSize1=${state.flightVsr.getVector(1).getValueCount}")
-                      listener.putNext()
-                      val offered = state.freeVsrs.offer(vsr) // add to free pool after sending over flight
-                      if (!offered) Shutdown.haltAndCatchFire(new IllegalStateException("Failed add VSR to free pool"))
-                    }
-                    state.finishedVsrs.clear() // clear finished list after sending all over flight
+                    resultSize = drainFinishedVsrs(resultSize, "next")
                   }
                 }.completedL.map { _ =>
                   FiloSchedulers.assertThreadName(FiloSchedulers.FlightIoSchedName)
-                  if (state.currentVsr != null) {
-                    val lastVsr = state.finishAndGetCurrentVsr()
-                    val unloader = new VectorUnloader(lastVsr)
-                    val loader = new VectorLoader(state.flightVsr)
-                    Using.resource(unloader.getRecordBatch) { rb =>
-                      val vsrBytes = rb.computeBodyLength()
-                      resultSize += vsrBytes
-                      res.queryStats.getResultBytesCounter(Nil).addAndGet(vsrBytes)
-                      execPlan.checkResultBytes(resultSize, queryConfig, res.warnings)
-                      loader.load(rb)
-                    }
-                    logger.debug(s"Putting last vsr into flight response for " +
-                      s"queryPlanId=${execPlan.planId} rowCount=${state.flightVsr.getRowCount} " +
-                      s"vectorSize0=${state.flightVsr.getVector(0).getValueCount} " +
-                      s"vectorSize1=${state.flightVsr.getVector(1).getValueCount}")
-                    listener.putNext()
-                    val offered = state.freeVsrs.offer(lastVsr) // add to free pool after sending over flight
-                    if (!offered) Shutdown.haltAndCatchFire(new IllegalStateException("Failed add VSR to free pool"))
-                  }
+                  // Move the partially-filled currentVsr into finishedVsrs first so the bracket
+                  // release can close it if drainFinishedVsrs throws below.
+                  // scalastyle:off null
+                  if (state.currentVsr != null) state.finishedVsrs += state.finishAndGetCurrentVsr()
+                  // scalastyle:on null
+                  resultSize = drainFinishedVsrs(resultSize, "last")
                 }
               }
             } { state =>
-              // this lambda is the finally clause for bracket method
+              // This lambda is the finally clause for the bracket: runs on success, error, AND
+              // cancellation, so it is the single guaranteed cleanup site for all VSR memory.
+              //
+              // VSR accounting at this point:
+              //   • state.flightVsr    — always allocated; close unconditionally
+              //   • state.freeVsrs     — VSRs that were sent and returned to the pool; close all
+              //   • state.finishedVsrs — VSRs not yet sent (non-empty only on exception mid-drain)
+              //   • state.currentVsr   — partially-filled VSR not yet moved to finishedVsrs
+              //                         (non-null only if populateRvContentsIntoVsrs threw before the
+              //                          pre-send finalisation ran — safety net)
               FiloSchedulers.assertThreadName(FiloSchedulers.FlightIoSchedName)
               Task.eval {
                 state.flightVsr.close()
+                // close any VSRs removed from finishedVsrs mid-drain but not yet in freeVsrs
+                // (drainFinishedVsrs catch already closed the one that threw, but any items after
+                // it in the ArrayBuffer are still here)
+                state.finishedVsrs.foreach(_.close())
+                state.finishedVsrs.clear()
+                // close VSRs that were successfully sent and returned to the pool
                 while (!state.freeVsrs.isEmpty) {
                   state.freeVsrs.poll().close()
                 }
+                // safety net: should always be null here, but close if present to avoid a leak
+                // scalastyle:off null
+                if (state.currentVsr != null) {
+                  state.currentVsr.close()
+                  state.currentVsr = null
+                }
+                // scalastyle:on null
               }
             }.map { _ =>
               FiloSchedulers.assertThreadName(FiloSchedulers.FlightIoSchedName)

--- a/coordinator/src/main/scala/filodb/coordinator/flight/FlightQueryResultStreaming.scala
+++ b/coordinator/src/main/scala/filodb/coordinator/flight/FlightQueryResultStreaming.scala
@@ -25,6 +25,7 @@ import filodb.core.QueryTimeoutException
 import filodb.core.memstore.FiloSchedulers
 import filodb.core.metrics.FilodbMetrics
 import filodb.core.query._
+import filodb.memory.data.Shutdown
 import filodb.query.{BadQueryException, QueryError, QueryResponse, QueryResult}
 import filodb.query.exec.ExecPlan
 
@@ -209,7 +210,7 @@ trait FlightQueryResultStreaming extends StrictLogging {
               // here we initialize the state object with emoty flightVsr which
               // will be populated when we need to send VSR over the wire as response
               flightAllocator.withRequestAllocator { a =>
-                VsrPopulationState(flightVsr = ArrowSerializedRangeVectorOps.emptyVectorSchemaRoot(a))
+                new VsrPopulationState(flightVsr = ArrowSerializedRangeVectorOps.emptyVectorSchemaRoot(a))
               } {
                 throw new IllegalStateException("FlightAllocator is already closed, cannot create VectorSchemaRoot")
               }
@@ -308,7 +309,8 @@ trait FlightQueryResultStreaming extends StrictLogging {
                         s"vectorSize0=${state.flightVsr.getVector(0).getValueCount} " +
                         s"vectorSize1=${state.flightVsr.getVector(1).getValueCount}")
                       listener.putNext()
-                      state.freeVsrs.offer(vsr) // add to free pool after sending over flight
+                      val offered = state.freeVsrs.offer(vsr) // add to free pool after sending over flight
+                      if (!offered) Shutdown.haltAndCatchFire(new IllegalStateException("Failed add VSR to free pool"))
                     }
                     state.finishedVsrs.clear() // clear finished list after sending all over flight
                   }
@@ -330,7 +332,8 @@ trait FlightQueryResultStreaming extends StrictLogging {
                       s"vectorSize0=${state.flightVsr.getVector(0).getValueCount} " +
                       s"vectorSize1=${state.flightVsr.getVector(1).getValueCount}")
                     listener.putNext()
-                    state.freeVsrs.offer(lastVsr) // add to free pool after sending over flight
+                    val offered = state.freeVsrs.offer(lastVsr) // add to free pool after sending over flight
+                    if (!offered) Shutdown.haltAndCatchFire(new IllegalStateException("Failed add VSR to free pool"))
                   }
                 }
               }

--- a/coordinator/src/test/scala/filodb.coordinator/ProtoConvertersSpec.scala
+++ b/coordinator/src/test/scala/filodb.coordinator/ProtoConvertersSpec.scala
@@ -107,7 +107,7 @@ class ProtoConvertersSpec extends AnyFunSpec with Matchers {
       )
 
       val queryStats = QueryStats()
-      val vsrs = ArrowSerializedRangeVectorOps.VsrPopulationState()
+      val vsrs = new ArrowSerializedRangeVectorOps.VsrPopulationState()
 
       // Populate VSR
       ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(

--- a/coordinator/src/test/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorSpec.scala
+++ b/coordinator/src/test/scala/filodb/coordinator/flight/ArrowSerializedRangeVectorSpec.scala
@@ -513,5 +513,35 @@ class ArrowSerializedRangeVectorSpec extends AnyFunSpec with Matchers with Befor
 
       allVsrs.foreach(_.close())
     }
+
+    it("should locate RV key rows correctly across 64-bit word boundaries in the isRvk bitmap") {
+      // convertVsrsIntoArrowSrvs scans the isRvk BitVector 64 rows (one machine word) at a time.
+      // Use enough small RVs that RV-key marker rows land at/around word boundaries (rows 63/64,
+      // 127/128, etc.) to exercise that boundary-crossing logic explicitly.
+      val numRvs = 130
+      val outputRange = Some(RvRange(1000, 1000, 2000))
+      val keys = (0 until numRvs).map(i => CustomRangeVectorKey(Map(UTF8Str("host") -> UTF8Str(s"server$i"))))
+      val rvs = keys.map(k => toRv(Seq((1000, 1.0), (2000, 2.0)), k, outputRange.get))
+
+      val queryStats = QueryStats()
+      val vsrs = ArrowSerializedRangeVectorOps.VsrPopulationState()
+      rvs.foreach { rv =>
+        ArrowSerializedRangeVectorOps.populateRvContentsIntoVsrs(
+          rv, recSchema, "testExecPlan", queryStats, allocator, vsrs
+        )
+      }
+
+      val allVsrs = vsrs.finishedVsrs ++ Seq(vsrs.currentVsr)
+      val srvs = ArrowSerializedRangeVectorOps.convertVsrsIntoArrowSrvs(allVsrs.toSeq, resSchema)
+
+      srvs.length shouldEqual numRvs
+      srvs.zip(keys).foreach { case (srv, key) =>
+        srv.key shouldEqual key
+        srv.numRowsSerialized shouldEqual 2
+        srv.rows().map(r => (r.getLong(0), r.getDouble(1))).toList shouldEqual Seq((1000, 1.0), (2000, 2.0))
+      }
+
+      allVsrs.foreach(_.close())
+    }
   }
 }

--- a/coordinator/src/test/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducerSpec.scala
+++ b/coordinator/src/test/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducerSpec.scala
@@ -22,7 +22,7 @@ import filodb.core.store.{InMemoryMetaStore, NullColumnStore, TimeRangeChunkScan
 import filodb.memory.format.ZeroCopyUTF8String.StringToUTF8
 import filodb.query.AggregationOperator.Count
 import filodb.query.exec._
-import filodb.query.{BinaryOperator, Cardinality, QueryResult}
+import filodb.query.{BinaryOperator, Cardinality, QueryError, QueryResult}
 
 class FiloDBSinglePartitionFlightProducerSpec extends AnyFunSpec with Matchers with BeforeAndAfter
                                                   with BeforeAndAfterAll with ScalaFutures {
@@ -376,6 +376,136 @@ class FiloDBSinglePartitionFlightProducerSpec extends AnyFunSpec with Matchers w
       }
 
       capturedEncoding should not equal Some("zstd")
+    }
+
+    // ---- memory-safety tests for query-limit exceptions ----
+
+    it("should return QueryError and not leak Arrow memory when checkResultBytes throws QueryLimitException") {
+      // Enforce a tiny result-bytes limit (1 byte) so that the very first VSR drained inside
+      // drainFinishedVsrs triggers checkResultBytes → QueryLimitException.  The bracket must
+      // close every in-flight VSR even when the exception fires mid-drain.
+      //
+      // Use a dedicated child allocator so this test is fully self-contained and does not
+      // interfere with the shared `allocator` managed by before/after.
+      val testAllocator = FlightAllocator.newChildAllocatorForTesting("ResultBytesLimitTest", 0, 3000000)
+      val tinyBytesLimit = PlannerParams(
+        enforcedLimits = PerQueryLimits(execPlanResultBytes = 1L),
+        warnLimits     = PerQueryLimits(execPlanResultBytes = 1L))
+      val limitedContext = QueryContext(plannerParams = tinyBytesLimit)
+      val limitedSession = QuerySession(limitedContext,
+        QueryConfig.unitTestingQueryConfig.copy(enforceResultByteLimit = true),
+        flightAllocator = Some(new FlightAllocator(testAllocator)))
+
+      val allocatedMemBeforeQuery = testAllocator.getAllocatedMemory
+
+      val mspe = MultiSchemaPartitionsExec(
+        limitedContext,
+        FlightPlanDispatcher(location, "test"),
+        timeseriesDatasetWithMetric.ref,
+        0,
+        filters,
+        chunkScanMethod, timeseriesDatasetWithMetric.schema.partition.options.metricColumn)
+      mspe.addRangeVectorTransformer(PeriodicSamplesMapper(0, 1000, 100000, None, None))
+
+      val qRes = mspe.dispatcher.dispatch(
+        ExecPlanWithClientParams(mspe, ClientParams(60000), limitedSession),
+        UnsupportedChunkSource()).runToFuture.futureValue
+
+      // The query should fail with QueryLimitException delivered as a QueryError footer
+      qRes shouldBe a[QueryError]
+      qRes.asInstanceOf[QueryError].t shouldBe a[QueryLimitException]
+
+      // Crucial: the bracket must have closed all in-flight VSRs — no Arrow memory should remain
+      limitedSession.close()
+      testAllocator.getAllocatedMemory shouldEqual allocatedMemBeforeQuery
+      testAllocator.close()
+    }
+
+    it("should return QueryError and not leak Arrow memory when checkSamplesLimit throws QueryLimitException") {
+      // Enforce a tiny samples limit (1 sample) so that checkSamplesLimit fires as soon as the
+      // first range-vector's sample count is tallied, before any VSR is fully drained.
+      // The bracket must still close all VSRs even though streaming aborted partway through.
+      val testAllocator = FlightAllocator.newChildAllocatorForTesting("SamplesLimitTest", 0, 3000000)
+      val tinySamplesLimit = PlannerParams(
+        enforcedLimits = PerQueryLimits(execPlanSamples = 1),
+        warnLimits     = PerQueryLimits(execPlanSamples = 1))
+      val limitedContext = QueryContext(plannerParams = tinySamplesLimit)
+      val limitedSession = QuerySession(limitedContext, QueryConfig.unitTestingQueryConfig,
+        flightAllocator = Some(new FlightAllocator(testAllocator)))
+
+      val allocatedMemBeforeQuery = testAllocator.getAllocatedMemory
+
+      val mspe = MultiSchemaPartitionsExec(
+        limitedContext,
+        FlightPlanDispatcher(location, "test"),
+        timeseriesDatasetWithMetric.ref,
+        0,
+        filters,
+        chunkScanMethod, timeseriesDatasetWithMetric.schema.partition.options.metricColumn)
+      mspe.addRangeVectorTransformer(PeriodicSamplesMapper(0, 1000, 100000, None, None))
+
+      val qRes = mspe.dispatcher.dispatch(
+        ExecPlanWithClientParams(mspe, ClientParams(60000), limitedSession),
+        UnsupportedChunkSource()).runToFuture.futureValue
+
+      // The query should fail with QueryLimitException delivered as a QueryError footer
+      qRes shouldBe a[QueryError]
+      qRes.asInstanceOf[QueryError].t shouldBe a[QueryLimitException]
+
+      // Crucial: the bracket must have closed all in-flight VSRs — no Arrow memory should remain
+      limitedSession.close()
+      testAllocator.getAllocatedMemory shouldEqual allocatedMemBeforeQuery
+      testAllocator.close()
+    }
+
+    it("should return QueryError and not leak Arrow memory when checkResultBytes throws on the second VSR") {
+      // This test exercises the specific code path where:
+      //   1. VSR1 is fully drained (putNext succeeds, VSR1 moved to freeVsrs)
+      //   2. VSR2 is taken from finishedVsrs (ownership transferred),
+      //      checkResultBytes fires, drainFinishedVsrs closes VSR2 inline before re-throwing
+      //   3. The bracket release closes VSR3 (currentVsr) and VSR1 (in freeVsrs)
+      //
+      // Two full VSRs are produced by using step=1ms over 0..100000ms, giving 100001 periodic
+      // samples per series.  Each binary record is ~20 bytes, so the first VSR fills at ~52 000
+      // rows (maxVecLen = 1MB).  The two series together produce at least 2 full VSRs before
+      // the limit is breached.
+      //
+      // Limit: maxVecLen * 2 = 2MB.  Each full VSR body is ~1.27MB (1MB data + offset/validity
+      // overhead), so VSR1 passes (1.27MB < 2MB) but VSR1+VSR2 (~2.54MB) exceeds the limit.
+      //
+      // After the query errors, the client holds one registered VSR copy (VSR1).
+      // limitedSession.close() releases it, returning testAllocator to allocatedMemBeforeQuery.
+      val testAllocator = FlightAllocator.newChildAllocatorForTesting("ResultBytesSecondVsrTest", 0, 10000000)
+      val limitBetweenTwoVsrs = ArrowSerializedRangeVectorOps.maxVecLen * 2L
+      val twoVsrBytesLimit = PlannerParams(
+        enforcedLimits = PerQueryLimits(execPlanResultBytes = limitBetweenTwoVsrs),
+        warnLimits     = PerQueryLimits(execPlanResultBytes = limitBetweenTwoVsrs))
+      val limitedContext = QueryContext(plannerParams = twoVsrBytesLimit)
+      val limitedSession = QuerySession(limitedContext,
+        QueryConfig.unitTestingQueryConfig.copy(enforceResultByteLimit = true),
+        flightAllocator = Some(new FlightAllocator(testAllocator)))
+
+      val allocatedMemBeforeQuery = testAllocator.getAllocatedMemory
+
+      val mspe = MultiSchemaPartitionsExec(
+        limitedContext,
+        FlightPlanDispatcher(location, "test"),
+        timeseriesDatasetWithMetric.ref, 0, filters, chunkScanMethod,
+        timeseriesDatasetWithMetric.schema.partition.options.metricColumn)
+      // step=1ms produces 100001 samples per series, overflowing the first VSR (~52 000-row limit)
+      mspe.addRangeVectorTransformer(PeriodicSamplesMapper(0, 1, 100000, None, None))
+
+      val qRes = mspe.dispatcher.dispatch(
+        ExecPlanWithClientParams(mspe, ClientParams(60000), limitedSession),
+        UnsupportedChunkSource()).runToFuture.futureValue
+
+      qRes shouldBe a[QueryError]
+      qRes.asInstanceOf[QueryError].t shouldBe a[QueryLimitException]
+
+      // limitedSession.close() releases the client-side VSR1 copy registered in flightAllocator
+      limitedSession.close()
+      testAllocator.getAllocatedMemory shouldEqual allocatedMemBeforeQuery
+      testAllocator.close()
     }
   }
 }

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -756,12 +756,10 @@ class ArrowSerializedRangeVector(val key: RangeVectorKey,
       private var rowsRead = 0
       private val emptyDouble = new TransientRow(0L, Double.NaN)
       private val emptyHist = new TransientHistRow(0L, Histogram.empty)
-      private var curTimestamp = outputRange.map(_.startMs).getOrElse(0L)
       private val step = outputRange.map(_.stepMs).getOrElse(1L)
-      private val canRemoveEmptyDouble = SerializedRangeVector.canRemoveEmptyRows(outputRange, schema) &&
-        schema.columns(1).colType == DoubleColumn
-      private val canRemoveEmptyHist = SerializedRangeVector.canRemoveEmptyRows(outputRange, schema) &&
-        schema.columns(1).colType == HistogramColumn
+      private val canRemoveEmpty = SerializedRangeVector.canRemoveEmptyRows(outputRange, schema)
+      private val canRemoveEmptyDouble = canRemoveEmpty && schema.columns(1).colType == DoubleColumn
+      private val canRemoveEmptyHist = canRemoveEmpty && schema.columns(1).colType == HistogramColumn
 
       final def hasNext: Boolean = rowsRead < numRowsSerialized
 

--- a/core/src/main/scala/filodb.core/query/RangeVector.scala
+++ b/core/src/main/scala/filodb.core/query/RangeVector.scala
@@ -789,6 +789,7 @@ class ArrowSerializedRangeVector(val key: RangeVectorKey,
 
         // Check if this is a null row (empty data that was filtered out during serialization)
         val retRow = if (currentBrIsNull) {
+          val curTimestamp = outputRange.get.startMs + rowsRead.toLong * step
           if (canRemoveEmptyDouble) {
             emptyDouble.timestamp = curTimestamp
             emptyDouble
@@ -808,7 +809,6 @@ class ArrowSerializedRangeVector(val key: RangeVectorKey,
         }
         currentRowInVsr += 1
         rowsRead += 1
-        curTimestamp += step
         offsetBufferPtr += 4 // Move to next offset (4 bytes per offset)
         retRow
       }


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Summary

  Three related concerns in the Arrow Flight result-streaming path are addressed together:

  1. Bug fix — Arrow memory leaks when a query limit exception fires mid-drain
  2. Bug fix — stale timestamp computed during null-row reconstruction in ArrowSerializedRangeVector
  3. Performance — per-row overhead in the serialisation hot path

  A suite of new regression tests is added that reproduce each query-limit scenario and assert zero Arrow memory is leaked.

  ---
  Changes

  FlightQueryResultStreaming — correct VSR ownership on exception

  The previous finishedVsrs.foreach { … } drain loop had a subtle ownership hazard: if checkResultBytes threw mid-iteration, the throwing VSR was neither in finishedVsrs
  (already removed by foreach) nor in freeVsrs (not yet returned), and the bracket's cleanup did not close it — a leak.

  This PR replaces the loop with drainFinishedVsrs(), which:
  - removes each VSR from finishedVsrs before sending it so the bracket always has a consistent view: unsent VSRs stay in finishedVsrs, sent VSRs go to freeVsrs, and the one
  that threw is closed inline in the catch block before re-throwing.
  - The bracket release is updated to close all four VSR categories: flightVsr, remaining finishedVsrs, all freeVsrs, and currentVsr as a safety net.

  ArrowSerializedRangeVectorOps — free-pool capacity and hot-path hoisting

  - MpscArrayQueue capacity raised from a hard-coded 5 to maxVsrs = 50; if the pool is ever full, haltAndCatchFire fires immediately instead of silently dropping a VSR.
  - canRemoveEmptyRows(…) and recordSchema.columns(1).colType were being evaluated on every row in the inner serialisation loop. Both are now hoisted to constants computed
  once before the loop.
  - Extracted updateVsrLengthInState() to eliminate three identical setValueCount / setRowCount call sites.

  RangeVector — timestamp derivation bug

  ArrowSerializedRangeVector's row iterator was reconstructing null-row timestamps by incrementing a mutable curTimestamp counter. When rows were skipped or re-used across
  VSR boundaries the counter could drift. The fix derives the timestamp directly: startMs + rowsRead * step. The mutable field is removed entirely.

  FiloDBSinglePartitionFlightProducerSpec — memory-safety regression tests

  Three new tests in FiloDBSinglePartitionFlightProducerSpec exercise the query-limit paths:


```
  ┌────────────────────────────────┬─────────────────────────────────────┬────────────────┐
  │              Test              │           Limit triggered           │  VSR position  │
  ├────────────────────────────────┼─────────────────────────────────────┼────────────────┤
  │ checkResultBytes on first VSR  │ execPlanResultBytes = 1 byte        │ VSR1 mid-drain │
  ├────────────────────────────────┼─────────────────────────────────────┼────────────────┤
  │ checkSamplesLimit              │ execPlanSamples = 1                 │ Before drain   │
  ├────────────────────────────────┼─────────────────────────────────────┼────────────────┤
  │ checkResultBytes on second VSR │ execPlanResultBytes = maxVecLen * 2 │ VSR2 mid-drain │
  └────────────────────────────────┴─────────────────────────────────────┴────────────────┘

```  

  Each test uses an isolated child allocator, asserts the response is a QueryError wrapping QueryLimitException, and asserts that testAllocator.getAllocatedMemory ==
  allocatedMemBeforeQuery after limitedSession.close().

  ---
  Testing

  sbt "coordinator/testOnly filodb.coordinator.flight.FiloDBSinglePartitionFlightProducerSpec"
  sbt "coordinator/testOnly filodb.coordinator.flight.ArrowSerializedRangeVectorSpec"
  sbt "coordinator/testOnly filodb.coordinator.ProtoConvertersSpec"
