### PR TITLE
fix(core): mark downsample shard not-ready when Lucene index writer permanently close

### DIFF
--- a/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
+++ b/core/src/main/scala/filodb.core/downsample/DownsampledTimeSeriesShard.scala
@@ -14,6 +14,7 @@ import monix.eval.Task
 import monix.execution.{CancelableFuture, Scheduler, UncaughtExceptionReporter}
 import monix.reactive.Observable
 import org.apache.lucene.search.CollectionTerminatedException
+import org.apache.lucene.store.AlreadyClosedException
 
 import filodb.core.{DatasetRef, Types, Utils}
 import filodb.core.binaryrecord2.RecordSchema
@@ -37,6 +38,7 @@ class DownsampledTimeSeriesShardStats(dataset: DatasetRef, shardNum: Int) {
   val indexEntriesRefreshed = FilodbMetrics.counter("index-entries-refreshed", tags)
   val indexEntriesPurged = FilodbMetrics.counter("index-entries-purged", tags)
   val indexRefreshFailed = FilodbMetrics.counter("index-refresh-failed", tags)
+  val indexFatalError = FilodbMetrics.counter("index-fatal-error", tags)
   val indexPurgeFailed = FilodbMetrics.counter("index-purge-failed", tags)
   val indexEntries = FilodbMetrics.gauge("downsample-store-index-entries", tags)
   val indexRamBytes = FilodbMetrics.bytesGauge("downsample-store-index-ram-bytes", tags)
@@ -66,6 +68,8 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
 
   val creationTime = System.currentTimeMillis()
   @volatile var isReadyForQuery = false
+
+  @volatile private var fatalIndexError = false
 
   private val downsampleTtls = downsampleConfig.ttls
   private val downsampledDatasetRefs = downsampleConfig.downsampleDatasetRefs(rawDatasetRef.dataset)
@@ -240,13 +244,24 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
       s"every ${rawStoreConfig.flushInterval}")
     houseKeepingFuture = Observable.intervalWithFixedDelay(rawStoreConfig.flushInterval,
       rawStoreConfig.flushInterval).mapEval { _ =>
-      purgeExpiredIndexEntries()
-      indexRefresh()
+      // Once the index has hit a fatal, unrecoverable error there is no point retrying - the
+      // Lucene IndexWriter is closed for good and every call below would just fail again.
+      if (fatalIndexError) Task.unit else {
+        purgeExpiredIndexEntries()
+        indexRefresh()
+      }
     }.map { _ =>
-      partKeyIndex.refreshReadersBlocking()
-      indexRefreshCount += 1
-      cardManager.triggerCardinalityCount(indexRefreshCount)
+      if (!fatalIndexError) {
+        partKeyIndex.refreshReadersBlocking()
+        indexRefreshCount += 1
+        cardManager.triggerCardinalityCount(indexRefreshCount)
+      }
     }.onErrorRestartUnlimited.completedL.runToFuture(housekeepingSched)
+  }
+
+  private def isFatalIndexException(t: Throwable): Boolean = t match {
+    case _: AlreadyClosedException => true
+    case _                         => Option(t.getCause).exists(isFatalIndexException)
   }
 
   private def purgeExpiredIndexEntries(): Unit = {
@@ -302,8 +317,18 @@ class DownsampledTimeSeriesShard(rawDatasetRef: DatasetRef,
       }
       .onErrorHandle { e =>
         stats.indexRefreshFailed.increment()
-        logger.error(s"Error occurred when refreshing downsample index " +
-          s"dataset=$rawDatasetRef shard=$shardNum fromHour=$fromHour toHour=$toHour", e)
+        if (isFatalIndexException(e)) {
+          stats.indexFatalError.increment()
+          fatalIndexError = true
+          isReadyForQuery = false
+          partKeyIndex.notifyLifecycleListener(IndexState.TriggerRebuild, System.currentTimeMillis())
+          logger.error(s"FATAL error refreshing downsample index, index writer is no longer usable - " +
+            s"marking shard not ready for query and halting further index refresh attempts " +
+            s"dataset=$rawDatasetRef shard=$shardNum fromHour=$fromHour toHour=$toHour", e)
+        } else {
+          logger.error(s"Error occurred when refreshing downsample index " +
+            s"dataset=$rawDatasetRef shard=$shardNum fromHour=$fromHour toHour=$toHour", e)
+        }
         0L
       }
   }


### PR DESCRIPTION

**Pull Request checklist**

- [x] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

**Current behavior :** 

 A fatal, unrecoverable error in the downsample Lucene index (e.g. IndexWriter closing itself after a disk-full error) is silently swallowed by indexRefresh's error handler, which returns 0L as if nothing happened. The housekeeping loop never sees a failure and keeps retrying forever against the dead writer, while the shard's isReadyForQuery flag stays true — so it keeps serving queries against a stale/broken index with no alert and no automatic recovery.

**New behavior :**

indexRefresh now detects fatal errors (via AlreadyClosedException in the cause chain) and responds by: marking the shard isReadyForQuery = false, halting further housekeeping attempts, flagging the index for a full rebuild on next restart (IndexState.TriggerRebuild), and incrementing a new index-fatal-error metric for alerting. Non-fatal errors behave as before.