### PR TITLE
Fix churn-finder-job partition config value

### DIFF
--- a/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelStatsKafkaProducer.scala
+++ b/spark-jobs/src/main/scala/filodb/labelchurnfinder/LabelStatsKafkaProducer.scala
@@ -32,7 +32,7 @@ class LabelStatsKafkaProducer(config: Config,
 
   private[labelchurnfinder] val kafkaConfig = config.getConfig("labelchurnfinder.kafka")
   private[labelchurnfinder] val topic = kafkaConfig.getString("topic")
-  private[labelchurnfinder] val mosaicPartition = config.getString("partition")
+  private[labelchurnfinder] val mosaicPartition = config.getString("deployment-partition-name")
 
   // Collect all kafka config properties to broadcast to executors
   private[labelchurnfinder] val kafkaProps: Map[String, String] = {

--- a/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelStatsKafkaProducerSpec.scala
+++ b/spark-jobs/src/test/scala/filodb/labelchurnfinder/LabelStatsKafkaProducerSpec.scala
@@ -159,7 +159,7 @@ class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAn
       val df = createTestDataFrame(testData)
       val config = ConfigFactory.parseString(
         """
-          |partition = "us-east-1-p1"
+          |deployment-partition-name = "us-east-1-p1"
           |labelchurnfinder.kafka {
           |  topic = "test-topic"
           |  pie.queue.kaffe.connect = "localhost:9092"
@@ -227,7 +227,7 @@ class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAn
     it("should use correct Kafka configuration values") {
       val config = ConfigFactory.parseString(
         """
-          |partition = "us-east-1-p1"
+          |deployment-partition-name = "us-east-1-p1"
           |labelchurnfinder.kafka {
           |  topic = "test-topic"
           |  pie.queue.kaffe.connect = "test-server:9092"
@@ -249,7 +249,7 @@ class LabelStatsKafkaProducerSpec extends AnyFunSpec with Matchers with BeforeAn
 
     val accConfig = ConfigFactory.parseString(
       """
-        |partition = "us-east-1-p1"
+        |deployment-partition-name = "us-east-1-p1"
         |labelchurnfinder.kafka {
         |  topic = "test-topic"
         |  pie.queue.kaffe.connect = "localhost:9092"


### PR DESCRIPTION
**Pull Request checklist**

- [ ] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :**
The partition value is resolved only in perf env due to custom override in helm-chart perf yaml

**New behavior :**
The partition value is resolved correctly for prod and perf environments via PARTITION_NAME env variable
