### PR TITLE
fix(deps): pin kryo to 4.0.2 to restore IdentityObjectIntMap.clear fix (kryo #558/#549)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -91,7 +91,7 @@ object Dependencies {
     "org.apache.lucene"            % "lucene-facet"       % "8.8.2" withJavadoc(),
     "com.github.alexandrnikitin"   %% "bloom-filter"      % "0.13.1", // Updated for Scala 2.13
     "org.rocksdb"                  % "rocksdbjni"         % "6.29.5",
-    "com.esotericsoftware"         % "kryo"               % "4.0.0" excludeAll(excludeMinlog),
+    "com.esotericsoftware"         % "kryo"               % "4.0.2" excludeAll(excludeMinlog),
     "com.dorkbox"                  % "MinLog-SLF4J"       % "1.12",
     "com.github.ben-manes.caffeine" % "caffeine"          % "3.0.5",
     "com.twitter"                  %% "chill"             % "0.10.0", // Updated for Scala 2.13


### PR DESCRIPTION
The Scala 2.13 upgrade left kryo resolving to 4.0.0 in the assembly. Two differently-named kryo artifacts coexist on the classpath — plain `com.esotericsoftware:kryo` (from de.javakaffee:kryo-serializers + the direct pin) and `com.esotericsoftware:kryo-shaded:4.0.2` (via chill). sbt does not evict across different artifact names, and sbt-assembly's `MergeStrategy.first` for `com.esotericsoftware.**` arbitrarily selected the plain `kryo:4.0.0` classes in the newer build.

kryo 4.0.0 predates fix #558/#549 ("IdentityObjectIntMap.clear taking more time — Realloc instead of clearing large maps"): MapReferenceResolver.reset()/DefaultClassResolver.reset() call `clear()` (walks the entire retained backing array) instead of `clear(2048)` (realloc/shrink). On query fan-in (aggregator) nodes the pooled Kryo reference map never shrinks after a large result, so every subsequent reset() is O(peak-capacity) — observed as a hot IdentityObjectIntMap.clear() in JFR profiles plus retained-map GC pressure.

Pinning `kryo` to 4.0.2 evicts the 4.0.0 copy so both `kryo` and `kryo-shaded` resolve to 4.0.2; verified the built assembly's MapReferenceResolver.reset() now uses clear(2048).

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

No change in behavior expected

**New behavior :**

No change in behavior expected

