### PR TITLE
test(coord): Fix patience config for flaky flight test

### DIFF
--- a/coordinator/src/test/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducerSpec.scala
+++ b/coordinator/src/test/scala/filodb/coordinator/flight/FiloDBSinglePartitionFlightProducerSpec.scala
@@ -39,7 +39,7 @@ class FiloDBSinglePartitionFlightProducerSpec extends AnyFunSpec with Matchers w
     .withFallback(ConfigFactory.load("application_test.conf")).resolve()
 
   private val memStore = new TimeSeriesMemStore(config.getConfig("filodb"), new NullColumnStore, new NullColumnStore, new InMemoryMetaStore())
-  implicit override val patienceConfig = PatienceConfig(timeout = Span(5, Seconds), interval = Span(50, Millis))
+  implicit override val patienceConfig = PatienceConfig(timeout = Span(10, Seconds), interval = Span(50, Millis))
 
   private val allocator = FlightAllocator.newChildAllocatorForTesting("FlightQueryProducerSpec", 0, 3000000)
   private var querySession: QuerySession = _


### PR DESCRIPTION
**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Increase test patience from 5s to 10s, so it is not flaky